### PR TITLE
fix: clean up ESLint errors to restore release gate

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,13 @@
+# wp-scripts compiled block artifacts (output of `npm run build`).
+# Source lives under blocks/*/src/. The compiled bundles below are checked-in
+# distribution artifacts and must not be linted.
+blocks/login-register/index.js
+blocks/password-reset/index.js
+
+# Generic build / vendor / minified output (kept in sync with the upstream
+# homeboy WordPress extension's defaults so local lint runs match CI).
+build/
+dist/
+node_modules/
+vendor/
+*.min.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+	"settings": {
+		"import/core-modules": [
+			"@wordpress/blocks",
+			"@wordpress/block-editor",
+			"@wordpress/components",
+			"@wordpress/element",
+			"@wordpress/i18n",
+			"@wordpress/data"
+		]
+	}
+}

--- a/assets/js/auth-utils.js
+++ b/assets/js/auth-utils.js
@@ -50,7 +50,10 @@
         const bytes = new Uint8Array(16);
         window.crypto.getRandomValues(bytes);
 
+        // Set RFC 4122 version (4) and variant (10xx) bits — bitwise required by spec.
+        // eslint-disable-next-line no-bitwise
         bytes[6] = (bytes[6] & 0x0f) | 0x40;
+        // eslint-disable-next-line no-bitwise
         bytes[8] = (bytes[8] & 0x3f) | 0x80;
 
         const hex = Array.from(bytes, function (b) {

--- a/assets/js/auth-utils.js
+++ b/assets/js/auth-utils.js
@@ -13,7 +13,7 @@
         }
 
         try {
-            var url = new URL(root, window.location.origin);
+            const url = new URL(root, window.location.origin);
             if (!url.pathname.endsWith('/')) {
                 url.pathname += '/';
             }
@@ -25,15 +25,15 @@
 
     function getRestRoot() {
         if (window.wpApiSettings && window.wpApiSettings.root) {
-            var normalized = normalizeRestRoot(window.wpApiSettings.root);
+            const normalized = normalizeRestRoot(window.wpApiSettings.root);
             if (normalized) {
                 return normalized;
             }
         }
 
-        var link = document.querySelector('link[rel="https://api.w.org/"]');
+        const link = document.querySelector('link[rel="https://api.w.org/"]');
         if (link && link.href) {
-            var linkRoot = normalizeRestRoot(link.href);
+            const linkRoot = normalizeRestRoot(link.href);
             if (linkRoot) {
                 return linkRoot;
             }
@@ -47,13 +47,13 @@
             return '';
         }
 
-        var bytes = new Uint8Array(16);
+        const bytes = new Uint8Array(16);
         window.crypto.getRandomValues(bytes);
 
         bytes[6] = (bytes[6] & 0x0f) | 0x40;
         bytes[8] = (bytes[8] & 0x3f) | 0x80;
 
-        var hex = Array.from(bytes, function (b) {
+        const hex = Array.from(bytes, function (b) {
             return b.toString(16).padStart(2, '0');
         });
 
@@ -72,13 +72,13 @@
 
     function getDeviceId() {
         try {
-            var key = 'extrachill_device_id';
-            var existing = window.localStorage.getItem(key);
+            const key = 'extrachill_device_id';
+            const existing = window.localStorage.getItem(key);
             if (existing) {
                 return existing;
             }
 
-            var generated = uuidv4();
+            const generated = uuidv4();
             if (!generated) {
                 return '';
             }
@@ -95,7 +95,7 @@
             return;
         }
 
-		var notice = container.querySelector('[data-ec-auth-notice="1"]');
+		let notice = container.querySelector('[data-ec-auth-notice="1"]');
 		if (!notice) {
 			notice = document.createElement('div');
 			notice.dataset.ecAuthNotice = '1';
@@ -106,7 +106,7 @@
 		notice.className = 'ec-auth-notice ec-auth-notice--' + type;
 		notice.innerHTML = '';
 
-        var p = document.createElement('p');
+        const p = document.createElement('p');
         if (allowHtml) {
             p.innerHTML = message;
         } else {
@@ -120,7 +120,7 @@
             return;
         }
 
-        var notice = container.querySelector('[data-ec-auth-notice="1"]');
+        const notice = container.querySelector('[data-ec-auth-notice="1"]');
         if (notice) {
             notice.remove();
         }
@@ -131,7 +131,7 @@
             return function () {};
         }
 
-        var original = button.value !== undefined ? button.value : button.textContent;
+        const original = button.value !== undefined ? button.value : button.textContent;
         button.disabled = true;
 
         if (button.value !== undefined) {
@@ -151,12 +151,12 @@
     }
 
     function getFormValue(form, selector) {
-        var el = form.querySelector(selector);
+        const el = form.querySelector(selector);
         return el ? el.value || '' : '';
     }
 
     function getFormChecked(form, selector) {
-        var el = form.querySelector(selector);
+        const el = form.querySelector(selector);
         return el ? !!el.checked : false;
     }
 
@@ -165,13 +165,13 @@
     }
 
     window.ECAuthUtils = {
-        getRestRoot: getRestRoot,
-        getDeviceId: getDeviceId,
-        renderNotice: renderNotice,
-        clearNotice: clearNotice,
-        setSubmitting: setSubmitting,
-        getFormValue: getFormValue,
-        getFormChecked: getFormChecked,
-        getCommunityUrl: getCommunityUrl
+        getRestRoot,
+        getDeviceId,
+        renderNotice,
+        clearNotice,
+        setSubmitting,
+        getFormValue,
+        getFormChecked,
+        getCommunityUrl
     };
 })();

--- a/assets/js/avatar-menu.js
+++ b/assets/js/avatar-menu.js
@@ -4,7 +4,7 @@
  * Handles user avatar dropdown menu toggling and click-outside behavior.
  * Provides keyboard accessibility with Escape key support.
  *
- * @package ExtraChillMultisite
+ * @package
  */
 document.addEventListener('DOMContentLoaded', function() {
     const avatarToggle = document.querySelector('.user-avatar-toggle');

--- a/assets/js/concert-tracking.js
+++ b/assets/js/concert-tracking.js
@@ -7,7 +7,7 @@
  *   - button-3 (neutral) when unmarked
  *   - button-2 (green accent) when marked
  *
- * @package ExtraChill\Users
+ * @package
  * @since 0.8.0
  */
 
@@ -16,6 +16,12 @@
 
 	/**
 	 * Toggle button between marked (button-2) and unmarked (button-3) states.
+	 * @param button
+	 * @param container
+	 * @param marked
+	 * @param labelEl
+	 * @param labelDefault
+	 * @param labelActive
 	 */
 	function setButtonState( button, container, marked, labelEl, labelDefault, labelActive ) {
 		if ( marked ) {
@@ -27,7 +33,7 @@
 			}
 			// Add check mark if not present.
 			if ( ! button.querySelector( '.ec-attendance__check' ) ) {
-				var check = document.createElement( 'span' );
+				const check = document.createElement( 'span' );
 				check.className = 'ec-attendance__check';
 				check.setAttribute( 'aria-hidden', 'true' );
 				check.textContent = '\u2713';
@@ -41,7 +47,7 @@
 				labelEl.textContent = labelDefault;
 			}
 			// Remove check mark.
-			var checkEl = button.querySelector( '.ec-attendance__check' );
+			const checkEl = button.querySelector( '.ec-attendance__check' );
 			if ( checkEl ) {
 				checkEl.remove();
 			}
@@ -49,19 +55,19 @@
 	}
 
 	document.addEventListener( 'click', function ( e ) {
-		var button = e.target.closest( '.ec-attendance__button' );
+		const button = e.target.closest( '.ec-attendance__button' );
 		if ( ! button ) {
 			return;
 		}
 
-		var action = button.getAttribute( 'data-action' );
+		const action = button.getAttribute( 'data-action' );
 		if ( ! action ) {
 			return;
 		}
 
 		// Redirect to login for non-authenticated users.
 		if ( action === 'login' ) {
-			var loginUrl = ( window.ecConcertTracking && window.ecConcertTracking.loginUrl ) || '/login/';
+			const loginUrl = ( window.ecConcertTracking && window.ecConcertTracking.loginUrl ) || '/login/';
 			window.location.href = loginUrl + '?redirect_to=' + encodeURIComponent( window.location.href );
 			return;
 		}
@@ -70,7 +76,7 @@
 			return;
 		}
 
-		var container = button.closest( '.ec-attendance' );
+		const container = button.closest( '.ec-attendance' );
 		if ( ! container ) {
 			return;
 		}
@@ -81,14 +87,14 @@
 		}
 		button.disabled = true;
 
-		var eventId = parseInt( container.getAttribute( 'data-event-id' ), 10 );
-		var blogId = parseInt( container.getAttribute( 'data-blog-id' ), 10 );
-		var labelDefault = container.getAttribute( 'data-label-default' );
-		var labelActive = container.getAttribute( 'data-label-active' );
-		var labelEl = button.querySelector( '.ec-attendance__label' );
+		const eventId = parseInt( container.getAttribute( 'data-event-id' ), 10 );
+		const blogId = parseInt( container.getAttribute( 'data-blog-id' ), 10 );
+		const labelDefault = container.getAttribute( 'data-label-default' );
+		const labelActive = container.getAttribute( 'data-label-active' );
+		const labelEl = button.querySelector( '.ec-attendance__label' );
 
 		// Optimistic UI update.
-		var isCurrentlyMarked = container.classList.contains( 'ec-attendance--marked' );
+		const isCurrentlyMarked = container.classList.contains( 'ec-attendance--marked' );
 		setButtonState( button, container, ! isCurrentlyMarked, labelEl, labelDefault, labelActive );
 
 		// API call.
@@ -101,12 +107,12 @@
 			},
 		} ).then( function ( response ) {
 			// Update count label.
-			var countEl = container.querySelector( '.ec-attendance__count' );
+			const countEl = container.querySelector( '.ec-attendance__count' );
 			if ( response.count > 0 ) {
 				if ( countEl ) {
 					countEl.textContent = response.count_label;
 				} else {
-					var newCount = document.createElement( 'span' );
+					const newCount = document.createElement( 'span' );
 					newCount.className = 'ec-attendance__count';
 					newCount.textContent = response.count_label;
 					container.appendChild( newCount );

--- a/assets/js/concert-tracking.js
+++ b/assets/js/concert-tracking.js
@@ -14,15 +14,7 @@
 ( function () {
 	'use strict';
 
-	/**
-	 * Toggle button between marked (button-2) and unmarked (button-3) states.
-	 * @param button
-	 * @param container
-	 * @param marked
-	 * @param labelEl
-	 * @param labelDefault
-	 * @param labelActive
-	 */
+	// Toggle button between marked (button-2) and unmarked (button-3) states.
 	function setButtonState( button, container, marked, labelEl, labelDefault, labelActive ) {
 		if ( marked ) {
 			container.classList.add( 'ec-attendance--marked' );

--- a/assets/js/google-signin.js
+++ b/assets/js/google-signin.js
@@ -4,6 +4,7 @@
  * Integrates Google Identity Services (GIS) library for authentication.
  * Uses ECAuthUtils for shared functionality.
  */
+/* global google */
 (function () {
     'use strict';
 
@@ -174,7 +175,7 @@
     /**
      * Check if current page is from /join flow.
      *
-     * @return {boolean}
+     * @return {boolean} True when the current URL carries from_join=true.
      */
     function isFromJoinFlow() {
         try {

--- a/assets/js/google-signin.js
+++ b/assets/js/google-signin.js
@@ -7,15 +7,15 @@
 (function () {
     'use strict';
 
-    var utils = window.ECAuthUtils;
-    var initialized = false;
+    const utils = window.ECAuthUtils;
+    let initialized = false;
 
     /**
      * Initialize Google Sign-In for all button containers on the page.
      *
-     * @param {Object} config Configuration object.
+     * @param {Object} config          Configuration object.
      * @param {string} config.clientId Google OAuth client ID.
-     * @param {string} config.restUrl REST API base URL.
+     * @param {string} config.restUrl  REST API base URL.
      */
     function init(config) {
         if (!config || !config.clientId) {
@@ -41,7 +41,7 @@
 
         google.accounts.id.initialize({
             client_id: config.clientId,
-            callback: function (response) {
+            callback (response) {
                 handleCredentialResponse(response, config);
             },
             auto_select: false,
@@ -85,7 +85,7 @@
             return;
         }
 
-        var containers = document.querySelectorAll('.google-signin-button');
+        const containers = document.querySelectorAll('.google-signin-button');
         containers.forEach(function (container) {
             renderButton(container);
         });
@@ -97,7 +97,7 @@
      * @return {string} Redirect URL or current page URL.
      */
     function getSuccessRedirectUrl() {
-        var input = document.querySelector('input[name="success_redirect_url"]');
+        const input = document.querySelector('input[name="success_redirect_url"]');
         if (input && input.value) {
             return input.value;
         }
@@ -108,7 +108,7 @@
      * Handle credential response from Google.
      *
      * @param {Object} response Google credential response.
-     * @param {Object} config Configuration object.
+     * @param {Object} config   Configuration object.
      */
     function handleCredentialResponse(response, config) {
         if (!response || !response.credential) {
@@ -116,7 +116,7 @@
             return;
         }
 
-        var deviceId = utils.getDeviceId();
+        const deviceId = utils.getDeviceId();
         if (!deviceId) {
             showError('Unable to generate device ID.');
             return;
@@ -126,12 +126,12 @@
         // and passed via wp_localize_script. The standard register form reads the
         // same value from config.fromJoin in view.js, so the two flows can never
         // drift even if the URL is mutated client-side after render.
-        var fromJoin = Boolean(config && config.fromJoin) || isFromJoinFlow();
-        var successRedirectUrl = getSuccessRedirectUrl();
+        const fromJoin = Boolean(config && config.fromJoin) || isFromJoinFlow();
+        const successRedirectUrl = getSuccessRedirectUrl();
 
         setGlobalLoading(true);
 
-        var url = new URL('auth/google', config.restUrl || utils.getRestRoot());
+        const url = new URL('auth/google', config.restUrl || utils.getRestRoot());
 
         fetch(url.toString(), {
             method: 'POST',
@@ -155,14 +155,14 @@
             .then(function (res) {
                 return res.json().then(function (data) {
                     if (!res.ok) {
-                        var message = data && data.message ? data.message : 'Google Sign-In failed.';
+                        const message = data && data.message ? data.message : 'Google Sign-In failed.';
                         throw new Error(message);
                     }
                     return data;
                 });
             })
             .then(function (data) {
-                var redirectUrl = data && data.redirect_url ? data.redirect_url : window.location.href;
+                const redirectUrl = data && data.redirect_url ? data.redirect_url : window.location.href;
                 window.location.assign(redirectUrl);
             })
             .catch(function (err) {
@@ -178,7 +178,7 @@
      */
     function isFromJoinFlow() {
         try {
-            var params = new URL(window.location.href).searchParams;
+            const params = new URL(window.location.href).searchParams;
             return params.get('from_join') === 'true';
         } catch (e) {
             return false;
@@ -191,7 +191,7 @@
      * @param {string} message Error message.
      */
     function showError(message) {
-        var container = document.querySelector('.login-register-form');
+        const container = document.querySelector('.login-register-form');
         if (container && utils) {
             utils.renderNotice(container, 'error', message);
         } else {
@@ -205,7 +205,7 @@
      * @param {boolean} loading Whether loading.
      */
     function setGlobalLoading(loading) {
-        var containers = document.querySelectorAll('.google-signin-button');
+        const containers = document.querySelectorAll('.google-signin-button');
         containers.forEach(function (container) {
             container.style.opacity = loading ? '0.5' : '1';
             container.style.pointerEvents = loading ? 'none' : 'auto';
@@ -213,7 +213,7 @@
     }
 
     window.ECGoogleSignIn = {
-        init: init,
-        renderAllButtons: renderAllButtons
+        init,
+        renderAllButtons
     };
 })();

--- a/blocks/login-register/src/index.js
+++ b/blocks/login-register/src/index.js
@@ -1,10 +1,19 @@
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps } from '@wordpress/block-editor';
+/**
+ * External dependencies
+ */
 import '@extrachill/components/styles/components.scss';
+/**
+ * Internal dependencies
+ */
 import './editor.css';
 
 registerBlockType( 'extrachill/login-register', {
-	edit: function( { attributes, setAttributes } ) {
+	edit( { attributes, setAttributes } ) {
 		const blockProps = useBlockProps();
 		const { redirectUrl } = attributes;
 

--- a/blocks/login-register/src/index.js
+++ b/blocks/login-register/src/index.js
@@ -12,30 +12,32 @@ import '@extrachill/components/styles/components.scss';
  */
 import './editor.css';
 
-registerBlockType( 'extrachill/login-register', {
-	edit( { attributes, setAttributes } ) {
-		const blockProps = useBlockProps();
-		const { redirectUrl } = attributes;
+function Edit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps();
+	const { redirectUrl } = attributes;
 
-		return (
-			<div { ...blockProps }>
-				<div className="login-register-block-preview">
-					<p>Login/Register Form</p>
-					<p className="block-description">This block displays a tabbed login and registration form on the frontend.</p>
+	return (
+		<div { ...blockProps }>
+			<div className="login-register-block-preview">
+				<p>Login/Register Form</p>
+				<p className="block-description">This block displays a tabbed login and registration form on the frontend.</p>
 
-					<div className="redirect-field-wrapper">
-						<label htmlFor="redirect-url-input">Redirect URL (Optional)</label>
-						<input
-							id="redirect-url-input"
-							type="text"
-							value={redirectUrl}
-							onChange={(e) => setAttributes({ redirectUrl: e.target.value })}
-							placeholder="https://example.com/"
-						/>
-						<span className="help-text">Leave empty to stay on current page after login. Set to homepage URL on /login page.</span>
-					</div>
+				<div className="redirect-field-wrapper">
+					<label htmlFor="redirect-url-input">Redirect URL (Optional)</label>
+					<input
+						id="redirect-url-input"
+						type="text"
+						value={ redirectUrl }
+						onChange={ ( e ) => setAttributes( { redirectUrl: e.target.value } ) }
+						placeholder="https://example.com/"
+					/>
+					<span className="help-text">Leave empty to stay on current page after login. Set to homepage URL on /login page.</span>
 				</div>
 			</div>
-		);
-	}
+		</div>
+	);
+}
+
+registerBlockType( 'extrachill/login-register', {
+	edit: Edit,
 } );

--- a/blocks/login-register/view.js
+++ b/blocks/login-register/view.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BlockShell, BlockShellHeader, BlockShellInner, Panel, ResponsiveTabs } from '@extrachill/components';

--- a/blocks/login-register/view.js
+++ b/blocks/login-register/view.js
@@ -67,8 +67,6 @@ function LoginPanel( { config, notice, setNotice } ) {
 		const formData = new window.FormData( form );
 		const identifier = String( formData.get( 'log' ) || '' ).trim();
 		const password = String( formData.get( 'pwd' ) || '' );
-		const remember = formData.get( 'rememberme' ) === 'forever';
-		const redirectTo = String( formData.get( 'redirect_to' ) || window.location.href );
 
 		if ( ! identifier || ! password ) {
 			setNotice( { type: 'error', message: 'Username and password are required.' } );
@@ -82,6 +80,8 @@ function LoginPanel( { config, notice, setNotice } ) {
 			return;
 		}
 
+		const remember = formData.get( 'rememberme' ) === 'forever';
+		const redirectTo = String( formData.get( 'redirect_to' ) || window.location.href );
 		const submitButton = form.querySelector( 'input[type="submit"], button[type="submit"]' );
 		const restore = utils?.setSubmitting ? utils.setSubmitting( submitButton, 'Logging in…' ) : () => {};
 
@@ -142,8 +142,8 @@ function LoginPanel( { config, notice, setNotice } ) {
 					<label htmlFor="user_pass">Password</label>
 					<input type="password" name="pwd" id="user_pass" className="input" placeholder="Your password" required />
 					<div className="login-remember-me">
-						<label>
-							<input type="checkbox" name="rememberme" value="forever" />
+						<label htmlFor="rememberme">
+							<input type="checkbox" id="rememberme" name="rememberme" value="forever" />
 							Remember me
 						</label>
 					</div>
@@ -154,7 +154,7 @@ function LoginPanel( { config, notice, setNotice } ) {
 				</form>
 				{ config.googleOAuthEnabled && <GoogleButtons /> }
 				<p className="login-register-prompt">
-					Don't have an account? <a href="#tab-register">Register here</a>
+					Don&apos;t have an account? <a href="#tab-register">Register here</a>
 				</p>
 			</div>
 		</Panel>
@@ -177,15 +177,13 @@ function RegisterPanel( { config, notice, setNotice } ) {
 		const email = String( formData.get( 'extrachill_email' ) || '' ).trim();
 		const password = String( formData.get( 'extrachill_password' ) || '' );
 		const passwordConfirm = String( formData.get( 'extrachill_password_confirm' ) || '' );
-		const turnstileResponse = String( formData.get( 'cf-turnstile-response' ) || '' );
-		const inviteToken = String( formData.get( 'invite_token' ) || '' );
-		const inviteArtistId = Number( formData.get( 'invite_artist_id' ) || 0 );
 
 		if ( ! email || ! password || ! passwordConfirm ) {
 			setNotice( { type: 'error', message: 'All fields are required.' } );
 			return;
 		}
 
+		const turnstileResponse = String( formData.get( 'cf-turnstile-response' ) || '' );
 		const turnstileWidget = form.querySelector( '.cf-turnstile' );
 		if ( turnstileWidget && ! turnstileResponse ) {
 			setNotice( { type: 'error', message: 'Captcha verification required. Please complete the challenge and try again.' } );
@@ -199,6 +197,8 @@ function RegisterPanel( { config, notice, setNotice } ) {
 			return;
 		}
 
+		const inviteToken = String( formData.get( 'invite_token' ) || '' );
+		const inviteArtistId = Number( formData.get( 'invite_artist_id' ) || 0 );
 		const submitButton = form.querySelector( 'input[type="submit"], button[type="submit"]' );
 		const restore = utils?.setSubmitting ? utils.setSubmitting( submitButton, 'Creating account…' ) : () => {};
 		const fromJoin = Boolean( config.fromJoin );
@@ -241,7 +241,6 @@ function RegisterPanel( { config, notice, setNotice } ) {
 			} );
 			restore();
 
-			const turnstileWidget = form.querySelector( '.cf-turnstile' );
 			if ( turnstileWidget && window.turnstile ) {
 				window.turnstile.reset( turnstileWidget );
 			}

--- a/blocks/onboarding/src/index.js
+++ b/blocks/onboarding/src/index.js
@@ -1,8 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps } from '@wordpress/block-editor';
 
 registerBlockType( 'extrachill/onboarding', {
-	edit: function() {
+	edit() {
 		const blockProps = useBlockProps();
 
 		return (

--- a/blocks/onboarding/src/index.js
+++ b/blocks/onboarding/src/index.js
@@ -4,18 +4,20 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps } from '@wordpress/block-editor';
 
-registerBlockType( 'extrachill/onboarding', {
-	edit() {
-		const blockProps = useBlockProps();
+function Edit() {
+	const blockProps = useBlockProps();
 
-		return (
-			<div { ...blockProps }>
-				<div className="onboarding-block-preview">
-					<h3>User Onboarding Form</h3>
-					<p>This block displays the onboarding form for new users.</p>
-					<p className="onboarding-block-note">Users will set their username and profile options here.</p>
-				</div>
+	return (
+		<div { ...blockProps }>
+			<div className="onboarding-block-preview">
+				<h3>User Onboarding Form</h3>
+				<p>This block displays the onboarding form for new users.</p>
+				<p className="onboarding-block-note">Users will set their username and profile options here.</p>
 			</div>
-		);
-	}
+		</div>
+	);
+}
+
+registerBlockType( 'extrachill/onboarding', {
+	edit: Edit,
 } );

--- a/blocks/onboarding/view.js
+++ b/blocks/onboarding/view.js
@@ -1,7 +1,7 @@
 (function () {
     'use strict';
 
-    var utils = window.ECAuthUtils;
+    const utils = window.ECAuthUtils;
 
     function init() {
         if (!utils) {
@@ -9,33 +9,33 @@
             return;
         }
 
-        var container = document.getElementById('extrachill-onboarding-form');
+        const container = document.getElementById('extrachill-onboarding-form');
         if (!container) {
             return;
         }
 
-        var form = document.getElementById('onboarding-form');
+        const form = document.getElementById('onboarding-form');
         if (!form) {
             return;
         }
 
-        var restUrl = container.dataset.restUrl || '';
-        var nonce = container.dataset.nonce || '';
-        var redirectUrl = container.dataset.redirectUrl || '/';
-        var fromJoin = container.dataset.fromJoin === 'true';
+        const restUrl = container.dataset.restUrl || '';
+        const nonce = container.dataset.nonce || '';
+        const redirectUrl = container.dataset.redirectUrl || '/';
+        const fromJoin = container.dataset.fromJoin === 'true';
 
-        var usernameInput = document.getElementById('onboarding-username');
-        var artistCheckbox = document.getElementById('user_is_artist');
-        var professionalCheckbox = document.getElementById('user_is_professional');
-        var submitButton = document.getElementById('onboarding-submit');
+        const usernameInput = document.getElementById('onboarding-username');
+        const artistCheckbox = document.getElementById('user_is_artist');
+        const professionalCheckbox = document.getElementById('user_is_professional');
+        const submitButton = document.getElementById('onboarding-submit');
 
         form.addEventListener('submit', function (event) {
             event.preventDefault();
             utils.clearNotice(container);
 
-            var username = usernameInput ? usernameInput.value.trim() : '';
-            var isArtist = artistCheckbox ? artistCheckbox.checked : false;
-            var isProfessional = professionalCheckbox ? professionalCheckbox.checked : false;
+            const username = usernameInput ? usernameInput.value.trim() : '';
+            const isArtist = artistCheckbox ? artistCheckbox.checked : false;
+            const isProfessional = professionalCheckbox ? professionalCheckbox.checked : false;
 
             if (!username) {
                 utils.renderNotice(container, 'error', 'Please enter a username.');
@@ -62,9 +62,9 @@
                 return;
             }
 
-            var restore = utils.setSubmitting(submitButton, 'Saving\u2026');
+            const restore = utils.setSubmitting(submitButton, 'Saving\u2026');
 
-            var url = restUrl + 'users/onboarding';
+            const url = restUrl + 'users/onboarding';
 
             fetch(url, {
                 method: 'POST',
@@ -74,7 +74,7 @@
                     'X-WP-Nonce': nonce
                 },
                 body: JSON.stringify({
-                    username: username,
+                    username,
                     user_is_artist: isArtist,
                     user_is_professional: isProfessional
                 })
@@ -82,18 +82,18 @@
                 .then(function (response) {
                     return response.json().then(function (data) {
                         if (!response.ok) {
-                            var message = data && data.message ? data.message : 'Something went wrong. Please try again.';
+                            const message = data && data.message ? data.message : 'Something went wrong. Please try again.';
                             throw new Error(message);
                         }
                         return data;
                     });
                 })
                 .then(function (data) {
-                    var finalRedirect = data && data.redirect_url ? data.redirect_url : redirectUrl;
+                    const finalRedirect = data && data.redirect_url ? data.redirect_url : redirectUrl;
                     window.location.assign(finalRedirect);
                 })
                 .catch(function (err) {
-                    var message = err && err.message ? err.message : 'Something went wrong. Please try again.';
+                    const message = err && err.message ? err.message : 'Something went wrong. Please try again.';
                     utils.renderNotice(container, 'error', message);
                     restore();
                 });

--- a/blocks/password-reset/src/index.js
+++ b/blocks/password-reset/src/index.js
@@ -4,16 +4,18 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps } from '@wordpress/block-editor';
 
-registerBlockType( 'extrachill/password-reset', {
-	edit: () => {
-		const blockProps = useBlockProps();
-		return (
-			<div { ...blockProps }>
-				<div style={{ padding: '20px', background: '#f0f0f0', border: '1px solid #ddd', borderRadius: '4px', textAlign: 'center' }}>
-					<p style={{ margin: '0', fontWeight: 'bold' }}>Password Reset Form</p>
-					<p style={{ margin: '10px 0 0', fontSize: '12px', color: '#666' }}>This block displays a password reset form on the frontend.</p>
-				</div>
+function Edit() {
+	const blockProps = useBlockProps();
+	return (
+		<div { ...blockProps }>
+			<div style={ { padding: '20px', background: '#f0f0f0', border: '1px solid #ddd', borderRadius: '4px', textAlign: 'center' } }>
+				<p style={ { margin: '0', fontWeight: 'bold' } }>Password Reset Form</p>
+				<p style={ { margin: '10px 0 0', fontSize: '12px', color: '#666' } }>This block displays a password reset form on the frontend.</p>
 			</div>
-		);
-	}
+		</div>
+	);
+}
+
+registerBlockType( 'extrachill/password-reset', {
+	edit: Edit,
 } );

--- a/blocks/password-reset/src/index.js
+++ b/blocks/password-reset/src/index.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps } from '@wordpress/block-editor';
 


### PR DESCRIPTION
Fixes #30.

`homeboy release extrachill-users` runs ESLint as part of its audit gate. Before this PR the gate reported **124 errors / 92 auto-fixable / 5 warnings across 11 of 12 JS files**, forcing every release to use `--skip-checks`. This PR drops it to **0 errors, 5 (intentional) warnings**, restoring the gate.

## Commits

1. `chore: add wp-scripts build artifacts to .eslintignore` — `blocks/login-register/index.js` and `blocks/password-reset/index.js` are wp-scripts compiled bundles checked into git. Linting them produces noise like `no-shadow` on mangled single-letter identifiers. Sources live in `blocks/*/src/`.
2. `style: run eslint --fix to clean up no-var, object-shorthand, and similar` — auto-fix sweep using the homeboy WordPress eslint config (extends `@wordpress/eslint-plugin/recommended`). Resolves 85 of 126 findings: 61 `no-var`, 15 `object-shorthand`, 9 `@wordpress/no-unused-vars-before-return`. No behavioral changes.
3. `fix: resolve remaining eslint errors for react hooks, globals, jsdoc, and a11y` — manual cleanup pass for the 36 surviving errors:
   - `Edit` capitalization in three block `src/index.js` files (`react-hooks/rules-of-hooks` requires PascalCase for components calling `useBlockProps`). `block.json` keeps `editorScript` pointing at the compiled bundle — no schema change.
   - Project `.eslintrc.json` declares `@wordpress/blocks`, `@wordpress/block-editor`, `@wordpress/components`, `@wordpress/element`, `@wordpress/i18n`, `@wordpress/data` as `import/core-modules` so `import/no-unresolved` stops flagging them (wp-scripts maps them to webpack externals at build time).
   - `/* global google */` in `google-signin.js` for the GIS library loaded externally; expanded the `@return` JSDoc with a description.
   - Targeted `no-bitwise` disables on the two RFC 4122 UUIDv4 spec lines in `auth-utils.js` (version + variant bits — bitwise required by spec).
   - Dropped the malformed JSDoc block in `concert-tracking.js` (untyped `@param` tags) in favor of a single-line comment.
   - `blocks/login-register/view.js`: reordered `LoginPanel` and `RegisterPanel` locals so values are not assigned before early-return checks; reused the outer `turnstileWidget` inside the catch block instead of redeclaring (`no-shadow`); associated the Remember-me label with its checkbox via `htmlFor` + matching `id`; replaced literal apostrophe in 'Don't have an account?' with `&apos;`.

## Verification

`homeboy lint extrachill-users` ESLint findings:

| Phase | Errors | Warnings |
|------:|-------:|---------:|
| Before | 124 | 5 |
| After | **0** | **5** |

The 5 remaining warnings are `no-console` on legitimate auth-failure logging in `google-signin.js` (lines 23, 28, 33, 199) and `blocks/onboarding/view.js:8`. Per the issue triage these are intentionally left as warnings — they fire on real auth errors and removing them would silently hide debugging signal.

`npm run build` still succeeds — no source changes broke the wp-scripts pipeline.

## Out of scope

PHPCS (103 findings) and PHPStan (80 findings) are being addressed by parallel minions on separate branches. This PR touches no PHP files.

cc <@532385681268408341>