### PR TITLE
feat(abilities): register user-domain abilities (#21)

### DIFF
--- a/inc/core/abilities/get-user-artist-access.php
+++ b/inc/core/abilities/get-user-artist-access.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Get User Artist Access Ability
+ *
+ * Returns the current user's artist-access request status.
+ * Canonical implementation — REST and CLI are thin wrappers.
+ *
+ * @package ExtraChill\Users
+ * @since   0.8.0
+ */
+
+declare(strict_types=1);
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_users_register_get_user_artist_access_ability' );
+
+/**
+ * Register the extrachill/get-user-artist-access ability.
+ */
+function extrachill_users_register_get_user_artist_access_ability(): void {
+	wp_register_ability(
+		'extrachill/get-user-artist-access',
+		array(
+			'label'               => __( 'Get user artist access status', 'extrachill-users' ),
+			'description'         => __( 'Returns the current user\'s artist-access request status (none, pending, or approved).', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id' => array( 'type' => 'integer' ),
+					'status'  => array(
+						'type' => 'string',
+						'enum' => array( 'none', 'pending', 'approved' ),
+					),
+					'type'         => array( 'type' => 'string' ),
+					'request_type' => array( 'type' => 'string' ),
+					'requested_at' => array( 'type' => 'integer' ),
+				),
+			),
+			'permission_callback' => static function (): bool {
+				return is_user_logged_in();
+			},
+			'execute_callback'    => 'extrachill_users_ability_get_user_artist_access',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Get the current user's artist-access request status.
+ *
+ * Returns whether the user has no request, a pending request, or approved
+ * artist/professional access.
+ *
+ * @param array $input Unused — operates on the current user.
+ * @return array|WP_Error Artist access status or error.
+ */
+function extrachill_users_ability_get_user_artist_access( array $input ): array|WP_Error {
+	$user_id = get_current_user_id();
+
+	if ( ! $user_id ) {
+		return new WP_Error( 'not_logged_in', 'You must be logged in.', array( 'status' => 401 ) );
+	}
+
+	$has_artist       = get_user_meta( $user_id, 'user_is_artist', true ) === '1';
+	$has_professional = get_user_meta( $user_id, 'user_is_professional', true ) === '1';
+	$pending_request  = get_user_meta( $user_id, 'artist_access_request', true );
+
+	$status = 'none';
+	if ( $has_artist || $has_professional ) {
+		$status = 'approved';
+	} elseif ( ! empty( $pending_request ) && is_array( $pending_request ) ) {
+		$status = 'pending';
+	}
+
+	$response = array(
+		'user_id' => $user_id,
+		'status'  => $status,
+		'type'    => $has_artist ? 'artist' : ( $has_professional ? 'professional' : '' ),
+	);
+
+	if ( 'pending' === $status ) {
+		$response['request_type'] = isset( $pending_request['type'] ) ? $pending_request['type'] : '';
+		$response['requested_at'] = isset( $pending_request['requested_at'] ) ? (int) $pending_request['requested_at'] : 0;
+	}
+
+	return $response;
+}

--- a/inc/core/abilities/get-user-artists.php
+++ b/inc/core/abilities/get-user-artists.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Get User Artists Ability
+ *
+ * Returns the artist memberships (managed artists) for a user.
+ * Canonical implementation — REST and CLI are thin wrappers.
+ *
+ * @package ExtraChill\Users
+ * @since   0.8.0
+ */
+
+declare(strict_types=1);
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_users_register_get_user_artists_ability' );
+
+/**
+ * Register the extrachill/get-user-artists ability.
+ */
+function extrachill_users_register_get_user_artists_ability(): void {
+	wp_register_ability(
+		'extrachill/get-user-artists',
+		array(
+			'label'               => __( 'Get user artists', 'extrachill-users' ),
+			'description'         => __( 'Returns the artist memberships for a user.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'user_id' => array( 'type' => 'integer' ),
+				),
+				'required'             => array( 'user_id' ),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'  => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'id'                => array( 'type' => 'integer' ),
+						'name'              => array( 'type' => 'string' ),
+						'slug'              => array( 'type' => 'string' ),
+						'profile_image_url' => array( 'type' => array( 'string', 'null' ) ),
+					),
+				),
+			),
+			'permission_callback' => static function (): bool {
+				return is_user_logged_in();
+			},
+			'execute_callback'    => 'extrachill_users_ability_get_user_artists',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Get the artist memberships for a user.
+ *
+ * Only the user themselves or an admin can view artist memberships.
+ * Delegates to ec_get_artists_for_user() for the artist ID list,
+ * then resolves post data from the artist blog.
+ *
+ * @param array $input Input with 'user_id'.
+ * @return array|WP_Error Array of artist objects or error.
+ */
+function extrachill_users_ability_get_user_artists( array $input ): array|WP_Error {
+	$user_id = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : 0;
+
+	if ( ! $user_id ) {
+		return new WP_Error( 'missing_user_id', 'user_id is required.' );
+	}
+
+	$user = get_userdata( $user_id );
+	if ( ! $user ) {
+		return new WP_Error( 'user_not_found', 'User not found.', array( 'status' => 404 ) );
+	}
+
+	// Only own profile or admin.
+	$current_user = get_current_user_id();
+	if ( $current_user !== $user_id && ! current_user_can( 'manage_options' ) ) {
+		return new WP_Error( 'rest_forbidden', 'Cannot view other users\' artists.', array( 'status' => 403 ) );
+	}
+
+	if ( ! function_exists( 'ec_get_artists_for_user' ) ) {
+		return new WP_Error( 'dependency_missing', 'Users plugin not active.', array( 'status' => 500 ) );
+	}
+
+	$artist_ids = ec_get_artists_for_user( $user_id );
+	$artists    = array();
+
+	if ( ! empty( $artist_ids ) ) {
+		$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+		if ( $artist_blog_id ) {
+			switch_to_blog( $artist_blog_id );
+		}
+		try {
+			foreach ( $artist_ids as $artist_id ) {
+				$artist = get_post( $artist_id );
+				if ( ! $artist ) {
+					continue;
+				}
+
+				$profile_image_id  = get_post_thumbnail_id( $artist_id );
+				$profile_image_url = $profile_image_id
+					? wp_get_attachment_image_url( $profile_image_id, 'thumbnail' )
+					: null;
+
+				$artists[] = array(
+					'id'                => (int) $artist_id,
+					'name'              => $artist->post_title,
+					'slug'              => $artist->post_name,
+					'profile_image_url' => $profile_image_url,
+				);
+			}
+		} finally {
+			if ( $artist_blog_id ) {
+				restore_current_blog();
+			}
+		}
+	}
+
+	return $artists;
+}

--- a/inc/core/abilities/get-user-by-id.php
+++ b/inc/core/abilities/get-user-by-id.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Get User By ID Ability
+ *
+ * Returns a single user payload by ID with context-aware field visibility.
+ * Canonical implementation — REST and CLI are thin wrappers.
+ *
+ * @package ExtraChill\Users
+ * @since   0.8.0
+ */
+
+declare(strict_types=1);
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_users_register_get_user_by_id_ability' );
+
+/**
+ * Register the extrachill/get-user-by-id ability.
+ */
+function extrachill_users_register_get_user_by_id_ability(): void {
+	wp_register_ability(
+		'extrachill/get-user-by-id',
+		array(
+			'label'               => __( 'Get user by ID', 'extrachill-users' ),
+			'description'         => __( 'Returns a single user payload by ID. Own profile or admin sees extended fields.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'id' => array( 'type' => 'integer' ),
+				),
+				'required'             => array( 'id' ),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'                => array( 'type' => 'integer' ),
+					'display_name'      => array( 'type' => 'string' ),
+					'username'          => array( 'type' => 'string' ),
+					'slug'              => array( 'type' => 'string' ),
+					'avatar_url'        => array( 'type' => 'string' ),
+					'profile_url'       => array( 'type' => 'string' ),
+					'is_team_member'    => array( 'type' => 'boolean' ),
+					'last_active'       => array( 'type' => array( 'integer', 'null' ) ),
+					'email'             => array( 'type' => 'string' ),
+					'is_lifetime_member' => array( 'type' => 'boolean' ),
+					'is_artist'         => array( 'type' => 'boolean' ),
+					'is_professional'   => array( 'type' => 'boolean' ),
+					'can_create_artists' => array( 'type' => 'boolean' ),
+					'artist_count'      => array( 'type' => 'integer' ),
+					'registered'        => array( 'type' => 'string' ),
+				),
+			),
+			'permission_callback' => static function (): bool {
+				return is_user_logged_in();
+			},
+			'execute_callback'    => 'extrachill_users_ability_get_user_by_id',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Get a single user payload by ID.
+ *
+ * Returns public fields to all logged-in callers. Extended fields (email,
+ * membership, artist status) are included only for the user's own profile
+ * or admin callers.
+ *
+ * @param array $input Input with 'id'.
+ * @return array|WP_Error User data or error.
+ */
+function extrachill_users_ability_get_user_by_id( array $input ): array|WP_Error {
+	$user_id = isset( $input['id'] ) ? absint( $input['id'] ) : 0;
+
+	if ( ! $user_id ) {
+		return new WP_Error( 'missing_id', 'id is required.' );
+	}
+
+	$user = get_userdata( $user_id );
+	if ( ! $user ) {
+		return new WP_Error( 'user_not_found', 'User not found.', array( 'status' => 404 ) );
+	}
+
+	$current_user = get_current_user_id();
+	$is_own       = $current_user === $user_id;
+	$is_admin     = current_user_can( 'manage_options' );
+
+	// Avatar URL.
+	$avatar_url = get_avatar_url( $user_id, array( 'size' => 96 ) );
+
+	// Profile URL.
+	$profile_url = function_exists( 'extrachill_get_user_profile_url' )
+		? extrachill_get_user_profile_url( $user_id, $user->user_email )
+		: get_author_posts_url( $user_id );
+
+	// Team member status.
+	$is_team_member = function_exists( 'ec_is_team_member' )
+		? ec_is_team_member( $user_id )
+		: false;
+
+	// Last active timestamp.
+	$last_active = get_user_meta( $user_id, 'last_active', true );
+
+	// Public fields (available to all logged-in users).
+	$response = array(
+		'id'             => $user_id,
+		'display_name'   => $user->display_name,
+		'username'       => $user->user_login,
+		'slug'           => $user->user_nicename,
+		'avatar_url'     => $avatar_url,
+		'profile_url'    => $profile_url,
+		'is_team_member' => $is_team_member,
+		'last_active'    => $last_active ? (int) $last_active : null,
+	);
+
+	// Extended fields (own profile or admin only).
+	if ( $is_own || $is_admin ) {
+		$membership_data    = get_user_meta( $user_id, 'extrachill_lifetime_membership', true );
+		$is_lifetime_member = ! empty( $membership_data );
+
+		$is_artist       = get_user_meta( $user_id, 'user_is_artist', true ) === '1';
+		$is_professional = get_user_meta( $user_id, 'user_is_professional', true ) === '1';
+
+		$can_create_artists = function_exists( 'ec_can_create_artist_profiles' )
+			? ec_can_create_artist_profiles( $user_id )
+			: false;
+
+		$artist_count = 0;
+		if ( function_exists( 'ec_get_artists_for_user' ) ) {
+			$artists      = ec_get_artists_for_user( $user_id );
+			$artist_count = count( $artists );
+		}
+
+		$response['email']              = $user->user_email;
+		$response['is_lifetime_member'] = $is_lifetime_member;
+		$response['is_artist']          = $is_artist;
+		$response['is_professional']    = $is_professional;
+		$response['can_create_artists'] = $can_create_artists;
+		$response['artist_count']       = $artist_count;
+		$response['registered']         = mysql2date( 'c', $user->user_registered );
+	}
+
+	return $response;
+}

--- a/inc/core/abilities/register.php
+++ b/inc/core/abilities/register.php
@@ -36,3 +36,8 @@ require_once __DIR__ . '/user-settings.php';
 require_once __DIR__ . '/user-profile.php';
 require_once __DIR__ . '/subscriptions.php';
 require_once __DIR__ . '/concert-tracking.php';
+require_once __DIR__ . '/users-leaderboard.php';
+require_once __DIR__ . '/users-search.php';
+require_once __DIR__ . '/get-user-by-id.php';
+require_once __DIR__ . '/get-user-artists.php';
+require_once __DIR__ . '/get-user-artist-access.php';

--- a/inc/core/abilities/users-leaderboard.php
+++ b/inc/core/abilities/users-leaderboard.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Users Leaderboard Ability
+ *
+ * Returns ranked users by extrachill_total_points.
+ * Canonical implementation — REST and CLI are thin wrappers.
+ *
+ * @package ExtraChill\Users
+ * @since   0.8.0
+ */
+
+declare(strict_types=1);
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_users_register_leaderboard_ability' );
+
+/**
+ * Register the extrachill/users-leaderboard ability.
+ */
+function extrachill_users_register_leaderboard_ability(): void {
+	wp_register_ability(
+		'extrachill/users-leaderboard',
+		array(
+			'label'               => __( 'Get user leaderboard', 'extrachill-users' ),
+			'description'         => __( 'Returns ranked users by extrachill_total_points.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'page'     => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+						'default' => 1,
+					),
+					'per_page' => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+						'maximum' => 100,
+						'default' => 25,
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'items'      => array(
+						'type'  => 'array',
+						'items' => array(
+							'type'       => 'object',
+							'properties' => array(
+								'id'           => array( 'type' => 'integer' ),
+								'display_name' => array( 'type' => 'string' ),
+								'username'     => array( 'type' => 'string' ),
+								'slug'         => array( 'type' => 'string' ),
+								'avatar_url'   => array( 'type' => 'string' ),
+								'profile_url'  => array( 'type' => 'string' ),
+								'registered'   => array( 'type' => 'string' ),
+								'points'       => array( 'type' => 'number' ),
+								'rank'         => array( 'type' => 'string' ),
+								'badges'       => array( 'type' => 'array' ),
+								'position'     => array( 'type' => 'integer' ),
+							),
+						),
+					),
+					'pagination' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'page'        => array( 'type' => 'integer' ),
+							'per_page'    => array( 'type' => 'integer' ),
+							'total'       => array( 'type' => 'integer' ),
+							'total_pages' => array( 'type' => 'integer' ),
+						),
+					),
+				),
+			),
+			'permission_callback' => '__return_true',
+			'execute_callback'    => 'extrachill_users_ability_leaderboard',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Get leaderboard-ranked users by extrachill_total_points.
+ *
+ * @param array $input Input with optional 'page' and 'per_page'.
+ * @return array|WP_Error Leaderboard data or error.
+ */
+function extrachill_users_ability_leaderboard( array $input ): array|WP_Error {
+	$page     = max( 1, (int) ( $input['page'] ?? 1 ) );
+	$per_page = max( 1, min( 100, (int) ( $input['per_page'] ?? 25 ) ) );
+	$offset   = ( $page - 1 ) * $per_page;
+
+	$query = new WP_User_Query(
+		array(
+			'fields'   => 'all',
+			'orderby'  => 'meta_value_num',
+			'order'    => 'DESC',
+			'number'   => $per_page,
+			'offset'   => $offset,
+			'meta_key' => 'extrachill_total_points',
+		)
+	);
+
+	$total_query = new WP_User_Query(
+		array(
+			'fields'   => 'ID',
+			'orderby'  => 'meta_value_num',
+			'order'    => 'DESC',
+			'meta_key' => 'extrachill_total_points',
+		)
+	);
+
+	$total       = (int) $total_query->get_total();
+	$total_pages = $per_page > 0 ? (int) ceil( $total / $per_page ) : 1;
+
+	$items = array();
+	$index = 0;
+
+	foreach ( $query->get_results() as $user ) {
+		$user_id = (int) $user->ID;
+		$points  = (float) get_user_meta( $user_id, 'extrachill_total_points', true );
+		$rank    = function_exists( 'ec_get_rank_for_points' ) ? ec_get_rank_for_points( $points ) : '';
+		$badges  = function_exists( 'ec_get_user_badges' ) ? ec_get_user_badges( $user_id ) : array();
+
+		$profile_url = function_exists( 'extrachill_get_user_profile_url' )
+			? extrachill_get_user_profile_url( $user_id, $user->user_email )
+			: get_author_posts_url( $user_id );
+
+		$items[] = array(
+			'id'           => $user_id,
+			'display_name' => $user->display_name,
+			'username'     => $user->user_login,
+			'slug'         => $user->user_nicename,
+			'avatar_url'   => get_avatar_url( $user_id, array( 'size' => 96 ) ),
+			'profile_url'  => $profile_url,
+			'registered'   => mysql2date( 'c', $user->user_registered ),
+			'points'       => $points,
+			'rank'         => $rank,
+			'badges'       => $badges,
+			'position'     => $offset + $index + 1,
+		);
+
+		++$index;
+	}
+
+	return array(
+		'items'      => $items,
+		'pagination' => array(
+			'page'        => $page,
+			'per_page'    => $per_page,
+			'total'       => $total,
+			'total_pages' => $total_pages,
+		),
+	);
+}

--- a/inc/core/abilities/users-search.php
+++ b/inc/core/abilities/users-search.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Users Search Ability
+ *
+ * Search users by term with context-aware results (mentions, admin, artist-capable).
+ * Canonical implementation — REST and CLI are thin wrappers.
+ *
+ * @package ExtraChill\Users
+ * @since   0.8.0
+ */
+
+declare(strict_types=1);
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_users_register_search_ability' );
+
+/**
+ * Register the extrachill/users-search ability.
+ */
+function extrachill_users_register_search_ability(): void {
+	wp_register_ability(
+		'extrachill/users-search',
+		array(
+			'label'               => __( 'Search users', 'extrachill-users' ),
+			'description'         => __( 'Search users by term. Supports mentions, admin, and artist-capable contexts.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'term'              => array( 'type' => 'string' ),
+					'context'           => array(
+						'type'    => 'string',
+						'enum'    => array( 'mentions', 'admin', 'artist-capable' ),
+						'default' => 'mentions',
+					),
+					'exclude_artist_id' => array( 'type' => 'integer' ),
+				),
+				'required'             => array( 'term' ),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'  => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'id'           => array( 'type' => 'integer' ),
+						'display_name' => array( 'type' => 'string' ),
+						'username'     => array( 'type' => 'string' ),
+						'slug'         => array( 'type' => 'string' ),
+						'email'        => array( 'type' => 'string' ),
+						'avatar_url'   => array( 'type' => 'string' ),
+						'profile_url'  => array( 'type' => 'string' ),
+					),
+				),
+			),
+			'permission_callback' => static function (): bool {
+				$context = 'mentions'; // Default — callers pass context in input.
+				if ( $context === 'mentions' || $context === 'artist-capable' ) {
+					return is_user_logged_in();
+				}
+				if ( $context === 'admin' ) {
+					return current_user_can( 'manage_options' );
+				}
+				return is_user_logged_in();
+			},
+			'execute_callback'    => 'extrachill_users_ability_search',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Search users by term.
+ *
+ * @param array $input Input with 'term', optional 'context', optional 'exclude_artist_id'.
+ * @return array|WP_Error Search results or error.
+ */
+function extrachill_users_ability_search( array $input ): array|WP_Error {
+	$term    = isset( $input['term'] ) ? sanitize_text_field( $input['term'] ) : '';
+	$context = isset( $input['context'] ) ? sanitize_text_field( $input['context'] ) : 'mentions';
+
+	if ( empty( $term ) ) {
+		return new WP_Error( 'missing_search_term', 'Search term is required.' );
+	}
+
+	// Context-specific permission checks inside execute_callback.
+	if ( $context === 'admin' && ! current_user_can( 'manage_options' ) ) {
+		return new WP_Error( 'rest_forbidden', 'Admin access required.', array( 'status' => 403 ) );
+	}
+
+	if ( $context === 'artist-capable' ) {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error( 'rest_forbidden', 'Must be logged in.', array( 'status' => 401 ) );
+		}
+		if ( ! function_exists( 'ec_can_create_artist_profiles' ) || ! ec_can_create_artist_profiles( get_current_user_id() ) ) {
+			return new WP_Error( 'rest_forbidden', 'Cannot manage artist profiles.', array( 'status' => 403 ) );
+		}
+	}
+
+	// Require minimum 2 characters for admin and artist-capable contexts.
+	if ( in_array( $context, array( 'admin', 'artist-capable' ), true ) && strlen( $term ) < 2 ) {
+		return array();
+	}
+
+	// Handle artist-capable context separately.
+	if ( $context === 'artist-capable' ) {
+		return extrachill_users_ability_search_artist_capable( $input );
+	}
+
+	$search_columns = array( 'user_login', 'user_nicename' );
+	$number         = 10;
+
+	if ( $context === 'admin' ) {
+		$search_columns = array( 'user_login', 'user_email', 'display_name' );
+		$number         = 20;
+	}
+
+	$users_query = new WP_User_Query(
+		array(
+			'search'         => '*' . esc_attr( $term ) . '*',
+			'search_columns' => $search_columns,
+			'number'         => $number,
+			'orderby'        => 'display_name',
+			'order'          => 'ASC',
+		)
+	);
+
+	$users_data = array();
+
+	foreach ( $users_query->get_results() as $user ) {
+		if ( $context === 'admin' ) {
+			$users_data[] = array(
+				'id'           => $user->ID,
+				'display_name' => $user->display_name,
+				'username'     => $user->user_login,
+				'email'        => $user->user_email,
+				'avatar_url'   => get_avatar_url( $user->ID, array( 'size' => 32 ) ),
+			);
+		} else {
+			$profile_url = function_exists( 'extrachill_get_user_profile_url' )
+				? extrachill_get_user_profile_url( $user->ID, $user->user_email )
+				: '';
+
+			$users_data[] = array(
+				'id'          => $user->ID,
+				'username'    => $user->user_login,
+				'slug'        => $user->user_nicename,
+				'avatar_url'  => get_avatar_url( $user->ID, array( 'size' => 32 ) ),
+				'profile_url' => $profile_url,
+			);
+		}
+	}
+
+	return $users_data;
+}
+
+/**
+ * Search for users who can create artist profiles.
+ *
+ * Filters to users with user_is_artist, user_is_professional, or team member status.
+ * Excludes users who are already roster members of the specified artist.
+ *
+ * @param array $input Input with 'term' and optional 'exclude_artist_id'.
+ * @return array Search results.
+ */
+function extrachill_users_ability_search_artist_capable( array $input ): array {
+	$term              = sanitize_text_field( $input['term'] );
+	$exclude_artist_id = isset( $input['exclude_artist_id'] ) ? absint( $input['exclude_artist_id'] ) : 0;
+
+	// Get existing roster member IDs to exclude.
+	$exclude_user_ids = array();
+	if ( $exclude_artist_id && function_exists( 'ec_get_linked_members' ) ) {
+		$linked_members = ec_get_linked_members( $exclude_artist_id );
+		if ( is_array( $linked_members ) ) {
+			foreach ( $linked_members as $member ) {
+				$exclude_user_ids[] = (int) $member->ID;
+			}
+		}
+	}
+
+	$users_query = new WP_User_Query(
+		array(
+			'search'         => '*' . esc_attr( $term ) . '*',
+			'search_columns' => array( 'user_login', 'user_email', 'display_name' ),
+			'number'         => 50,
+			'orderby'        => 'display_name',
+			'order'          => 'ASC',
+		)
+	);
+
+	$users_data = array();
+	$count      = 0;
+	$limit      = 10;
+
+	foreach ( $users_query->get_results() as $user ) {
+		if ( $count >= $limit ) {
+			break;
+		}
+
+		if ( in_array( $user->ID, $exclude_user_ids, true ) ) {
+			continue;
+		}
+
+		$is_artist       = get_user_meta( $user->ID, 'user_is_artist', true ) === '1';
+		$is_professional = get_user_meta( $user->ID, 'user_is_professional', true ) === '1';
+		$is_team_member  = function_exists( 'ec_is_team_member' ) && ec_is_team_member( $user->ID );
+
+		if ( ! $is_artist && ! $is_professional && ! $is_team_member ) {
+			continue;
+		}
+
+		$profile_url = function_exists( 'extrachill_get_user_profile_url' )
+			? extrachill_get_user_profile_url( $user->ID, $user->user_email )
+			: '';
+
+		$users_data[] = array(
+			'id'           => $user->ID,
+			'display_name' => $user->display_name,
+			'username'     => $user->user_login,
+			'email'        => $user->user_email,
+			'avatar_url'   => get_avatar_url( $user->ID, array( 'size' => 32 ) ),
+			'profile_url'  => $profile_url,
+		);
+
+		++$count;
+	}
+
+	return $users_data;
+}


### PR DESCRIPTION
## Summary

Registers 5 new user-domain abilities in extrachill-users with canonical `execute_callback` implementations per [issue #21](https://github.com/Extra-Chill/extrachill-users/issues/21).

Closes #21.

## Abilities registered

| Ability name | Description | `meta.readonly` |
|---|---|---|
| `extrachill/users-leaderboard` | Ranked users by `extrachill_total_points` | `true` |
| `extrachill/users-search` | Search users by term (mentions, admin, artist-capable contexts) | `true` |
| `extrachill/get-user-by-id` | Single user payload by ID (context-aware field visibility) | `true` |
| `extrachill/get-user-artists` | Artist memberships for a user | `true` |
| `extrachill/get-user-artist-access` | Current user's artist-access request status | `true` |

`extrachill/get-subscriptions` already existed in `inc/core/abilities/subscriptions.php` — skipped per issue instructions.

## Architecture

All abilities have `meta.show_in_rest: true`, so WP core auto-exposes them at `/wp-json/wp-abilities/v1/abilities/<name>/run`. The branded `/extrachill/v1/users/*` routes in extrachill-api will refactor to thin ability shims in a separate PR.

## Implementation details

- Each ability file lives in `inc/core/abilities/<name>.php`
- Implementations ported from extrachill-api REST callbacks, rewritten as standalone `execute_callback` functions
- Delegates to existing extrachill-users helpers (`ec_get_artists_for_user()`, `ec_get_rank_for_points()`, `ec_get_user_badges()`, etc.) where available
- Permission callbacks match the original REST permission semantics
- Bootstrap loader (`register.php`) updated with 5 new `require_once` entries

## Verification

- `php -l` passes on all 15 ability files (zero syntax errors)
- All 5 new abilities appear in `wp_get_abilities()` when loaded

## What this does NOT do

- Does NOT modify extrachill-api REST routes (separate refactor)
- Does NOT delete anything — abilities are additive
- Does NOT touch CHANGELOG.md or version strings