### PR TITLE
fix(bearer-auth): use narrow Authorization header sanitizer instead of sanitize_text_field

### DIFF
--- a/inc/auth-tokens/bearer-auth.php
+++ b/inc/auth-tokens/bearer-auth.php
@@ -38,21 +38,35 @@ function extrachill_users_authenticate_bearer_token( $user_id ) {
 /**
  * Extracts Bearer token from Authorization header.
  *
+ * Sanitization: we deliberately do NOT use sanitize_text_field() on
+ * the Authorization header. sanitize_text_field() HTML-encodes
+ * characters like `<`, `>`, `&`, `"`, and `'`, which is destructive
+ * for opaque bearer tokens that may contain any of those characters
+ * (see chubes4/wp-native#44 for a sibling bug where this caused ~45%
+ * of opaque tokens to silently fail authentication).
+ *
+ * Extra Chill's own JWT tokens are base64url-encoded by construction
+ * and never contain HTML-special characters, so the previous code
+ * happened to work — but the same anti-pattern is a latent risk for
+ * any future bearer token format we accept here. The fix is to use
+ * a narrow header sanitizer that strips only CR/LF (HTTP header
+ * injection protection) and null bytes, then trims outer whitespace.
+ *
  * @return string|null Token string or null if not present.
  */
 function extrachill_users_get_bearer_token(): ?string {
 	$auth_header = null;
 
 	if ( isset( $_SERVER['HTTP_AUTHORIZATION'] ) ) {
-		$auth_header = sanitize_text_field( wp_unslash( $_SERVER['HTTP_AUTHORIZATION'] ) );
+		$auth_header = extrachill_users_sanitize_authorization_header( wp_unslash( $_SERVER['HTTP_AUTHORIZATION'] ) );
 	} elseif ( isset( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ) ) {
-		$auth_header = sanitize_text_field( wp_unslash( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ) );
+		$auth_header = extrachill_users_sanitize_authorization_header( wp_unslash( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ) );
 	} elseif ( function_exists( 'getallheaders' ) ) {
 		$headers = getallheaders();
 		if ( isset( $headers['Authorization'] ) ) {
-			$auth_header = sanitize_text_field( $headers['Authorization'] );
+			$auth_header = extrachill_users_sanitize_authorization_header( $headers['Authorization'] );
 		} elseif ( isset( $headers['authorization'] ) ) {
-			$auth_header = sanitize_text_field( $headers['authorization'] );
+			$auth_header = extrachill_users_sanitize_authorization_header( $headers['authorization'] );
 		}
 	}
 
@@ -61,6 +75,25 @@ function extrachill_users_get_bearer_token(): ?string {
 	}
 
 	return substr( $auth_header, 7 );
+}
+
+/**
+ * Narrow sanitizer for the Authorization header.
+ *
+ * Strips CR/LF (HTTP header-injection protection) and null bytes,
+ * then trims outer whitespace. Does NOT call sanitize_text_field()
+ * — see the extraction docblock above for why that's destructive
+ * for opaque bearer tokens.
+ *
+ * @param mixed $value Raw Authorization header value.
+ * @return string Sanitized header string.
+ */
+function extrachill_users_sanitize_authorization_header( $value ): string {
+	if ( ! is_string( $value ) ) {
+		return '';
+	}
+
+	return trim( str_replace( array( "\r", "\n", "\0" ), '', $value ) );
 }
 
 /**

--- a/tests/integration/BearerAuthTest.php
+++ b/tests/integration/BearerAuthTest.php
@@ -93,4 +93,67 @@ class Test_Bearer_Auth extends WP_UnitTestCase {
 		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer invalid.token.here';
 		$this->assertFalse( extrachill_users_authenticate_bearer_token( false ) );
 	}
+
+	// -----------------------------------------------------------------
+	// Sanitizer regression tests — see chubes4/wp-native#44
+	// -----------------------------------------------------------------
+
+	public function test_sanitizer_preserves_html_special_characters(): void {
+		// sanitize_text_field() would HTML-encode these. The narrow
+		// header sanitizer must not.
+		$cases = array(
+			'token<with<angle>brackets'  => 'token<with<angle>brackets',
+			'amp&ersand&token'           => 'amp&ersand&token',
+			'quote"in"token'             => 'quote"in"token',
+			"apos'in'token"              => "apos'in'token",
+			'mixed<>&"\'characters'      => 'mixed<>&"\'characters',
+		);
+		foreach ( $cases as $input => $expected ) {
+			$this->assertSame(
+				$expected,
+				extrachill_users_sanitize_authorization_header( $input ),
+				sprintf( 'Token "%s" should be preserved verbatim.', $input )
+			);
+		}
+	}
+
+	public function test_sanitizer_strips_header_injection_chars(): void {
+		$malicious = "Bearer token-payload\r\nX-Injected: evil";
+		$cleaned   = extrachill_users_sanitize_authorization_header( $malicious );
+
+		$this->assertStringNotContainsString( "\r", $cleaned );
+		$this->assertStringNotContainsString( "\n", $cleaned );
+		$this->assertSame( 'Bearer token-payloadX-Injected: evil', $cleaned );
+	}
+
+	public function test_sanitizer_strips_null_bytes(): void {
+		$with_nulls = "Bearer token\0withnull";
+		$cleaned    = extrachill_users_sanitize_authorization_header( $with_nulls );
+
+		$this->assertStringNotContainsString( "\0", $cleaned );
+		$this->assertSame( 'Bearer tokenwithnull', $cleaned );
+	}
+
+	public function test_sanitizer_trims_outer_whitespace(): void {
+		$this->assertSame(
+			'Bearer token',
+			extrachill_users_sanitize_authorization_header( "  Bearer token  \t" )
+		);
+	}
+
+	public function test_sanitizer_handles_non_string_input(): void {
+		$this->assertSame( '', extrachill_users_sanitize_authorization_header( null ) );
+		$this->assertSame( '', extrachill_users_sanitize_authorization_header( 42 ) );
+		$this->assertSame( '', extrachill_users_sanitize_authorization_header( array( 'evil' ) ) );
+	}
+
+	public function test_get_bearer_token_preserves_html_special_chars_in_token(): void {
+		// Regression: previously sanitize_text_field() would mangle a
+		// token like "Bearer abc<def&ghi" into "Bearer abc&lt;def&amp;ghi".
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer abc<def&ghi"jkl\'mno>pqr';
+		$this->assertSame(
+			'abc<def&ghi"jkl\'mno>pqr',
+			extrachill_users_get_bearer_token()
+		);
+	}
 }


### PR DESCRIPTION
Defensive fix mirroring the upstream fix in [chubes4/wp-native#44](https://github.com/chubes4/wp-native/pull/45) (sibling PR).

## Why

`extrachill_users_get_bearer_token()` previously called `sanitize_text_field()` on the raw Authorization header. That function HTML-encodes `<`, `>`, `&`, `"`, and `'`, which is destructive for opaque bearer tokens that may legitimately contain those characters.

Extra Chill's own JWT access tokens are **base64url-encoded** by construction (`inc/auth-tokens/tokens.php`) and never contain HTML-special characters — so this code happened to work. But the same anti-pattern caused ~45-88% of opaque tokens to silently fail authentication in `wp-native-auth`'s bearer path, and it's a latent risk for any future token format we ever accept through this extractor (third-party Bearer schemes, OAuth bearer tokens from external providers, etc.).

This PR closes that latent risk while the sibling upstream fix lands in wp-native.

## Changes

### `inc/auth-tokens/bearer-auth.php`
- New `extrachill_users_sanitize_authorization_header()` helper that strips only CR/LF and null bytes (HTTP header-injection protection), then trims outer whitespace.
- `extrachill_users_get_bearer_token()` swaps all four `sanitize_text_field()` calls to use the new helper.
- Docblock added explaining the anti-pattern and pointing to the upstream bug for context.

### `tests/integration/BearerAuthTest.php`
Six regression tests added to the existing Bearer Auth integration test suite:
- HTML-special characters preserved verbatim in token bodies
- CR/LF stripped (header injection protection)
- Null bytes stripped
- Outer whitespace trimmed
- Non-string input safely returns empty (no warnings, no fatals)
- Real-world extraction path with HTML-special chars in the token

## Verification

PHP lint clean on both changed files. No new findings in homeboy lint.

## Refs

- Extra-Chill/extrachill-users#18 (investigation that surfaced this)
- chubes4/wp-native#44 (upstream bug + sibling fix PR)