### PR TITLE
feat(login): wire Cloudflare Turnstile into login panel

### DIFF
--- a/blocks/login-register/view.js
+++ b/blocks/login-register/view.js
@@ -59,6 +59,12 @@ function LoggedInCard( { config } ) {
 }
 
 function LoginPanel( { config, notice, setNotice } ) {
+	const panelRef = useRef( null );
+
+	useEffect( () => {
+		renderTurnstile( panelRef.current );
+	} );
+
 	const handleSubmit = async ( event ) => {
 		event.preventDefault();
 		setNotice( null );
@@ -70,6 +76,13 @@ function LoginPanel( { config, notice, setNotice } ) {
 
 		if ( ! identifier || ! password ) {
 			setNotice( { type: 'error', message: 'Username and password are required.' } );
+			return;
+		}
+
+		const turnstileResponse = String( formData.get( 'cf-turnstile-response' ) || '' );
+		const turnstileWidget = form.querySelector( '.cf-turnstile' );
+		if ( turnstileWidget && ! turnstileResponse ) {
+			setNotice( { type: 'error', message: 'Captcha verification required. Please complete the challenge and try again.' } );
 			return;
 		}
 
@@ -94,6 +107,7 @@ function LoginPanel( { config, notice, setNotice } ) {
 				body: JSON.stringify( {
 					identifier,
 					password,
+					turnstile_response: turnstileResponse,
 					device_id: deviceId,
 					remember,
 					set_cookie: true,
@@ -122,12 +136,16 @@ function LoginPanel( { config, notice, setNotice } ) {
 				html: ` ${ message } <a href="${ config.resetPasswordUrl }">Forgot your password?</a>`,
 			} );
 			restore();
+
+			if ( turnstileWidget && window.turnstile ) {
+				window.turnstile.reset( turnstileWidget );
+			}
 		}
 	};
 
 	return (
 		<Panel>
-			<div className="login-register-form">
+			<div className="login-register-form" ref={ panelRef }>
 				{ notice && (
 					<div className={ `ec-auth-notice ec-auth-notice--${ notice.type }` }>
 						<p dangerouslySetInnerHTML={ notice.html ? { __html: notice.html } : undefined }>
@@ -148,6 +166,7 @@ function LoginPanel( { config, notice, setNotice } ) {
 						</label>
 					</div>
 					<input type="submit" className="button-2 button-medium" value="Log In" />
+					<div className="login-register-turnstile" dangerouslySetInnerHTML={ { __html: config.turnstileHtml } } />
 					<div className="login-forgot-password">
 						<a href={ config.resetPasswordUrl }>Forgot your password?</a>
 					</div>


### PR DESCRIPTION
## Summary

Render the Cloudflare Turnstile widget on the **login** form in the `login-register` block and pass `turnstile_response` in the POST body to `/auth/login`. This mirrors the existing registration panel pattern in the same block.

`render.php` already exposes `config.turnstileHtml` to both panels (line 114), so no PHP changes are required — this is purely the frontend wiring.

Closes #39

## Coordination — read before merging

> **This PR and [`Extra-Chill/extrachill-api#49`](https://github.com/Extra-Chill/extrachill-api/pull/49) MUST ship together.**
>
> - extrachill-api#49 adds the captcha requirement to `/auth/login` on the backend.
> - This PR adds the widget + `turnstile_response` to the frontend payload.
> - Deploying **either one without the other will break login network-wide** for browser clients:
>   - Backend-only: every web login fails with "Captcha verification required".
>   - Frontend-only: the widget renders but the backend ignores the token; not broken, but the captcha enforcement is silently bypassed.
> - App clients (sending `HTTP_EXTRACHILL_CLIENT: app`) are exempt on the backend and unaffected by either PR.

## Changes

Only `blocks/login-register/view.js` (`LoginPanel`):

- Add `panelRef` + `useEffect` calling the existing `renderTurnstile()` helper on mount.
- Read `cf-turnstile-response` from FormData and bail with an inline notice if the widget is present but the user didn't complete the challenge.
- Pass `turnstile_response` in the JSON body to `/extrachill/v1/auth/login`.
- Inject `config.turnstileHtml` into the form via `dangerouslySetInnerHTML`, placed inside the `<form>` just below the submit button.
- On error, call `window.turnstile.reset()` so the user can retry.

The diff is intentionally small and symmetric with `RegisterPanel`'s Turnstile wiring.

## Files NOT changed (intentional)

- `blocks/login-register/render.php` — `turnstileHtml` is already in the config payload; no PHP change needed.
- `inc/**` — backend captcha verification lives in extrachill-api#49.
- `build/**` — gitignored in this repo; homeboy rebuilds at release time.

## Acceptance criteria (from #39)

- [x] Turnstile widget renders on the login panel (mirrors registration panel rendering).
- [x] `turnstile_response` included in the `/auth/login` POST body.
- [x] Inline error notice when the widget is present but the user hasn't completed the challenge.
- [x] Widget is reset on error so the user can retry.
- [x] 2FA flow preserved — captcha runs in `permission_callback` before `extrachill_users_login_with_tokens()`, so `requires_2fa` redirect logic is untouched.
- [x] App clients (`HTTP_EXTRACHILL_CLIENT: app`) remain exempt — the login-register block never sets that header; native apps don't use this block.
- [ ] Frontend smoke test on a staging deploy (reviewer-time, post-merge once both PRs land).

## Verification performed

- `npm run build` succeeds; the rebuilt `build/login-register/view.js` contains `cf-turnstile-response` and `turnstile_response` twice (once for login, once for register).
- `php -l blocks/login-register/render.php` clean (no changes there).
- Visual diff against `RegisterPanel` confirms the wiring is symmetric.

<@532385681268408341> ready for review.