### PR TITLE
fix: route wp-core password reset emails to /reset-password/

### DIFF
--- a/inc/auth/login.php
+++ b/inc/auth/login.php
@@ -188,6 +188,13 @@ add_filter( 'authenticate', 'extrachill_intercept_auth_error', 99, 3 );
 
 /**
  * Redirect direct wp-login.php access to custom login page.
+ *
+ * Password reset links from WordPress core emails point at
+ * wp-login.php?action=rp&key=...&login=... — without special handling
+ * the generic redirect strips the query string and dumps users on
+ * /login/ with no way to set a new password. We catch action=rp /
+ * action=resetpass explicitly and redirect to the community
+ * /reset-password/ page so the key + login survive the hop.
  */
 function extrachill_redirect_wp_login_access() {
 	if ( false === strpos( strtolower( $_SERVER['REQUEST_URI'] ), '/wp-login.php' ) ) {
@@ -202,11 +209,32 @@ function extrachill_redirect_wp_login_access() {
 		return;
 	}
 
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Reading reset key from query string for redirect routing; no state change here.
+	$action = isset( $_GET['action'] ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : '';
+
 	// Allow two-factor authentication challenge pages through.
-	$action = isset( $_GET['action'] ) ? $_GET['action'] : '';
 	if ( in_array( $action, array( 'validate_2fa', 'revalidate_2fa' ), true ) ) {
 		return;
 	}
+
+	// Route password reset links to the community /reset-password/ handler.
+	if ( in_array( $action, array( 'rp', 'resetpass' ), true ) ) {
+		$key   = isset( $_GET['key'] ) ? sanitize_text_field( wp_unslash( $_GET['key'] ) ) : '';
+		$login = isset( $_GET['login'] ) ? sanitize_text_field( wp_unslash( $_GET['login'] ) ) : '';
+
+		$reset_url = add_query_arg(
+			array(
+				'action' => 'reset',
+				'key'    => rawurlencode( $key ),
+				'login'  => rawurlencode( $login ),
+			),
+			ec_get_site_url( 'community' ) . '/reset-password/'
+		);
+
+		wp_safe_redirect( $reset_url );
+		exit;
+	}
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 	wp_safe_redirect( home_url( '/login/' ) );
 	exit;

--- a/inc/auth/password-reset.php
+++ b/inc/auth/password-reset.php
@@ -23,6 +23,94 @@ function ec_custom_lostpassword_url( $lostpassword_url, $redirect ) {
 add_filter( 'lostpassword_url', 'ec_custom_lostpassword_url', 10, 2 );
 
 /**
+ * Rewrite WordPress core password reset email to point at /reset-password/.
+ *
+ * WordPress core's retrieve_password() generates a reset URL of the form
+ *   {network_site_url}/wp-login.php?action=rp&key=...&login=...
+ * On Extra Chill, /wp-login.php is redirected to /login/ by
+ * extrachill_redirect_wp_login_access() — but the redirect strips the
+ * key/login (or, with the wp-login.php redirect fix, sends users to
+ * community.extrachill.com/reset-password/ via 302). Either way we want
+ * the link in the email body itself to point at the right destination
+ * from the start, so admin-triggered resets (wp user reset-password,
+ * wp-admin → Users → "Send password reset") deliver a clickable link
+ * the user can land on without a redirect dance.
+ *
+ * Same handler the /reset-password/ render template processes via
+ * ec_handle_reset_password().
+ *
+ * @param array   $email      Default email content (subject, message, headers, to).
+ * @param string  $key        Password reset key.
+ * @param string  $user_login User login of the recipient.
+ * @param WP_User $user_data  User object of the recipient.
+ * @return array Modified email content with the reset URL pointing at /reset-password/.
+ */
+function ec_filter_password_reset_email( $email, $key, $user_login, $user_data ) {
+	$reset_url = add_query_arg(
+		array(
+			'action' => 'reset',
+			'key'    => rawurlencode( $key ),
+			'login'  => rawurlencode( $user_login ),
+		),
+		ec_get_site_url( 'community' ) . '/reset-password/'
+	);
+
+	// Replace the wp-login.php link in the body with the canonical reset URL.
+	if ( isset( $email['message'] ) && is_string( $email['message'] ) ) {
+		$email['message'] = preg_replace(
+			'#https?://\S*wp-login\.php\?action=rp\S*#i',
+			$reset_url,
+			$email['message']
+		);
+	}
+
+	return $email;
+}
+add_filter( 'retrieve_password_notification_email', 'ec_filter_password_reset_email', 10, 4 );
+
+/**
+ * Rewrite the new-user notification email reset link.
+ *
+ * When admins create users via wp-admin → Users → Add New (with notification)
+ * or `wp user create --send-email`, WordPress sends a welcome email
+ * containing the same wp-login.php?action=rp reset link. Filter that too.
+ *
+ * @param array   $email      Default email content.
+ * @param WP_User $user       Newly created user.
+ * @param string  $blogname   Site name.
+ * @return array Modified email content.
+ */
+function ec_filter_new_user_notification_email( $email, $user, $blogname ) {
+	if ( ! isset( $email['message'] ) || ! is_string( $email['message'] ) ) {
+		return $email;
+	}
+
+	// Extract the reset key from the existing wp-login.php URL so we don't
+	// need to regenerate one (the email already embeds the key WP minted).
+	if ( ! preg_match( '#wp-login\.php\?action=rp&key=([^&\s]+)&login=([^&\s]+)#i', $email['message'], $matches ) ) {
+		return $email;
+	}
+
+	$reset_url = add_query_arg(
+		array(
+			'action' => 'reset',
+			'key'    => $matches[1],
+			'login'  => $matches[2],
+		),
+		ec_get_site_url( 'community' ) . '/reset-password/'
+	);
+
+	$email['message'] = preg_replace(
+		'#https?://\S*wp-login\.php\?action=rp\S*#i',
+		$reset_url,
+		$email['message']
+	);
+
+	return $email;
+}
+add_filter( 'wp_new_user_notification_email', 'ec_filter_new_user_notification_email', 10, 3 );
+
+/**
  * Get the transient key for password reset attempts.
  *
  * Keyed on requester IP only (not on submitted user_login) so attackers


### PR DESCRIPTION
Closes #46.

## Problem

WordPress core's `retrieve_password()` builds reset URLs as `{network_site_url}/wp-login.php?action=rp&key=...&login=...`. On Extra Chill, `extrachill_redirect_wp_login_access()` 302s any `/wp-login.php` GET to `/login/` and **drops the query string**, so the reset key + login disappear. The user lands on a generic login form with no way to set a new password from their email.

Real-world incident logged in the issue: new user Sarah Bentley (ID 607, 2026-05-22) was sent a password reset via `wp user reset-password`, clicked the email link, and ended up dead-in-the-water on `/login/`.

## Fix

Two surgical changes:

### 1. `inc/auth/password-reset.php` — filter the email URL at the source

Add two new filters so links in core-generated emails point at the working handler from the start (no redirect dance needed):

- `retrieve_password_notification_email` — rewrites the URL in standard password reset emails (`wp user reset-password`, wp-admin → Users → "Send password reset", lostpassword form via WP-core handler).
- `wp_new_user_notification_email` — rewrites the URL in welcome emails sent on `wp user create --send-email` or wp-admin → Users → Add New with notification.

Both rewrite to `community.extrachill.com/reset-password/?action=reset&key=...&login=...` — the same URL the existing `/reset-password/` render template and `ec_handle_reset_password()` already process.

### 2. `inc/auth/login.php` — preserve reset key on the wp-login.php redirect

`extrachill_redirect_wp_login_access()` now detects `action=rp` / `action=resetpass` and redirects to `/reset-password/` with the key and login intact, instead of stripping the query string and sending users to `/login/`. This catches:

- Stale emails sent before this fix lands
- Any other code path that might still generate `wp-login.php`-style reset links (e.g., third-party plugins, password protection flows we don't control)

## Verification plan after deploy

1. `wp --allow-root --path=/var/www/extrachill.com --url=extrachill.com user reset-password <test-user-id>` — confirm the resulting email body contains `community.extrachill.com/reset-password/?action=reset&key=...&login=...` (no `wp-login.php` substring).
2. Hit a stale-style URL manually: `curl -I 'https://extrachill.com/wp-login.php?action=rp&key=foo&login=bar'` — should `Location:` to `https://community.extrachill.com/reset-password/?action=reset&key=foo&login=bar`.
3. Click through a real reset email end-to-end on a test account.

## Out of scope

- The lostpassword **form** (`extrachill/v1/auth/lostpassword` REST + `ec_handle_password_reset_request()`) already generates a correct URL via `ec_send_password_reset_email()`. No change needed there.
- WP core's `wp_login_url` itself remains unfiltered — the GUI login URL still surfaces as `wp_login_url()` which other plugins may rely on. The redirect handles routing.