### PR TITLE
feat: harden password reset with hooks, logging, and rate limiting

### DIFF
--- a/inc/auth/password-reset.php
+++ b/inc/auth/password-reset.php
@@ -23,6 +23,39 @@ function ec_custom_lostpassword_url( $lostpassword_url, $redirect ) {
 add_filter( 'lostpassword_url', 'ec_custom_lostpassword_url', 10, 2 );
 
 /**
+ * Get the transient key for password reset attempts.
+ *
+ * Keyed on requester IP only (not on submitted user_login) so attackers
+ * cannot bypass the limit by varying the input.
+ *
+ * @return string Transient key.
+ */
+function ec_get_password_reset_attempt_key() {
+	$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+	return 'ec_password_reset_attempts_' . md5( $ip );
+}
+
+/**
+ * Check if password reset requests are blocked due to too many attempts.
+ *
+ * @return bool True if blocked.
+ */
+function ec_is_password_reset_blocked() {
+	$attempts = get_transient( ec_get_password_reset_attempt_key() );
+	return $attempts && $attempts >= 5;
+}
+
+/**
+ * Record a password reset request attempt.
+ */
+function ec_record_password_reset_attempt() {
+	$key      = ec_get_password_reset_attempt_key();
+	$attempts = get_transient( $key );
+	$attempts = $attempts ? $attempts + 1 : 1;
+	set_transient( $key, $attempts, 15 * MINUTE_IN_SECONDS );
+}
+
+/**
  * Handle password reset request form submission.
  */
 function ec_handle_password_reset_request() {
@@ -30,11 +63,34 @@ function ec_handle_password_reset_request() {
 
 	$redirect->verify_nonce( 'ec_password_reset_nonce', 'ec_password_reset_request' );
 
+	if ( ec_is_password_reset_blocked() ) {
+		$redirect->error( __( 'Too many password reset requests. Please try again in 15 minutes.', 'extrachill-users' ) );
+	}
+
 	// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce verified above through EC_Redirect_Handler.
 	$user_login = isset( $_POST['user_login'] ) ? trim( sanitize_text_field( wp_unslash( $_POST['user_login'] ) ) ) : '';
 
 	if ( empty( $user_login ) ) {
 		$redirect->error( __( 'Please enter your email or username.', 'extrachill-users' ) );
+	}
+
+	ec_record_password_reset_attempt();
+
+	/**
+	 * Fires before password reset processing.
+	 *
+	 * Mirrors WordPress core's wp-login.php action so plugins (rate limiters,
+	 * audit loggers, captcha validators) listening for reset attempts see ours.
+	 *
+	 * Listeners can add errors to the WP_Error object to abort the flow.
+	 *
+	 * @param WP_Error $errors WP_Error object to collect validation errors.
+	 */
+	$errors = new WP_Error();
+	do_action( 'lostpassword_post', $errors );
+
+	if ( $errors->has_errors() ) {
+		$redirect->error( $errors->get_error_message() );
 	}
 
 	if ( strpos( $user_login, '@' ) !== false ) {
@@ -44,7 +100,41 @@ function ec_handle_password_reset_request() {
 	}
 
 	if ( ! $user ) {
+		/**
+		 * Fires when a password reset lookup fails.
+		 *
+		 * Mirrors WordPress core's retrieve_password_failure action so
+		 * silent failures (issue #27) are observable. Also writes to
+		 * error_log when WP_DEBUG_LOG is on so misses surface in debug.log.
+		 *
+		 * @param WP_Error $errors WP_Error containing the failure reason.
+		 */
+		$failure_errors = new WP_Error( 'invalid_email', __( 'There is no account with that username or email address.', 'extrachill-users' ) );
+		do_action( 'retrieve_password_failure', $failure_errors );
+
+		if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentional debug log; gated on WP_DEBUG_LOG.
+			error_log( sprintf( '[ec_password_reset] No user found for input (sanitized length=%d, contains_at=%s)', strlen( $user_login ), strpos( $user_login, '@' ) !== false ? 'yes' : 'no' ) );
+		}
+
+		// Enumeration protection: same generic success message regardless of whether a user was found.
 		$redirect->success( __( 'If an account exists with that email or username, you will receive a password reset link.', 'extrachill-users' ) );
+	}
+
+	/**
+	 * Fires before a password reset key is generated for a found user.
+	 *
+	 * Mirrors WordPress core's retrieve_password action. Listeners can
+	 * short-circuit by adding errors to the WP_Error object.
+	 *
+	 * @param WP_Error $errors    WP_Error object to collect validation errors.
+	 * @param WP_User  $user_data User object whose password is being reset.
+	 */
+	$user_errors = new WP_Error();
+	do_action( 'retrieve_password', $user_errors, $user );
+
+	if ( $user_errors->has_errors() ) {
+		$redirect->error( $user_errors->get_error_message() );
 	}
 
 	$reset_key = get_password_reset_key( $user );
@@ -134,8 +224,8 @@ function ec_send_password_reset_email( $user, $reset_key ) {
 		ec_get_site_url( 'community' ) . '/reset-password/'
 	);
 
-	$subject  = __( 'Password Reset Request - Extra Chill', 'extrachill-users' );
-	$message  = '<html><body>';
+	$subject = __( 'Password Reset Request - Extra Chill', 'extrachill-users' );
+	$message = '<html><body>';
 	/* translators: %s: user display name. */
 	$message .= '<p>' . sprintf( __( 'Hello <strong>%s</strong>,', 'extrachill-users' ), esc_html( $user->display_name ) ) . '</p>';
 	$message .= '<p>' . __( 'Someone requested a password reset for your Extra Chill account.', 'extrachill-users' ) . '</p>';
@@ -145,6 +235,34 @@ function ec_send_password_reset_email( $user, $reset_key ) {
 	$message .= '<p>' . __( 'If you didn\'t request this, you can safely ignore this email.', 'extrachill-users' ) . '</p>';
 	$message .= '<p>' . __( 'Much love,', 'extrachill-users' ) . '<br>' . __( 'Extra Chill', 'extrachill-users' ) . '</p>';
 	$message .= '</body></html>';
+
+	/**
+	 * Filters the password reset email subject.
+	 *
+	 * Mirrors WordPress core's retrieve_password_title filter so existing
+	 * integrations work. Note: core passes (string $title, string $user_login,
+	 * WP_User $user_data); we match that signature.
+	 *
+	 * @param string  $subject    Default email subject.
+	 * @param string  $user_login User login of the recipient.
+	 * @param WP_User $user       User object of the recipient.
+	 */
+	$subject = apply_filters( 'retrieve_password_title', $subject, $user->user_login, $user );
+
+	/**
+	 * Filters the password reset email message.
+	 *
+	 * Mirrors WordPress core's retrieve_password_message filter. Note: core
+	 * passes (string $message, string $key, string $user_login, WP_User $user_data);
+	 * we match that signature. Our message is HTML; filters that expect plain
+	 * text should check $headers and act accordingly.
+	 *
+	 * @param string  $message    Default email body (HTML).
+	 * @param string  $reset_key  Password reset key.
+	 * @param string  $user_login User login of the recipient.
+	 * @param WP_User $user       User object of the recipient.
+	 */
+	$message = apply_filters( 'retrieve_password_message', $message, $reset_key, $user->user_login, $user );
 
 	$headers = array(
 		'Content-Type: text/html; charset=UTF-8',


### PR DESCRIPTION
Follow-up to #28 / issue #27.

## Why not delegate to core `retrieve_password()`?

Looked into this. Core `retrieve_password()` would replace our:
- **Branded HTML email** (`ec_send_password_reset_email`) — core sends plain text
- **Custom reset URL** pointing to `/reset-password/` on community — core points at `wp-login.php?action=rp`
- **Cross-site flash-message redirects** via `EC_Redirect_Handler` — core has no concept of `source_url` across multisite subdomains

Those are intentional. The custom auth shell exists because we route users away from wp-admin and keep flash-message context across subsites. Delegating wholesale would be a UX regression.

**What we were actually missing from core:** dual lookup (fixed in #28), the hooks/filters that plugins listen for, observability, and rate limiting. This PR adds those three.

## What's in here

**Core hooks/filters wired in** so plugin integrations (audit, captcha, rate-limit-login, etc.) see our reset flow the same way they see `wp-login.php`'s:

- `lostpassword_post` — fires before lookup, listeners can short-circuit by adding errors to the WP_Error
- `retrieve_password` — fires after user is found, before key generation, listeners can short-circuit
- `retrieve_password_failure` — fires on lookup miss (still followed by enumeration-protection generic success to the user)
- `retrieve_password_title` — email subject filter, core signature `(string, string $user_login, WP_User)`
- `retrieve_password_message` — email body filter, core signature `(string, string $key, string $user_login, WP_User)`

**Logging on lookup miss.** Issue #27 explicitly called out silent failures being invisible in `debug.log`. Adds `error_log()` gated on `WP_DEBUG_LOG`, logging only sanitized metadata (input length + whether it contained `@`) — no PII, no submitted credentials.

**Rate limiting.** Mirrors `ec_rate_limit_login` in `inc/auth/login.php`. 5 reset requests per IP per 15-minute window via WP transients. **Keyed on requester IP only**, not on submitted `user_login`, so attackers cannot bypass the limit by varying the input.

## Preserved behavior

- Enumeration-protection generic success on lookup miss — unchanged
- Branded HTML email template — unchanged (now filterable)
- Cross-site `EC_Redirect_Handler` flash messages — unchanged
- Custom `/reset-password/` URL — unchanged
- Dual lookup (email/username) from #28 — unchanged

## Validation

- `php -l` clean
- Single file, +118 lines, no other changes
- No `CHANGELOG.md` edits, no version bump (homeboy owns both)

Fires the same hook names as core but does NOT call core's `retrieve_password()`. If anyone in the future wants to switch to core wholesale, see the analysis above for what would regress.