### PR TITLE
refactor: migrate user emails to datamachine/send-email (closes #40)

### DIFF
--- a/inc/auth/password-reset.php
+++ b/inc/auth/password-reset.php
@@ -225,16 +225,12 @@ function ec_send_password_reset_email( $user, $reset_key ) {
 	);
 
 	$subject = __( 'Password Reset Request - Extra Chill', 'extrachill-users' );
-	$message = '<html><body>';
-	/* translators: %s: user display name. */
-	$message .= '<p>' . sprintf( __( 'Hello <strong>%s</strong>,', 'extrachill-users' ), esc_html( $user->display_name ) ) . '</p>';
-	$message .= '<p>' . __( 'Someone requested a password reset for your Extra Chill account.', 'extrachill-users' ) . '</p>';
-	$message .= '<p>' . __( 'If this was you, click the link below to reset your password:', 'extrachill-users' ) . '</p>';
-	$message .= '<p><a href="' . esc_url( $reset_url ) . '">' . __( 'Reset Your Password', 'extrachill-users' ) . '</a></p>';
-	$message .= '<p>' . __( 'This link will expire in 24 hours.', 'extrachill-users' ) . '</p>';
-	$message .= '<p>' . __( 'If you didn\'t request this, you can safely ignore this email.', 'extrachill-users' ) . '</p>';
-	$message .= '<p>' . __( 'Much love,', 'extrachill-users' ) . '<br>' . __( 'Extra Chill', 'extrachill-users' ) . '</p>';
-	$message .= '</body></html>';
+
+	$body_html  = '<p>' . esc_html__( 'Someone requested a password reset for your Extra Chill account.', 'extrachill-users' ) . '</p>';
+	$body_html .= '<p>' . esc_html__( 'If this was you, click the button below to reset your password:', 'extrachill-users' ) . '</p>';
+	$body_html .= '<p>' . esc_html__( 'This link will expire in 24 hours.', 'extrachill-users' ) . '</p>';
+	$body_html .= '<p>' . esc_html__( 'If you didn\'t request this, you can safely ignore this email.', 'extrachill-users' ) . '</p>';
+	$body_html .= '<p>' . esc_html__( 'Much love,', 'extrachill-users' ) . '<br>' . esc_html__( 'Extra Chill', 'extrachill-users' ) . '</p>';
 
 	/**
 	 * Filters the password reset email subject.
@@ -250,24 +246,37 @@ function ec_send_password_reset_email( $user, $reset_key ) {
 	$subject = apply_filters( 'retrieve_password_title', $subject, $user->user_login, $user );
 
 	/**
-	 * Filters the password reset email message.
+	 * Filters the password reset email message body (HTML inner content).
 	 *
-	 * Mirrors WordPress core's retrieve_password_message filter. Note: core
-	 * passes (string $message, string $key, string $user_login, WP_User $user_data);
-	 * we match that signature. Our message is HTML; filters that expect plain
-	 * text should check $headers and act accordingly.
+	 * Mirrors WordPress core's retrieve_password_message filter signature.
+	 * Note: the body is the inner HTML content passed to the EC email
+	 * template — it does NOT include `<html>`/`<body>` wrappers. The
+	 * `extrachill/minimal` template owns greeting + CTA + footer.
 	 *
-	 * @param string  $message    Default email body (HTML).
+	 * @param string  $body_html  Default email body inner HTML.
 	 * @param string  $reset_key  Password reset key.
 	 * @param string  $user_login User login of the recipient.
 	 * @param WP_User $user       User object of the recipient.
 	 */
-	$message = apply_filters( 'retrieve_password_message', $message, $reset_key, $user->user_login, $user );
+	$body_html = apply_filters( 'retrieve_password_message', $body_html, $reset_key, $user->user_login, $user );
 
-	$headers = array(
-		'Content-Type: text/html; charset=UTF-8',
-		'From: Extra Chill <' . get_option( 'admin_email' ) . '>',
+	$result = ec_send_email(
+		array(
+			'to'         => $user->user_email,
+			'subject'    => $subject,
+			'template'   => 'extrachill/minimal',
+			'from_name'  => 'Extra Chill',
+			'from_email' => get_option( 'admin_email' ),
+			'context'    => array(
+				'subject_html'   => esc_html( $subject ),
+				'body_html'      => $body_html,
+				'recipient_name' => $user->display_name,
+				'cta_url'        => $reset_url,
+				'cta_label'      => __( 'Reset Your Password', 'extrachill-users' ),
+				'preheader'      => __( 'Reset your Extra Chill password — link expires in 24 hours.', 'extrachill-users' ),
+			),
+		)
 	);
 
-	return wp_mail( $user->user_email, $subject, $message, $headers );
+	return ! empty( $result['success'] );
 }

--- a/inc/core/abilities/artist-access.php
+++ b/inc/core/abilities/artist-access.php
@@ -132,7 +132,7 @@ function extrachill_users_register_artist_access_abilities() {
  * @param array $input Unused.
  * @return array Array with 'requests' key containing pending request data.
  */
-function extrachill_users_ability_list_artist_access_requests( $input ) {
+function extrachill_users_ability_list_artist_access_requests() {
 	$user_query = new WP_User_Query(
 		array(
 			'blog_id'  => 0,
@@ -351,7 +351,7 @@ function extrachill_users_send_artist_access_request_email( $user_id, $user, $ac
 		$user->display_name
 	);
 
-	$body_html  = '<p>' . sprintf(
+	$body_html = '<p>' . sprintf(
 		/* translators: 1: user display name, 2: user email, 3: request type label */
 		esc_html__( '%1$s (%2$s) has requested artist platform access.', 'extrachill-users' ),
 		esc_html( $user->display_name ),
@@ -395,7 +395,7 @@ function extrachill_users_send_artist_access_approval_email( $user, $type ) {
 
 	$subject = 'Your Extra Chill Artist Platform Access Has Been Approved';
 
-	$body_html  = '<p>' . sprintf(
+	$body_html = '<p>' . sprintf(
 		/* translators: %s: access type label */
 		esc_html__( 'Your request for %s access on Extra Chill has been approved!', 'extrachill-users' ),
 		esc_html( $type_label )

--- a/inc/core/abilities/artist-access.php
+++ b/inc/core/abilities/artist-access.php
@@ -351,20 +351,36 @@ function extrachill_users_send_artist_access_request_email( $user_id, $user, $ac
 		$user->display_name
 	);
 
-	$message = sprintf(
-		"%s (%s) has requested artist platform access.\n\nRequest type: %s\n\n",
-		$user->display_name,
-		$user->user_email,
-		$type_label
-	);
+	$body_html  = '<p>' . sprintf(
+		/* translators: 1: user display name, 2: user email, 3: request type label */
+		esc_html__( '%1$s (%2$s) has requested artist platform access.', 'extrachill-users' ),
+		esc_html( $user->display_name ),
+		esc_html( $user->user_email )
+	) . '</p>';
+	$body_html .= '<p><strong>' . esc_html__( 'Request type:', 'extrachill-users' ) . '</strong> ' . esc_html( $type_label ) . '</p>';
 
 	if ( $approve_url ) {
-		$message .= sprintf( "Approve this request:\n%s\n\n", $approve_url );
+		$body_html .= '<p><a href="' . esc_url( $approve_url ) . '">' . esc_html__( 'Approve this request', 'extrachill-users' ) . '</a></p>';
 	}
 
-	$message .= sprintf( "Manage all requests:\n%s", $admin_tools_url );
+	$body_html .= '<p><a href="' . esc_url( $admin_tools_url ) . '">' . esc_html__( 'Manage all requests', 'extrachill-users' ) . '</a></p>';
 
-	wp_mail( $admin_email, $subject, $message );
+	ec_send_email(
+		array(
+			'to'       => $admin_email,
+			'subject'  => $subject,
+			'template' => 'extrachill/minimal',
+			'context'  => array(
+				'subject_html' => esc_html( $subject ),
+				'body_html'    => $body_html,
+				'preheader'    => sprintf(
+					/* translators: %s: user display name */
+					__( 'Artist access request from %s', 'extrachill-users' ),
+					$user->display_name
+				),
+			),
+		)
+	);
 }
 
 /**
@@ -377,17 +393,31 @@ function extrachill_users_send_artist_access_approval_email( $user, $type ) {
 	$create_url = 'https://artist.extrachill.com/create-artist/';
 	$type_label = 'artist' === $type ? 'artist' : 'music industry professional';
 
-	$subject  = 'Your Extra Chill Artist Platform Access Has Been Approved';
-	$message  = "Hey {$user->display_name},\n\n";
-	$message .= "Your request for {$type_label} access on Extra Chill has been approved!\n\n";
-	$message .= "You can now create your artist profile and link page:\n";
-	$message .= "{$create_url}\n\n";
-	$message .= "Your link page will be available at extrachill.link/your-artist-name once you set it up.\n\n";
-	$message .= "Welcome to the platform.\n\n";
-	$message .= "— Extra Chill\n";
-	$message .= 'https://extrachill.com';
+	$subject = 'Your Extra Chill Artist Platform Access Has Been Approved';
 
-	$headers = array( 'Content-Type: text/plain; charset=UTF-8' );
+	$body_html  = '<p>' . sprintf(
+		/* translators: %s: access type label */
+		esc_html__( 'Your request for %s access on Extra Chill has been approved!', 'extrachill-users' ),
+		esc_html( $type_label )
+	) . '</p>';
+	$body_html .= '<p>' . esc_html__( 'You can now create your artist profile and link page.', 'extrachill-users' ) . '</p>';
+	$body_html .= '<p>' . esc_html__( 'Your link page will be available at extrachill.link/your-artist-name once you set it up.', 'extrachill-users' ) . '</p>';
+	$body_html .= '<p>' . esc_html__( 'Welcome to the platform.', 'extrachill-users' ) . '</p>';
+	$body_html .= '<p>— Extra Chill</p>';
 
-	wp_mail( $user->user_email, $subject, $message, $headers );
+	ec_send_email(
+		array(
+			'to'       => $user->user_email,
+			'subject'  => $subject,
+			'template' => 'extrachill/branded',
+			'context'  => array(
+				'subject_html'   => esc_html( $subject ),
+				'body_html'      => $body_html,
+				'recipient_name' => $user->display_name,
+				'cta_url'        => $create_url,
+				'cta_label'      => __( 'Create Your Artist Profile', 'extrachill-users' ),
+				'preheader'      => __( 'Your artist platform access is approved.', 'extrachill-users' ),
+			),
+		)
+	);
 }

--- a/inc/core/abilities/user-settings.php
+++ b/inc/core/abilities/user-settings.php
@@ -303,41 +303,40 @@ function extrachill_users_ability_change_email( $input ) {
 		)
 	);
 
-	// Send confirmation email.
-	/* translators: Do not translate USERNAME, ADMIN_URL, EMAIL, SITENAME, SITEURL: those are placeholders. */
-	$email_text = __(
-		'Howdy ###USERNAME###,
-
-Someone requested a change to the email address on your account.
-
-Please click the following link to confirm this change:
-###ADMIN_URL###
-
-If you did not request this, you can safely ignore and delete this email.
-
-This email was sent to ###EMAIL###
-
-Regards,
-###SITENAME###
-###SITEURL###',
-		'extrachill-users'
+	$subject = sprintf(
+		/* translators: %s: site name */
+		__( '[%s] Email Change Request', 'extrachill-users' ),
+		wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES )
 	);
 
-	$email_text = str_replace( '###USERNAME###', $user->user_login, $email_text );
-	$email_text = str_replace( '###ADMIN_URL###', $confirm_url, $email_text );
-	$email_text = str_replace( '###EMAIL###', $new_email, $email_text );
-	$email_text = str_replace( '###SITENAME###', wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ), $email_text );
-	$email_text = str_replace( '###SITEURL###', home_url(), $email_text );
+	// Build HTML body from the plain-text template. The template owns greeting + signature,
+	// so we strip those lines and convert the action paragraph to a CTA.
+	$body_html  = '<p>' . esc_html__( 'Someone requested a change to the email address on your account.', 'extrachill-users' ) . '</p>';
+	$body_html .= '<p>' . esc_html__( 'Please click the button below to confirm this change:', 'extrachill-users' ) . '</p>';
+	$body_html .= '<p>' . sprintf(
+		/* translators: %s: email address */
+		esc_html__( 'This email was sent to %s.', 'extrachill-users' ),
+		'<strong>' . esc_html( $new_email ) . '</strong>'
+	) . '</p>';
+	$body_html .= '<p>' . esc_html__( 'If you did not request this, you can safely ignore and delete this email.', 'extrachill-users' ) . '</p>';
 
-	$sent = wp_mail(
-		$new_email,
-		sprintf(
-			/* translators: %s: site name */
-			__( '[%s] Email Change Request', 'extrachill-users' ),
-			wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES )
-		),
-		$email_text
+	$result = ec_send_email(
+		array(
+			'to'       => $new_email,
+			'subject'  => $subject,
+			'template' => 'extrachill/minimal',
+			'context'  => array(
+				'subject_html'   => esc_html( $subject ),
+				'body_html'      => $body_html,
+				'recipient_name' => $user->user_login,
+				'cta_url'        => $confirm_url,
+				'cta_label'      => __( 'Confirm Email Change', 'extrachill-users' ),
+				'preheader'      => __( 'Confirm your new email address on Extra Chill.', 'extrachill-users' ),
+			),
+		)
 	);
+
+	$sent = ! empty( $result['success'] );
 
 	if ( ! $sent ) {
 		delete_user_meta( $user_id, '_new_email' );

--- a/inc/core/moderation/email.php
+++ b/inc/core/moderation/email.php
@@ -23,10 +23,24 @@ function extrachill_users_send_moderation_email( WP_User $user, array $status ) 
 		$message = __( 'Your account has been banned. Please contact support if you believe this is a mistake.', 'extrachill-users' );
 	}
 
+	$body_html = '<p>' . esc_html( $message ) . '</p>';
+
 	if ( $reason ) {
-		/* translators: %s: moderation reason text. */
-		$message .= "\n\n" . sprintf( __( 'Reason: %s', 'extrachill-users' ), $reason );
+		$body_html .= '<p><strong>' . esc_html__( 'Reason:', 'extrachill-users' ) . '</strong> ' . esc_html( $reason ) . '</p>';
 	}
 
-	return wp_mail( $user->user_email, $subject, $message );
+	$result = ec_send_email(
+		array(
+			'to'       => $user->user_email,
+			'subject'  => $subject,
+			'template' => 'extrachill/minimal',
+			'context'  => array(
+				'subject_html'   => esc_html( $subject ),
+				'body_html'      => $body_html,
+				'recipient_name' => $user->display_name,
+			),
+		)
+	);
+
+	return ! empty( $result['success'] );
 }

--- a/inc/core/registration-emails.php
+++ b/inc/core/registration-emails.php
@@ -22,8 +22,8 @@ function extrachill_notify_admin_new_user( $user_id, $registration_page, $regist
 	if ( ! $user_data instanceof WP_User ) {
 		return;
 	}
-	$username  = $user_data->user_login;
-	$email     = $user_data->user_email;
+	$username = $user_data->user_login;
+	$email    = $user_data->user_email;
 
 	$admin_email = get_option( 'admin_email' );
 	$subject     = 'New User Registration Notification';

--- a/inc/core/registration-emails.php
+++ b/inc/core/registration-emails.php
@@ -28,19 +28,32 @@ function extrachill_notify_admin_new_user( $user_id, $registration_page, $regist
 	$admin_email = get_option( 'admin_email' );
 	$subject     = 'New User Registration Notification';
 
-	$message      = "A new user has registered on the Extra Chill platform.\n\n";
-	$message     .= 'Username: ' . $username . " (auto-generated)\n";
-	$message     .= 'Email: ' . $email . "\n";
-	$message     .= 'User ID: ' . $user_id . "\n";
 	$source_label = $registration_source ? sanitize_text_field( (string) $registration_source ) : 'Unknown';
 	$method_label = $registration_method ? sanitize_text_field( (string) $registration_method ) : 'Unknown';
+	$page_display = $registration_page ? esc_url( $registration_page ) : 'Unknown';
+	$edit_url     = admin_url( "user-edit.php?user_id={$user_id}" );
 
-	$message .= "Registration Source: {$source_label} ({$method_label})\n";
-	$message .= 'Registration Page: ' . ( $registration_page ? esc_url( $registration_page ) : 'Unknown' ) . "\n";
-	$message .= "\nAdmin Edit: " . admin_url( "user-edit.php?user_id={$user_id}" );
-	$message .= "\nNote: User has not yet completed onboarding — profile URL not available until username is chosen.";
+	$body_html  = '<p>A new user has registered on the Extra Chill platform.</p>';
+	$body_html .= '<p><strong>Username:</strong> ' . esc_html( $username ) . ' (auto-generated)<br>';
+	$body_html .= '<strong>Email:</strong> ' . esc_html( $email ) . '<br>';
+	$body_html .= '<strong>User ID:</strong> ' . (int) $user_id . '<br>';
+	$body_html .= '<strong>Registration Source:</strong> ' . esc_html( $source_label ) . ' (' . esc_html( $method_label ) . ')<br>';
+	$body_html .= '<strong>Registration Page:</strong> ' . esc_html( $page_display ) . '</p>';
+	$body_html .= '<p><a href="' . esc_url( $edit_url ) . '">Edit user in admin</a></p>';
+	$body_html .= '<p><em>Note: User has not yet completed onboarding — profile URL not available until username is chosen.</em></p>';
 
-	wp_mail( $admin_email, $subject, $message );
+	ec_send_email(
+		array(
+			'to'       => $admin_email,
+			'subject'  => $subject,
+			'template' => 'extrachill/minimal',
+			'context'  => array(
+				'subject_html' => esc_html( $subject ),
+				'body_html'    => $body_html,
+				'preheader'    => 'New user registered: ' . $username,
+			),
+		)
+	);
 }
 
 add_action( 'extrachill_new_user_registered', 'extrachill_notify_admin_new_user', 10, 4 );
@@ -57,38 +70,35 @@ function extrachill_send_welcome_email_complete( $user_data ) {
 	$username        = $user_data->user_login;
 	$email           = $user_data->user_email;
 	$reset_pass_link = ec_get_site_url( 'community' ) . '/reset-password/';
+	$community_url   = ec_get_site_url( 'community' );
 
-	$subject       = 'Welcome to the Extra Chill Community!';
-	$message       = '<html><body>';
-	$message      .= '<p>Hello <strong>' . esc_html( $username ) . '</strong>,</p>';
-	$message      .= "<p>Welcome to <strong>Extra Chill</strong>! Now that you're here, this place is a lot more chill!</p>";
-	$message      .= '<p>With your account, you can now participate in community discussions, comment on posts, and follow your favorite artists.</p>';
-	$message      .= "<p>Get started by <a href='" . esc_url( ec_get_site_url( 'community' ) . '/t/introductions-thread' ) . "'>introducing yourself in The Back Bar</a>!</p>";
-	$message      .= '<p><strong>Account Details:</strong><br>';
-	$message      .= 'Username: <strong>' . esc_html( $username ) . '</strong><br>';
-	$message      .= "If you forget your password, you can reset it <a href='" . esc_url( $reset_pass_link ) . "'>here</a>.</p>";
-	$main_site_url = ec_get_site_url( 'main' );
-	$community_url = ec_get_site_url( 'community' );
-	$message      .= '<p><strong>Explore the Platform:</strong><br>';
-	$message      .= "<a href='" . esc_url( $main_site_url . '/blog' ) . "'>Blog</a><br>";
-	$message      .= "<a href='" . esc_url( $community_url ) . "'>Community</a><br>";
-	$message      .= "<a href='" . esc_url( ec_get_site_url( 'events' ) ) . "'>Events Calendar</a><br>";
-	$message      .= "<a href='" . esc_url( ec_get_site_url( 'artist' ) ) . "'>Artist Platform</a><br>";
-	$message      .= "<a href='" . esc_url( ec_get_site_url( 'newsletter' ) ) . "'>Newsletter</a><br>";
-	$message      .= "<a href='" . esc_url( ec_get_site_url( 'shop' ) ) . "'>Shop</a><br>";
-	$message      .= "<a href='" . esc_url( ec_get_site_url( 'docs' ) ) . "'>Documentation</a></p>";
-	$message      .= '<p><strong>Need Help?</strong><br>';
-	$message      .= "<a href='" . esc_url( $main_site_url . '/contact/' ) . "'>Contact Us</a><br>";
-	$message      .= "<a href='" . esc_url( $community_url . '/r/tech-support' ) . "'>Tech Support</a></p>";
-	$message      .= '<p>See you around!</p>';
-	$message      .= '<p>Much love,<br>';
-	$message      .= 'Extra Chill</p>';
-	$message      .= '</body></html>';
+	$subject = 'Welcome to the Extra Chill Community!';
 
-	$from_email = get_option( 'admin_email' );
-	$headers    = array( 'Content-Type: text/html; charset=UTF-8', 'From: Extra Chill <' . $from_email . '>' );
+	$body_html  = "<p>Welcome to <strong>Extra Chill</strong>! Now that you're here, this place is a lot more chill!</p>";
+	$body_html .= '<p>With your account, you can now participate in community discussions, comment on posts, and follow your favorite artists.</p>';
+	$body_html .= '<p><strong>Account Details:</strong><br>';
+	$body_html .= 'Username: <strong>' . esc_html( $username ) . '</strong><br>';
+	$body_html .= 'If you forget your password, you can reset it <a href="' . esc_url( $reset_pass_link ) . '">here</a>.</p>';
+	$body_html .= '<p>See you around!</p>';
+	$body_html .= '<p>Much love,<br>Extra Chill</p>';
 
-	return wp_mail( $email, $subject, $message, $headers );
+	$result = ec_send_email(
+		array(
+			'to'       => $email,
+			'subject'  => $subject,
+			'template' => 'extrachill/branded',
+			'context'  => array(
+				'subject_html'   => esc_html( $subject ),
+				'body_html'      => $body_html,
+				'recipient_name' => $username,
+				'cta_url'        => $community_url . '/t/introductions-thread',
+				'cta_label'      => 'Introduce Yourself',
+				'preheader'      => 'Welcome to Extra Chill — your account is ready.',
+			),
+		)
+	);
+
+	return ! empty( $result['success'] );
 }
 
 /**
@@ -104,35 +114,31 @@ function extrachill_send_welcome_email_incomplete( $user_data ) {
 	$reset_pass_link = ec_get_site_url( 'community' ) . '/reset-password/';
 	$onboarding_url  = ec_get_site_url( 'community' ) . '/onboarding/';
 
-	$subject       = 'Complete Your Extra Chill Account Setup!';
-	$message       = '<html><body>';
-	$message      .= '<p>Hello!</p>';
-	$message      .= "<p>Welcome to <strong>Extra Chill</strong>! You're almost ready to join the community.</p>";
-	$message      .= "<p><strong><a href='" . esc_url( $onboarding_url ) . "'>Complete your account setup</a></strong> to choose your username and get started.</p>";
-	$message      .= '<p>Once set up, you can participate in community discussions, comment on posts, and follow your favorite artists.</p>';
-	$message      .= '<p><strong>Account Details:</strong><br>';
-	$message      .= 'Email: <strong>' . esc_html( $email ) . '</strong><br>';
-	$message      .= "If you forget your password, you can reset it <a href='" . esc_url( $reset_pass_link ) . "'>here</a>.</p>";
-	$main_site_url = ec_get_site_url( 'main' );
-	$community_url = ec_get_site_url( 'community' );
-	$message      .= '<p><strong>Explore the Platform:</strong><br>';
-	$message      .= "<a href='" . esc_url( $main_site_url . '/blog' ) . "'>Blog</a><br>";
-	$message      .= "<a href='" . esc_url( $community_url ) . "'>Community</a><br>";
-	$message      .= "<a href='" . esc_url( ec_get_site_url( 'events' ) ) . "'>Events Calendar</a><br>";
-	$message      .= "<a href='" . esc_url( ec_get_site_url( 'artist' ) ) . "'>Artist Platform</a><br>";
-	$message      .= "<a href='" . esc_url( ec_get_site_url( 'newsletter' ) ) . "'>Newsletter</a><br>";
-	$message      .= "<a href='" . esc_url( ec_get_site_url( 'shop' ) ) . "'>Shop</a><br>";
-	$message      .= "<a href='" . esc_url( ec_get_site_url( 'docs' ) ) . "'>Documentation</a></p>";
-	$message      .= '<p><strong>Need Help?</strong><br>';
-	$message      .= "<a href='" . esc_url( $main_site_url . '/contact/' ) . "'>Contact Us</a><br>";
-	$message      .= "<a href='" . esc_url( $community_url . '/r/tech-support' ) . "'>Tech Support</a></p>";
-	$message      .= '<p>See you around!</p>';
-	$message      .= '<p>Much love,<br>';
-	$message      .= 'Extra Chill</p>';
-	$message      .= '</body></html>';
+	$subject = 'Complete Your Extra Chill Account Setup!';
 
-	$from_email = get_option( 'admin_email' );
-	$headers    = array( 'Content-Type: text/html; charset=UTF-8', 'From: Extra Chill <' . $from_email . '>' );
+	$body_html  = "<p>Welcome to <strong>Extra Chill</strong>! You're almost ready to join the community.</p>";
+	$body_html .= '<p><strong><a href="' . esc_url( $onboarding_url ) . '">Complete your account setup</a></strong> to choose your username and get started.</p>';
+	$body_html .= '<p>Once set up, you can participate in community discussions, comment on posts, and follow your favorite artists.</p>';
+	$body_html .= '<p><strong>Account Details:</strong><br>';
+	$body_html .= 'Email: <strong>' . esc_html( $email ) . '</strong><br>';
+	$body_html .= 'If you forget your password, you can reset it <a href="' . esc_url( $reset_pass_link ) . '">here</a>.</p>';
+	$body_html .= '<p>See you around!</p>';
+	$body_html .= '<p>Much love,<br>Extra Chill</p>';
 
-	return wp_mail( $email, $subject, $message, $headers );
+	$result = ec_send_email(
+		array(
+			'to'       => $email,
+			'subject'  => $subject,
+			'template' => 'extrachill/branded',
+			'context'  => array(
+				'subject_html' => esc_html( $subject ),
+				'body_html'    => $body_html,
+				'cta_url'      => $onboarding_url,
+				'cta_label'    => 'Complete Your Account Setup',
+				'preheader'    => 'Finish setting up your Extra Chill account.',
+			),
+		)
+	);
+
+	return ! empty( $result['success'] );
 }


### PR DESCRIPTION
Closes #40

**Depends on** Extra-Chill/data-machine#2067 (adds `template`, `context`, `mail_site_id` + `datamachine/send-email-queued`) **+** Extra-Chill/extrachill-multisite#27 (exposes `ec_send_email()` wrapper + registers `extrachill/branded` and `extrachill/minimal` templates). **Opened as DRAFT** until those foundation PRs merge.

## Summary

Migrates every `wp_mail()` call site in `extrachill-users` onto `ec_send_email()`. Inline `<html><body>` markup and `Content-Type: text/html` headers are removed — the EC email templates own document chrome, greeting, and footer. Recipient personalization moves into the template's `recipient_name` slot; primary actions become CTA buttons via `cta_url`/`cta_label`.

## Per-call-site migration

| File | Function | Old | New (template) | Rationale |
|---|---|---|---|---|
| `inc/core/registration-emails.php` | `extrachill_notify_admin_new_user` | `wp_mail()` plain text to admin | `ec_send_email` -> `extrachill/minimal` | Admin alert sent to `admin_email`, not a platform user |
| `inc/core/registration-emails.php` | `extrachill_send_welcome_email_complete` | `wp_mail()` inline HTML with platform link grid | `ec_send_email` -> `extrachill/branded` | Marketing-feeling onboarding email; template owns link grid + CTA to introductions thread |
| `inc/core/registration-emails.php` | `extrachill_send_welcome_email_incomplete` | `wp_mail()` inline HTML with platform link grid | `ec_send_email` -> `extrachill/branded` | Multi-section onboarding email with primary CTA to onboarding flow |
| `inc/core/moderation/email.php` | `extrachill_users_send_moderation_email` | `wp_mail()` plain text | `ec_send_email` -> `extrachill/minimal` | Transactional single-purpose notification (ban/suspend) |
| `inc/auth/password-reset.php` | `ec_send_password_reset_email` | `wp_mail()` inline HTML + `Content-Type` header | `ec_send_email` -> `extrachill/minimal` | Transactional reset; reset URL surfaces as CTA button. `from_name`/`from_email` passed through ability |
| `inc/core/abilities/artist-access.php` | `extrachill_users_send_artist_access_request_email` | `wp_mail()` plain text to admin | `ec_send_email` -> `extrachill/minimal` | Admin alert sent to `admin_email` |
| `inc/core/abilities/artist-access.php` | `extrachill_users_send_artist_access_approval_email` | `wp_mail()` plain text | `ec_send_email` -> `extrachill/branded` | Marketing-feeling account-approval email; CTA to artist creation flow |
| `inc/core/abilities/user-settings.php` | `extrachill_users_ability_change_email` | `wp_mail()` plain text with `###PLACEHOLDER###` | `ec_send_email` -> `extrachill/minimal` | Transactional email-change verification; confirmation URL as CTA |

## Acceptance checks

- `grep -rn \"wp_mail\" inc/` -> 0 matches
- `grep -rn \"Content-Type: text/html\" inc/` -> 0 matches
- `grep -rn \"<html>\" inc/` -> 1 match, inside a docblock in `password-reset.php` explaining that the filter callback now receives inner HTML rather than a full document
- `php -l` clean on every modified file

## Behavioral notes

- **Filter signature preserved.** `retrieve_password_title` keeps its original signature. `retrieve_password_message` keeps its `(message, key, user_login, user)` signature, but the filtered value is now the inner HTML body passed to the template (no `<html>`/`<body>` wrappers). Docblock updated accordingly.
- **Success detection** for callers that depended on `wp_mail()`'s boolean now reads `! empty( $result['success'] )` from the ability response. This preserves the `$sent` flag used by `ec_handle_password_reset_request` and `extrachill_users_ability_change_email` for the \"failed to send\" error branch.
- **`mail_site_id`** is auto-resolved by `ec_send_email()` via `ec_mail_site_id()`, so subsite contexts that lack SMTP credentials transparently route through the main site.
- **`recipient_name`** is populated wherever a `WP_User` is in scope (`display_name`, falling back to `user_login` for the email-change flow where `display_name` may not yet reflect the new identity).

## Smoke-test checklist (post-merge)

Manual flows to verify on staging once the foundation PRs land:

- [ ] Register a new user via `/login` -> admin receives \"New User Registration Notification\" (minimal template); user receives the appropriate welcome email (branded template, complete or incomplete variant depending on onboarding state)
- [ ] Trigger \"Lost password?\" from `/reset-password/` -> email arrives via minimal template with working CTA button; reset link completes successfully
- [ ] As an admin, ban or suspend a user (with a reason set) -> banned user receives a minimal-template email containing the reason
- [ ] Submit an artist-access request from the user dashboard -> admin receives a minimal-template email with working \"Approve this request\" link; on approval, user receives a branded-template email with working \"Create Your Artist Profile\" CTA
- [ ] Change account email from user settings -> verification email arrives at the new address (minimal template); clicking the confirm CTA completes the change

## Out of scope

- No CHANGELOG edit (homeboy-owned)
- No version bumps (homeboy-owned)
- Queue migration via `ec_send_email_queued()` left for a follow-up — current call sites are user-triggered and don't benefit from async dispatch