### PR TITLE
fix: harden Google sign-in render race and consolidate from_join source

### DIFF
--- a/assets/js/google-signin.js
+++ b/assets/js/google-signin.js
@@ -122,7 +122,11 @@
             return;
         }
 
-        var fromJoin = isFromJoinFlow();
+        // Single source of truth: from_join is captured server-side at render time
+        // and passed via wp_localize_script. The standard register form reads the
+        // same value from config.fromJoin in view.js, so the two flows can never
+        // drift even if the URL is mutated client-side after render.
+        var fromJoin = Boolean(config && config.fromJoin) || isFromJoinFlow();
         var successRedirectUrl = getSuccessRedirectUrl();
 
         setGlobalLoading(true);

--- a/blocks/login-register/render.php
+++ b/blocks/login-register/render.php
@@ -31,12 +31,17 @@ if ( $google_oauth_enabled ) {
 			true
 		);
 
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only flag from URL used for analytics/UX hint, not for state changes.
+		$google_from_join = isset( $_GET['from_join'] ) && 'true' === sanitize_text_field( wp_unslash( $_GET['from_join'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
 		wp_localize_script(
 			'extrachill-google-signin',
 			'ecGoogleConfig',
 			array(
 				'clientId' => get_site_option( 'extrachill_google_client_id', '' ),
 				'restUrl'  => rest_url( 'extrachill/v1/' ),
+				'fromJoin' => $google_from_join,
 			)
 		);
 	}
@@ -91,6 +96,10 @@ if ( isset( $_GET['action'] ) && 'ec_accept_invite' === $_GET['action'] && isset
 	// phpcs:enable WordPress.Security.NonceVerification.Recommended
 }
 
+// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only flag from URL used for analytics/UX hint, not for state changes.
+$from_join = isset( $_GET['from_join'] ) && 'true' === sanitize_text_field( wp_unslash( $_GET['from_join'] ) );
+// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
 $config = array(
 	'loggedIn'            => is_user_logged_in(),
 	'googleOAuthEnabled'  => $google_oauth_enabled,
@@ -101,6 +110,7 @@ $config = array(
 	'inviteToken'         => $invite_token,
 	'inviteArtistId'      => $invite_artist_id,
 	'invitedEmail'        => $invited_email,
+	'fromJoin'            => $from_join,
 	'turnstileHtml'       => wp_kses_post( ec_render_turnstile_widget() ),
 	'initialNotice'       => $initial_notice ? array(
 		'message' => $initial_notice['text'] ?? '',

--- a/blocks/login-register/view.js
+++ b/blocks/login-register/view.js
@@ -198,7 +198,7 @@ function RegisterPanel( { config, notice, setNotice } ) {
 
 		const submitButton = form.querySelector( 'input[type="submit"], button[type="submit"]' );
 		const restore = utils?.setSubmitting ? utils.setSubmitting( submitButton, 'Creating account…' ) : () => {};
-		const fromJoin = new URL( window.location.href ).searchParams.get( 'from_join' ) === 'true';
+		const fromJoin = Boolean( config.fromJoin );
 
 		try {
 			const url = new URL( 'extrachill/v1/auth/register', utils.getRestRoot() );
@@ -274,24 +274,104 @@ function RegisterPanel( { config, notice, setNotice } ) {
 	);
 }
 
+function isGoogleIdentityReady() {
+	return Boolean( window.google && window.google.accounts && window.google.accounts.id );
+}
+
+/**
+ * Wait for Google Identity Services library to load.
+ *
+ * The gsi/client script is enqueued in the footer alongside our view.js, and on
+ * cold loads it may still be in-flight when LoginRegisterApp mounts. Without
+ * waiting, ECGoogleSignIn.init() bails early and the user sees an empty button
+ * slot until they hard-refresh. Resolves immediately when ready, listens for the
+ * script's load event when possible, and falls back to short polling.
+ *
+ * @param {number} timeoutMs Maximum wait time before giving up.
+ * @return {Promise<boolean>} Resolves true if ready, false on timeout.
+ */
+function waitForGoogleIdentity( timeoutMs = 5000 ) {
+	return new Promise( ( resolve ) => {
+		if ( isGoogleIdentityReady() ) {
+			resolve( true );
+			return;
+		}
+
+		let settled = false;
+		const finish = ( ok ) => {
+			if ( settled ) {
+				return;
+			}
+			settled = true;
+			resolve( ok );
+		};
+
+		const scriptEl = document.querySelector( 'script[src*="accounts.google.com/gsi/client"]' );
+		if ( scriptEl ) {
+			scriptEl.addEventListener( 'load', () => finish( isGoogleIdentityReady() ), { once: true } );
+			scriptEl.addEventListener( 'error', () => finish( false ), { once: true } );
+		}
+
+		const pollMs = 100;
+		let elapsed = 0;
+		const interval = window.setInterval( () => {
+			if ( isGoogleIdentityReady() ) {
+				window.clearInterval( interval );
+				finish( true );
+				return;
+			}
+			elapsed += pollMs;
+			if ( elapsed >= timeoutMs ) {
+				window.clearInterval( interval );
+				finish( false );
+			}
+		}, pollMs );
+	} );
+}
+
 function LoginRegisterApp( { config } ) {
 	const [ activeTab, setActiveTab ] = useState( 'login' );
 	const [ loginNotice, setLoginNotice ] = useState( null );
 	const [ registerNotice, setRegisterNotice ] = useState(
 		config.initialNotice ? { type: config.initialNotice.type, message: config.initialNotice.message } : null
 	);
+	const [ googleReady, setGoogleReady ] = useState( () => isGoogleIdentityReady() );
 
 	useEffect( () => {
-		if ( window.ECGoogleSignIn && window.ecGoogleConfig ) {
-			window.ECGoogleSignIn.init( window.ecGoogleConfig );
+		if ( ! config.googleOAuthEnabled ) {
+			return;
 		}
-	}, [] );
+
+		let cancelled = false;
+		const initWhenReady = async () => {
+			const ready = await waitForGoogleIdentity();
+			if ( cancelled ) {
+				return;
+			}
+			if ( ! ready ) {
+				return;
+			}
+			setGoogleReady( true );
+			if ( window.ECGoogleSignIn && window.ecGoogleConfig ) {
+				window.ECGoogleSignIn.init( window.ecGoogleConfig );
+			}
+		};
+
+		initWhenReady();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ config.googleOAuthEnabled ] );
 
 	useEffect( () => {
+		if ( ! googleReady ) {
+			return;
+		}
 		if ( window.ECGoogleSignIn && typeof window.ECGoogleSignIn.renderAllButtons === 'function' ) {
 			window.ECGoogleSignIn.renderAllButtons();
 		}
-	}, [ activeTab ] );
+	}, [ activeTab, googleReady ] );
 
 	const tabs = useMemo(
 		() => [


### PR DESCRIPTION
## Summary

Two follow-up fixes from the login/register block audit (after #15 landed the auto-link fix). Both are real bugs that affect users on the cold-load path.

## Fix 1 — `from_join` source drift

**Before:** the standard register form read `from_join` from `window.location.href` at submit time. The Google flow read it from `window.location.href` at click time. Two reads from the same URL, but two different points in the lifecycle, with no shared state. If anything mutated the URL between mount and submit (deep links, `history.replaceState`, tab navigation that clears query strings), the two flows would disagree on whether the user came from `/join`.

**After:** capture `from_join` once on the server during render, pass it through `config.fromJoin` (and `ecGoogleConfig.fromJoin` for the Google script). Both client paths read from the same value. URL mutation can no longer cause drift.

The Google script keeps `isFromJoinFlow()` as a fallback for direct script embeds outside the block, but inside the block the server-rendered value wins.

## Fix 2 — GSI library load race

**Before:** `LoginRegisterApp` mounts on DOMContentLoaded. The \`gsi/client\` script is enqueued in the footer alongside \`view.js\` and on cold loads is often still in-flight when React mounts. The init `useEffect` fires once, calls \`ECGoogleSignIn.init()\`, which logs \`'Google Identity Services not loaded'\` and bails. No retry. User sees an empty button slot until they hard-refresh.

**After:** new \`waitForGoogleIdentity()\` helper that:

1. Resolves immediately if \`google.accounts.id\` is already available
2. Listens for the \`load\` and \`error\` events on the \`<script src=\"…/gsi/client\">\` tag so init runs the moment the library finishes loading
3. Polls every 100ms with a 5s ceiling as a defensive fallback (covers cached scripts and slow lazy-init paths)
4. Returns \`false\` on timeout — we just don't init, no spam

A new \`googleReady\` state gates both the init and the per-tab \`renderAllButtons()\` call so the button can't be rendered before its container is wired up.

## Test plan

Manual on extrachill.com after deploy:

1. Cold load \`/login/\` with cache disabled. Watch DevTools Network → confirm \`gsi/client\` loads after \`view.js\`. Confirm Google button appears without hard refresh.
2. Throttle network to Slow 3G, repeat. Button should still appear within 5s.
3. Block \`accounts.google.com\` in DevTools (Request blocking). Confirm \`waitForGoogleIdentity\` times out gracefully — no console spam loop.
4. With \`?from_join=true\`, sign up with email/password → verify \`from_join\` reaches the REST endpoint as \`true\` (check XHR payload).
5. Same URL, sign up with Google → verify \`from_join\` reaches \`/auth/google\` as \`true\`.
6. Without \`?from_join=true\`, both flows send \`false\`.

## Why this didn't ship as part of #15

#15 was scoped to the highest-impact correctness bug (auto-link dead-end) so it could be released and verified independently. These are UX hardening fixes — separate commit, separate PR, separate release.

## Out of scope

The audit also flagged adding Turnstile to Google sign-up (item #4) and hiding the \"or\" divider when GSI fails to load (item #6). Those are deliberate product decisions, not bugs — leaving for a future PR after the team agrees on Google + Turnstile policy.