### PR TITLE
Fix: theme button classes + datamachine_get_event_dates() API

### DIFF
--- a/assets/css/concert-tracking.css
+++ b/assets/css/concert-tracking.css
@@ -1,57 +1,30 @@
 /**
  * Concert Tracking — Attendance Button Styles
  *
- * Minimal styles — inherits theme button patterns.
- * BEM: .ec-attendance, .ec-attendance__button, .ec-attendance__count
+ * Supplements the theme's button class system (button-2, button-3, button-large).
+ * Only defines layout for the attendance container and count label.
+ * Button styling comes from the theme's button-* classes in style.css.
  *
  * @package ExtraChill\Users
  * @since 0.8.0
  */
 
+/* Container: inline-flex for button + count side by side */
 .ec-attendance {
 	display: inline-flex;
 	align-items: center;
-	gap: 8px;
+	gap: var(--spacing-sm, 0.5rem);
 }
 
-.ec-attendance__button {
-	display: inline-flex;
-	align-items: center;
-	gap: 4px;
-	padding: 6px 14px;
-	border: 1px solid var(--color-border, #d1d5db);
-	border-radius: 4px;
-	background: transparent;
-	color: var(--color-text, #1f2937);
-	font-size: 0.85rem;
-	font-weight: 500;
-	cursor: pointer;
-	transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
-	line-height: 1.4;
-}
-
-.ec-attendance__button:hover {
-	background-color: var(--color-surface-hover, #f3f4f6);
-	border-color: var(--color-border-hover, #9ca3af);
-}
-
-.ec-attendance__button--active {
-	background-color: var(--color-accent-subtle, #eff6ff);
-	border-color: var(--color-accent, #3b82f6);
-	color: var(--color-accent, #3b82f6);
-}
-
-.ec-attendance__button--active:hover {
-	background-color: var(--color-accent-subtle-hover, #dbeafe);
-}
-
+/* Check mark inside button — inherits button text color */
 .ec-attendance__check {
-	font-size: 0.75rem;
+	font-size: 0.85em;
 	line-height: 1;
 }
 
+/* Attendance count label */
 .ec-attendance__count {
-	font-size: 0.8rem;
-	color: var(--color-text-muted, #6b7280);
+	font-size: var(--font-size-sm, 0.8125rem);
+	color: var(--muted-text, #6b7280);
 	white-space: nowrap;
 }

--- a/assets/js/concert-tracking.js
+++ b/assets/js/concert-tracking.js
@@ -3,7 +3,9 @@
  *
  * Handles click events on .ec-attendance__button elements.
  * Uses wp.apiFetch for authenticated REST calls.
- * Optimistic UI updates for instant feedback.
+ * Optimistic UI updates toggle between theme button classes:
+ *   - button-3 (neutral) when unmarked
+ *   - button-2 (green accent) when marked
  *
  * @package ExtraChill\Users
  * @since 0.8.0
@@ -11,6 +13,40 @@
 
 ( function () {
 	'use strict';
+
+	/**
+	 * Toggle button between marked (button-2) and unmarked (button-3) states.
+	 */
+	function setButtonState( button, container, marked, labelEl, labelDefault, labelActive ) {
+		if ( marked ) {
+			container.classList.add( 'ec-attendance--marked' );
+			button.classList.remove( 'button-3' );
+			button.classList.add( 'button-2' );
+			if ( labelEl ) {
+				labelEl.textContent = labelActive;
+			}
+			// Add check mark if not present.
+			if ( ! button.querySelector( '.ec-attendance__check' ) ) {
+				var check = document.createElement( 'span' );
+				check.className = 'ec-attendance__check';
+				check.setAttribute( 'aria-hidden', 'true' );
+				check.textContent = '\u2713';
+				button.insertBefore( check, labelEl );
+			}
+		} else {
+			container.classList.remove( 'ec-attendance--marked' );
+			button.classList.remove( 'button-2' );
+			button.classList.add( 'button-3' );
+			if ( labelEl ) {
+				labelEl.textContent = labelDefault;
+			}
+			// Remove check mark.
+			var checkEl = button.querySelector( '.ec-attendance__check' );
+			if ( checkEl ) {
+				checkEl.remove();
+			}
+		}
+	}
 
 	document.addEventListener( 'click', function ( e ) {
 		var button = e.target.closest( '.ec-attendance__button' );
@@ -49,37 +85,11 @@
 		var blogId = parseInt( container.getAttribute( 'data-blog-id' ), 10 );
 		var labelDefault = container.getAttribute( 'data-label-default' );
 		var labelActive = container.getAttribute( 'data-label-active' );
+		var labelEl = button.querySelector( '.ec-attendance__label' );
 
 		// Optimistic UI update.
 		var isCurrentlyMarked = container.classList.contains( 'ec-attendance--marked' );
-		var labelEl = button.querySelector( '.ec-attendance__label' );
-		var checkEl = button.querySelector( '.ec-attendance__check' );
-
-		if ( isCurrentlyMarked ) {
-			// Unmarking.
-			container.classList.remove( 'ec-attendance--marked' );
-			button.classList.remove( 'ec-attendance__button--active' );
-			if ( labelEl ) {
-				labelEl.textContent = labelDefault;
-			}
-			if ( checkEl ) {
-				checkEl.remove();
-			}
-		} else {
-			// Marking.
-			container.classList.add( 'ec-attendance--marked' );
-			button.classList.add( 'ec-attendance__button--active' );
-			if ( labelEl ) {
-				labelEl.textContent = labelActive;
-			}
-			if ( ! checkEl ) {
-				var newCheck = document.createElement( 'span' );
-				newCheck.className = 'ec-attendance__check';
-				newCheck.setAttribute( 'aria-hidden', 'true' );
-				newCheck.textContent = '\u2713';
-				button.insertBefore( newCheck, labelEl );
-			}
-		}
+		setButtonState( button, container, ! isCurrentlyMarked, labelEl, labelDefault, labelActive );
 
 		// API call.
 		wp.apiFetch( {
@@ -106,24 +116,11 @@
 			}
 
 			// Sync actual state (in case optimistic was wrong).
-			if ( response.marked ) {
-				container.classList.add( 'ec-attendance--marked' );
-				button.classList.add( 'ec-attendance__button--active' );
-			} else {
-				container.classList.remove( 'ec-attendance--marked' );
-				button.classList.remove( 'ec-attendance__button--active' );
-			}
-
+			setButtonState( button, container, response.marked, labelEl, labelDefault, labelActive );
 			button.disabled = false;
 		} ).catch( function () {
 			// Revert optimistic update on failure.
-			if ( isCurrentlyMarked ) {
-				container.classList.add( 'ec-attendance--marked' );
-				button.classList.add( 'ec-attendance__button--active' );
-			} else {
-				container.classList.remove( 'ec-attendance--marked' );
-				button.classList.remove( 'ec-attendance__button--active' );
-			}
+			setButtonState( button, container, isCurrentlyMarked, labelEl, labelDefault, labelActive );
 			button.disabled = false;
 		} );
 	} );

--- a/inc/concert-tracking/buttons.php
+++ b/inc/concert-tracking/buttons.php
@@ -3,6 +3,9 @@
  * Concert tracking button rendering and asset loading.
  *
  * Renders the attendance toggle button on event detail pages.
+ * Uses the theme's button class system (button-2/button-3 + button-large)
+ * to stay consistent with ticket and share buttons in the action row.
+ *
  * The button label is derived from event timing:
  *   - Upcoming → "Going"
  *   - Ongoing  → "Check In"
@@ -43,9 +46,9 @@ function ec_users_render_attendance_button( int $event_id ) {
 		),
 	);
 
-	$label_set  = $labels[ $timing ] ?? $labels['past'];
-	$is_marked  = false;
-	$action     = 'login';
+	$label_set   = $labels[ $timing ] ?? $labels['past'];
+	$is_marked   = false;
+	$action      = 'login';
 	$count_label = ec_users_format_count_label( $count, $timing );
 
 	if ( is_user_logged_in() ) {
@@ -54,8 +57,10 @@ function ec_users_render_attendance_button( int $event_id ) {
 	}
 
 	$button_label = $is_marked ? $label_set['active'] : $label_set['default'];
+
+	// Theme button classes: button-2 (green accent) when active, button-3 (neutral) when not.
+	$button_class = $is_marked ? 'button-2' : 'button-3';
 	$marked_class = $is_marked ? ' ec-attendance--marked' : '';
-	$active_class = $is_marked ? ' ec-attendance__button--active' : '';
 
 	?>
 	<div class="ec-attendance<?php echo esc_attr( $marked_class ); ?>"
@@ -64,7 +69,7 @@ function ec_users_render_attendance_button( int $event_id ) {
 		 data-timing="<?php echo esc_attr( $timing ); ?>"
 		 data-label-default="<?php echo esc_attr( $label_set['default'] ); ?>"
 		 data-label-active="<?php echo esc_attr( $label_set['active'] ); ?>">
-		<button class="ec-attendance__button<?php echo esc_attr( $active_class ); ?>"
+		<button class="ec-attendance__button <?php echo esc_attr( $button_class ); ?> button-large"
 				data-action="<?php echo esc_attr( $action ); ?>"
 				type="button">
 			<?php if ( $is_marked ) : ?>
@@ -109,12 +114,11 @@ function ec_users_enqueue_concert_tracking_assets() {
 			true
 		);
 
-		// Pass login URL for non-authenticated users.
 		wp_localize_script(
 			'extrachill-users-concert-tracking',
 			'ecConcertTracking',
 			array(
-				'loginUrl' => wp_login_url(),
+				'loginUrl'   => wp_login_url(),
 				'isLoggedIn' => is_user_logged_in(),
 			)
 		);

--- a/inc/concert-tracking/service.php
+++ b/inc/concert-tracking/service.php
@@ -211,42 +211,31 @@ function ec_users_get_user_event_count( int $user_id, int $blog_id = 0 ): int {
  * @return string 'upcoming' | 'ongoing' | 'past'
  */
 function ec_users_get_event_timing( int $event_id ): string {
-	global $wpdb;
-
-	// Query the datamachine_event_dates table (the canonical source for event times).
-	$blog_id       = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : get_current_blog_id();
-	$events_prefix = $wpdb->get_blog_prefix( $blog_id );
-	$dates_table   = $events_prefix . 'datamachine_event_dates';
-
-	$row = $wpdb->get_row(
-		$wpdb->prepare(
-			"SELECT start_datetime, end_datetime FROM {$dates_table} WHERE post_id = %d LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted prefix.
-			$event_id
-		),
-		ARRAY_A
-	);
-
-	if ( ! $row || empty( $row['start_datetime'] ) ) {
+	// Use the data-machine-events canonical API for event dates.
+	if ( ! function_exists( 'datamachine_get_event_dates' ) ) {
 		return 'past';
 	}
 
-	$now            = current_time( 'timestamp' ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested -- needed for timezone-aware comparison.
-	$event_start_ts = strtotime( $row['start_datetime'] );
+	$dates = datamachine_get_event_dates( $event_id );
 
-	if ( ! $event_start_ts ) {
+	if ( ! $dates || empty( $dates->start_datetime ) ) {
 		return 'past';
 	}
 
-	// Use end_datetime if available, otherwise default 4-hour show window.
-	$event_end_ts = ! empty( $row['end_datetime'] )
-		? strtotime( $row['end_datetime'] )
-		: $event_start_ts + ( 4 * HOUR_IN_SECONDS );
+	// Match UpcomingFilter logic from data-machine-events:
+	// upcoming = start >= now OR end >= now
+	// past     = start < now AND (end < now OR end IS NULL)
+	$now            = current_time( 'mysql' );
+	$event_start    = $dates->start_datetime;
+	$event_end      = $dates->end_datetime ?? null;
 
-	if ( $now < $event_start_ts ) {
+	// If start is in the future, it's upcoming.
+	if ( $event_start >= $now ) {
 		return 'upcoming';
 	}
 
-	if ( $now >= $event_start_ts && $now <= $event_end_ts ) {
+	// If end exists and is still in the future, it's ongoing.
+	if ( $event_end && $event_end >= $now ) {
 		return 'ongoing';
 	}
 


### PR DESCRIPTION
## Two Fixes

### 1. Button uses theme design tokens
**Before:** Custom BEM classes with hardcoded colors (`--color-border`, `--color-accent`)
**After:** Theme `button-3 button-large` (neutral) → `button-2 button-large` (green accent) on toggle

The attendance button now matches the ticket button (`button-1 button-large`) and share button (`button-2 button-large`) in the action row. CSS reduced from 57 lines to 31 — only container layout and count label.

### 2. Event timing uses DM Events API
**Before:** Raw SQL against `datamachine_event_dates` table
**After:** `datamachine_get_event_dates( $post_id )` canonical API

Matches `UpcomingFilter` logic from data-machine-events:
- `start >= now` → upcoming
- `end >= now` (and start < now) → ongoing  
- otherwise → past

Fixes the bug where a March 31 event was showing "I Was There" on March 28.