### PR TITLE
fix: accept username or email in password reset form

### DIFF
--- a/blocks/password-reset/render.php
+++ b/blocks/password-reset/render.php
@@ -58,15 +58,15 @@ if ( 'reset' === $password_reset_action && ! empty( $key ) && ! empty( $login ) 
 	?>
 	<div class="password-reset-form">
 		<h2><?php esc_html_e( 'Reset Your Password', 'extrachill-users' ); ?></h2>
-		<p><?php esc_html_e( 'Enter your email address and we\'ll send you a link to reset your password.', 'extrachill-users' ); ?></p>
+		<p><?php esc_html_e( 'Enter your email or username and we\'ll send you a link to reset your password.', 'extrachill-users' ); ?></p>
 
 		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 			<input type="hidden" name="action" value="ec_password_reset_request">
 			<?php EC_Redirect_Handler::render_hidden_fields(); ?>
 			<?php wp_nonce_field( 'ec_password_reset_request', 'ec_password_reset_nonce' ); ?>
 
-			<label for="user_login"><?php esc_html_e( 'Email Address', 'extrachill-users' ); ?></label>
-			<input type="email" name="user_login" id="user_login" required>
+			<label for="user_login"><?php esc_html_e( 'Email or Username', 'extrachill-users' ); ?></label>
+			<input type="text" name="user_login" id="user_login" required>
 
 			<input type="submit" class="button-1 button-medium" value="<?php esc_attr_e( 'Send Reset Link', 'extrachill-users' ); ?>">
 		</form>

--- a/inc/auth/password-reset.php
+++ b/inc/auth/password-reset.php
@@ -31,16 +31,20 @@ function ec_handle_password_reset_request() {
 	$redirect->verify_nonce( 'ec_password_reset_nonce', 'ec_password_reset_request' );
 
 	// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce verified above through EC_Redirect_Handler.
-	$user_login = isset( $_POST['user_login'] ) ? sanitize_text_field( wp_unslash( $_POST['user_login'] ) ) : '';
+	$user_login = isset( $_POST['user_login'] ) ? trim( sanitize_text_field( wp_unslash( $_POST['user_login'] ) ) ) : '';
 
 	if ( empty( $user_login ) ) {
-		$redirect->error( __( 'Please enter your email address.', 'extrachill-users' ) );
+		$redirect->error( __( 'Please enter your email or username.', 'extrachill-users' ) );
 	}
 
-	$user = get_user_by( 'email', $user_login );
+	if ( strpos( $user_login, '@' ) !== false ) {
+		$user = get_user_by( 'email', $user_login );
+	} else {
+		$user = get_user_by( 'login', $user_login );
+	}
 
 	if ( ! $user ) {
-		$redirect->success( __( 'If an account exists with that email, you will receive a password reset link.', 'extrachill-users' ) );
+		$redirect->success( __( 'If an account exists with that email or username, you will receive a password reset link.', 'extrachill-users' ) );
 	}
 
 	$reset_key = get_password_reset_key( $user );


### PR DESCRIPTION
Fixes #27

## Summary

Password reset previously looked up users by **email only** (`get_user_by('email', $user_login)`), so any username input — or even an email that wasn't the exact one on file — fell through to the generic success message and **no email was ever sent**. WordPress core's `retrieve_password()` accepts both username and email; this restores that behavior.

## Changes

**`inc/auth/password-reset.php`** — `ec_handle_password_reset_request()`:
- Trim the input first.
- Branch lookup on whether the input contains `@`:
  - contains `@` → `get_user_by('email', $user_login)`
  - otherwise → `get_user_by('login', $user_login)`
- Generic-success enumeration-protection message text updated to mention both email and username (behavior preserved — still returns success on no-match so attackers can't probe for valid accounts).
- Empty-input error message also updated to "Please enter your email or username."

**`blocks/password-reset/render.php`** — request form template:
- `<input type="email">` → `<input type="text">` so usernames pass browser validation.
- Label: "Email Address" → "Email or Username".
- Helper text: "Enter your email address and we'll send you a link…" → "Enter your email or username and we'll send you a link…".

`build/` is gitignored in this repo and regenerated from `blocks/` via the `copy:block-files` script at release time, so the source-of-truth edit lives in `blocks/password-reset/render.php`.

## Preserved behavior

The enumeration-protection generic success message on lookup-miss is **intentionally preserved** — attackers should not be able to distinguish valid from invalid accounts via the reset form.

## Out of scope (follow-up)

Issue #27 also suggested delegating to core `retrieve_password()` (which already handles dual lookup, rate limiting, and the `lostpassword_post` hook). That's a larger refactor and intentionally left as a follow-up; this PR is the minimal fix to stop silently dropping reset requests.

## Validation

- `php -l` clean on both files.
- Visual code review against issue #27 reproduction steps.