### PR TITLE
fix: content sweep silently misses bbPress and per-site CPTs

### DIFF
--- a/inc/core/moderation/content.php
+++ b/inc/core/moderation/content.php
@@ -16,25 +16,33 @@ function extrachill_users_get_user_content_objects( int $user_id ): array {
 		'archived' => 0,
 	) );
 
+	global $wpdb;
+
 	foreach ( $sites as $site ) {
 		switch_to_blog( (int) $site->blog_id );
 		try {
-			$post_ids = get_posts(
-				array(
-					'author'         => $user_id,
-					'post_type'      => 'any',
-					'post_status'    => 'any',
-					'posts_per_page' => -1,
-					'fields'         => 'ids',
+			// Query the posts table directly. Avoids `post_type => 'any'` which
+			// only expands to post types registered in the current request
+			// context. switch_to_blog() does not load per-site plugins, so
+			// types like bbPress `topic` / `reply` and per-site CPTs are NOT
+			// registered when this runs from another site's request — and
+			// would be silently skipped, leaving banned users' content live.
+			$post_ids = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT ID FROM {$wpdb->posts}
+					 WHERE post_author = %d
+					   AND post_type NOT IN ( 'revision', 'nav_menu_item', 'custom_css', 'customize_changeset', 'oembed_cache', 'user_request', 'wp_block', 'wp_template', 'wp_template_part', 'wp_global_styles', 'wp_navigation', 'wp_font_family', 'wp_font_face' )",
+					$user_id
 				)
 			);
 
 			foreach ( $post_ids as $post_id ) {
+				$post_id = (int) $post_id;
 				$objects[] = array(
 					'type'      => 'post',
 					'blog_id'   => (int) $site->blog_id,
-					'object_id' => (int) $post_id,
-					'post_type' => get_post_type( $post_id ),
+					'object_id' => $post_id,
+					'post_type' => get_post_field( 'post_type', $post_id ),
 				);
 			}
 


### PR DESCRIPTION
## Summary

Banned users' content stayed publicly visible because the content discovery query depended on which plugins were loaded in the current request context.

`extrachill_users_get_user_content_objects()` calls `get_posts( post_type => 'any' )` inside a `switch_to_blog()` loop. WordPress's `'any'` only expands to post types **registered in the current request** — it does not register the target site's plugins. So when moderation runs from a non-community context (WP-CLI from extrachill.com, REST from the main site, etc.), bbPress isn't loaded, `topic` / `reply` aren't in the post type registry, and `get_posts` silently returns zero rows for community-only spammers.

Symptom: ban applies, `ban-status` correctly reports `hide_content: true`, sessions revoked, email sent — but the spam topics stay `publish`.

## Caught in the wild

extrachill.com production, 2026-05-10:
- community.extrachill.com user 605 (`dbsdigibank9`)
- Banned with `--reason-key=spam` from `wp` running on the main site
- 12 topics + replies (IDs 14100–14111) remained `post_status: publish`
- Required manual cleanup

## Fix

Query `wp_posts` directly with `$wpdb`. Visibility is now independent of which plugins happen to be loaded:

```php
\$post_ids = \$wpdb->get_col(
    \$wpdb->prepare(
        \"SELECT ID FROM {\$wpdb->posts}
         WHERE post_author = %d
           AND post_type NOT IN ( ...core internal types... )\",
        \$user_id
    )
);
```

The exclusion list is just WP core's internal post types (`revision`, `nav_menu_item`, `custom_css`, `customize_changeset`, `oembed_cache`, `user_request`, `wp_block`, `wp_template`, `wp_template_part`, `wp_global_styles`, `wp_navigation`, `wp_font_family`, `wp_font_face`). Everything else — registered or not — is content the user authored and should be subject to the ban.

Also swapped `get_post_type()` for `get_post_field( 'post_type', \$id )` on readback. Same context-dependency issue (`get_post_type` checks the registered types in some code paths); `get_post_field` reads the column directly.

The downstream apply loop already handles unregistered post types correctly: when `bbp_spam_topic` / `bbp_spam_reply` are unavailable, it falls through to `wp_update_post( post_status => 'draft' )` which hides the content. So the fix is purely in the discovery query.

## Test plan

```bash
wp extrachill users ban <community-only-spammer> --reason-key=spam
wp --url=community.extrachill.com post list --post_type=topic --author=<id> --post_status=any --fields=ID,post_status
# Before: post_status=publish
# After:  post_status=draft (or 'spam' if invoked from community subsite where bbPress IS loaded)
```

## Notes

There's a related cosmetic inconsistency: when bbPress IS loaded (CLI run with `--url=community.extrachill.com`), topics get `post_status=spam` (bbPress's own status). When bbPress isn't loaded (from main site context), they get `post_status=draft`. Both hide the content from the front-end. Worth normalizing in a follow-up but not urgent.