### PR TITLE
fix: sync block.json versions on release so style/script changes bust caches

### DIFF
--- a/blocks/login-register/block.json
+++ b/blocks/login-register/block.json
@@ -17,7 +17,7 @@
 		"multiple": true
 	},
 	"textdomain": "extrachill-users",
-	"version": "0.5.9",
+	"version": "0.10.1",
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
 	"render": "file:./render.php",

--- a/blocks/onboarding/block.json
+++ b/blocks/onboarding/block.json
@@ -17,7 +17,7 @@
 		"multiple": false
 	},
 	"textdomain": "extrachill-users",
-	"version": "0.5.9",
+	"version": "0.10.1",
 	"render": "file:./render.php",
 	"style": "file:./style.css",
 	"viewScript": "file:./view.js"

--- a/blocks/password-reset/block.json
+++ b/blocks/password-reset/block.json
@@ -7,7 +7,7 @@
 	"icon": "lock",
 	"description": "Custom password reset form for users who forgot their password",
 	"textdomain": "extrachill-users",
-	"version": "0.5.9",
+	"version": "0.10.1",
 	"editorScript": "file:./index.js",
 	"render": "file:./render.php",
 	"style": "file:./style.css"

--- a/homeboy.json
+++ b/homeboy.json
@@ -14,6 +14,18 @@
     {
       "file": "extrachill-users.php",
       "pattern": "EXTRACHILL_USERS_VERSION',\\s*'([0-9.]+)'"
+    },
+    {
+      "file": "blocks/login-register/block.json",
+      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+    },
+    {
+      "file": "blocks/onboarding/block.json",
+      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+    },
+    {
+      "file": "blocks/password-reset/block.json",
+      "pattern": "\"version\":\\s*\"([0-9.]+)\""
     }
   ]
 }


### PR DESCRIPTION
## Summary

WordPress uses each `block.json` `version` field as the cache-bust query string (`?ver=X.Y.Z`) on every style/script handle a block registers. When the plugin version moves forward but `block.json` files stay pinned, browsers keep serving stale CSS/JS for those blocks until the version string changes.

The auth flow blocks in this plugin have been frozen at `0.5.9` for the entire `0.6 → 0.10` series — **five minor versions** of UI work served as `?ver=0.5.9` to repeat visitors.

## Drift table

| File | Before | After | Plugin |
|---|---|---|---|
| `blocks/login-register/block.json` | `0.5.9` | `0.10.1` | `0.10.1` |
| `blocks/onboarding/block.json` | `0.5.9` | `0.10.1` | `0.10.1` |
| `blocks/password-reset/block.json` | `0.5.9` | `0.10.1` | `0.10.1` |

## Why this matters more here

These are not internal admin blocks — they are the **user-facing critical paths**:

- **login-register** — every returning visitor who logs in
- **onboarding** — every new signup
- **password-reset** — recovery flow

Any style/script changes shipped during the `0.6 → 0.10` window have effectively been invisible to anyone whose browser had the `0.5.9` assets cached. Even a hard refresh on a single page wouldn't fix it for the user across the whole flow — WordPress emits the same `?ver=0.5.9` everywhere the block is registered.

## What changed

**1. Sync versions (3 files, 1 line each)** — bump the three drifted `block.json` files to the current plugin version (`0.10.1`) so the cache bust takes effect on next deploy.

**2. Add to homeboy version_targets (`homeboy.json`)** — register the three `block.json` files so future `homeboy release` runs bump them in lockstep with the plugin header and the `EXTRACHILL_USERS_VERSION` constant. No more drift.

```json
{
  "file": "blocks/login-register/block.json",
  "pattern": "\"version\":\\s*\"([0-9.]+)\""
}
```

(plus matching entries for `onboarding` and `password-reset`)

## Acceptance criteria

- [x] All three `block.json` files report `0.10.1`
- [x] `homeboy.json` still parses as valid JSON
- [x] Three new entries appended to `version_targets` matching existing style
- [x] `git diff --stat` shows only the expected small surface (3 × 1 line + ~12 lines `homeboy.json`)
- [x] No reformat of unrelated JSON, indentation preserved (tab-indented `block.json` stays tab-indented)
- [x] No changes to plugin header version, `CHANGELOG.md`, or `EXTRACHILL_USERS_VERSION` — homeboy owns those
- [ ] On next `homeboy release`, all five version targets (header, constant, 3× block.json) advance together

## Playbook

Same pattern as Extra-Chill/data-machine-events#279.

cc <@532385681268408341>