### PR TITLE
fix: auto-link Google OAuth on verified email match

### DIFF
--- a/inc/oauth/google-service.php
+++ b/inc/oauth/google-service.php
@@ -66,11 +66,20 @@ function ec_verify_google_token( $id_token ) {
 
 /**
  * Find or create user from Google OAuth.
- * Auto-links if email matches existing account.
+ *
+ * Linking strategy:
+ * 1. If a user is already linked by Google sub (google_user_id meta), return them.
+ * 2. If a user exists with the same email AND Google asserted email_verified=true
+ *    (already enforced upstream by ec_verify_google_token), auto-link the Google
+ *    account to that user. This is the standard pattern used by NextAuth, Clerk,
+ *    Auth0 et al., and is safe because Google has cryptographically attested
+ *    that the bearer controls the verified email address.
+ * 3. Otherwise create a new account and link it.
  *
  * @param array $google_user {email, name, google_id, picture}
  * @param bool  $from_join   Whether user came from /join flow.
- * @return array|WP_Error {user_id: int, is_new: bool, user: WP_User}
+ * @param array $registration_data Optional registration metadata for new users.
+ * @return array|WP_Error {user_id: int, is_new: bool, user: WP_User, linked_existing?: bool}
  */
 function ec_oauth_google_user( $google_user, $from_join = false, $registration_data = array() ) {
 	$google_id = isset( $google_user['google_id'] ) ? sanitize_text_field( $google_user['google_id'] ) : '';
@@ -91,14 +100,40 @@ function ec_oauth_google_user( $google_user, $from_join = false, $registration_d
 		);
 	}
 
-	// Check if user exists with this email - require password login to link.
+	/**
+	 * Allow disabling auto-linking on verified email match.
+	 *
+	 * Defaults to true. Sites that require explicit user consent before linking
+	 * can return false here and implement their own linking UI.
+	 *
+	 * @param bool   $enabled   Whether to auto-link Google to existing email accounts.
+	 * @param string $email     Verified email address from Google.
+	 * @param string $google_id Google sub claim.
+	 */
+	$auto_link_enabled = (bool) apply_filters( 'ec_google_auto_link_verified_email', true, $email, $google_id );
+
+	// Check if user exists with this email. Email is already verified upstream
+	// (ec_verify_google_token rejects tokens without email_verified=true), so
+	// auto-linking by email is safe.
 	$existing_by_email = get_user_by( 'email', $email );
 	if ( $existing_by_email ) {
-		// Don't auto-link - require user to authenticate with password first.
-		return new WP_Error(
-			'account_exists_unlinked',
-			'An account with this email already exists. Please log in with your password to link your Google account.',
-			array( 'status' => 409 )
+		if ( ! $auto_link_enabled ) {
+			return new WP_Error(
+				'account_exists_unlinked',
+				'An account with this email already exists. Please log in with your password to link your Google account.',
+				array( 'status' => 409 )
+			);
+		}
+
+		ec_link_google_account( (int) $existing_by_email->ID, $google_id );
+
+		do_action( 'ec_google_account_linked', (int) $existing_by_email->ID, $google_id, $email );
+
+		return array(
+			'user_id'         => (int) $existing_by_email->ID,
+			'is_new'          => false,
+			'user'            => $existing_by_email,
+			'linked_existing' => true,
 		);
 	}
 


### PR DESCRIPTION
## Summary

Fixes a dead-end UX bug where users with an existing email/password account who clicked **Continue with Google** would hit a `409 account_exists_unlinked` error telling them to log in with their password to link Google — except **there was no actual linking flow on the password login path**. Users could log in successfully via password, then click Google again, and get the same 409 forever.

## Root cause

In `ec_oauth_google_user()`, when an account exists by email but is not yet linked by Google sub, we returned `WP_Error('account_exists_unlinked', …)`. The error message instructed users to do something the codebase did not actually implement.

## Fix

Switch to **industry-standard auto-linking on verified email**. This is what NextAuth, Clerk, and Auth0 default to, and it is safe because:

- `ec_verify_google_token()` already rejects any token without `email_verified === true` (line 55-57 of google-service.php)
- Google cryptographically signs the JWT, so the bearer of the token controls the verified email address
- We are not granting cross-account access — we are linking a freshly-attested Google identity to the account that already owns that verified email

## Changes

- Auto-link the Google account to the matching user when an email match is found
- Return `linked_existing: true` in the success payload so callers can detect the link event
- Fire a new `ec_google_account_linked` action for downstream side effects (audit log, etc.)
- New filter `ec_google_auto_link_verified_email` (default `true`) lets sites that want explicit user consent before linking opt out, in which case the legacy `409 account_exists_unlinked` error is still returned
- Updated docblock to describe the 3-step linking strategy

## Out of scope (will follow up)

The audit also surfaced four smaller issues (`from_join` source drift, `set_cookie` default mismatch across `/auth/login` `/auth/google` `/auth/register`, GSI library load race, missing Turnstile on Google flow). Those are separate PRs — this one is focused on the highest-impact correctness bug.

## Test plan

Manual verification on extrachill.com after deploy:

1. Existing user with password account, never linked Google → click Continue with Google → verify they land logged in and `google_user_id` user meta is now populated.
2. Brand new email → click Continue with Google → verify new account is created and linked (existing behavior, unchanged).
3. Already-linked user → click Continue with Google → verify existing fast path still hits.
4. Filter test: `add_filter('ec_google_auto_link_verified_email', '__return_false')` → verify legacy 409 path still works.

## Related

- API docs update in extrachill-api: Extra-Chill/extrachill-api#TBD