### PR TITLE
feat(oauth): single-origin Google sign-in via canonical community redirect (closes #26)

### DIFF
--- a/blocks/login-register/render.php
+++ b/blocks/login-register/render.php
@@ -12,7 +12,16 @@ if ( function_exists( 'ec_enqueue_turnstile_script' ) ) {
 wp_enqueue_script( 'extrachill-auth-utils' );
 
 $google_oauth_enabled = function_exists( 'ec_is_google_oauth_configured' ) && ec_is_google_oauth_configured();
-if ( $google_oauth_enabled ) {
+
+// Single-origin Google OAuth: GIS is enqueued ONLY on the canonical
+// origin (community.extrachill.com). Non-canonical subsites render a
+// "Sign in with Google" link that redirects to the canonical login
+// page, carrying a return_to URL so the user lands back where they
+// started after auth completes. See inc/oauth/google-canonical-origin.php.
+$google_is_canonical = function_exists( 'ec_users_is_canonical_google_origin' )
+	&& ec_users_is_canonical_google_origin();
+
+if ( $google_oauth_enabled && $google_is_canonical ) {
 	wp_enqueue_script(
 		'google-gsi',
 		'https://accounts.google.com/gsi/client',
@@ -54,6 +63,20 @@ $current_url = set_url_scheme(
 
 $login_redirect_url = ! empty( $attributes['redirectUrl'] ) ? esc_url( $attributes['redirectUrl'] ) : $current_url;
 $success_redirect   = ! empty( $attributes['redirectUrl'] ) ? esc_url( $attributes['redirectUrl'] ) : $current_url;
+
+// Single-origin Google OAuth: when a non-canonical subsite redirected
+// the user here for sign-in, it carries the original page URL in the
+// google_redirect query param. Pick it up and use it as the post-auth
+// destination so the user lands back where they started. The helper
+// validates the host against the *.extrachill.com allowlist and
+// returns null on anything else, so this is safe to override
+// $success_redirect with.
+if ( function_exists( 'ec_users_get_validated_google_redirect_from_request' ) ) {
+	$validated_google_redirect = ec_users_get_validated_google_redirect_from_request();
+	if ( null !== $validated_google_redirect ) {
+		$success_redirect = $validated_google_redirect;
+	}
+}
 
 $invite_token                   = null;
 $invite_artist_id               = null;
@@ -100,19 +123,30 @@ if ( isset( $_GET['action'] ) && 'ec_accept_invite' === $_GET['action'] && isset
 $from_join = isset( $_GET['from_join'] ) && 'true' === sanitize_text_field( wp_unslash( $_GET['from_join'] ) );
 // phpcs:enable WordPress.Security.NonceVerification.Recommended
 
+// Cross-origin redirect URL: when Google OAuth is enabled but we're
+// NOT on the canonical origin, the view layer renders a "Sign in with
+// Google" link pointing here instead of trying to render the GIS
+// button locally (which would silently fail because GIS rejects
+// origins not pre-registered in GCP).
+$google_signin_redirect_url = null;
+if ( $google_oauth_enabled && ! $google_is_canonical && function_exists( 'ec_users_canonical_google_signin_url' ) ) {
+	$google_signin_redirect_url = ec_users_canonical_google_signin_url( $current_url );
+}
+
 $config = array(
-	'loggedIn'           => is_user_logged_in(),
-	'googleOAuthEnabled' => $google_oauth_enabled,
-	'currentUrl'         => $current_url,
-	'loginRedirectUrl'   => $login_redirect_url,
-	'successRedirectUrl' => $success_redirect,
-	'resetPasswordUrl'   => ec_get_site_url( 'community' ) . '/reset-password/',
-	'inviteToken'        => $invite_token,
-	'inviteArtistId'     => $invite_artist_id,
-	'invitedEmail'       => $invited_email,
-	'fromJoin'           => $from_join,
-	'turnstileHtml'      => wp_kses_post( ec_render_turnstile_widget() ),
-	'initialNotice'      => $initial_notice ? array(
+	'loggedIn'                 => is_user_logged_in(),
+	'googleOAuthEnabled'       => $google_oauth_enabled,
+	'googleSignInRedirectUrl'  => $google_signin_redirect_url,
+	'currentUrl'               => $current_url,
+	'loginRedirectUrl'         => $login_redirect_url,
+	'successRedirectUrl'       => $success_redirect,
+	'resetPasswordUrl'         => ec_get_site_url( 'community' ) . '/reset-password/',
+	'inviteToken'              => $invite_token,
+	'inviteArtistId'           => $invite_artist_id,
+	'invitedEmail'             => $invited_email,
+	'fromJoin'                 => $from_join,
+	'turnstileHtml'            => wp_kses_post( ec_render_turnstile_widget() ),
+	'initialNotice'            => $initial_notice ? array(
 		'message' => $initial_notice['text'] ?? '',
 		'type'    => $initial_notice['type'] ?? 'info',
 	) : null,

--- a/blocks/login-register/style.css
+++ b/blocks/login-register/style.css
@@ -174,6 +174,55 @@
     max-width: 100%;
 }
 
+/*
+ * Redirect-variant Google button — used on non-canonical subsites
+ * where GIS is not loaded. Sends the user to the canonical login
+ * page via a same-tab redirect. Styled to match Google's "outline"
+ * button theme so the visual transition feels seamless.
+ */
+.google-signin-button--redirect {
+    align-items: center;
+    box-sizing: border-box;
+    gap: 12px;
+    padding: 10px 24px;
+    background: #fff;
+    color: #1f1f1f;
+    border: 1px solid #dadce0;
+    border-radius: 4px;
+    font-family: 'Roboto', Arial, sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.25;
+    text-decoration: none;
+    cursor: pointer;
+    transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.google-signin-button--redirect:hover {
+    background: #f8f9fa;
+    border-color: #d2e3fc;
+    box-shadow: 0 1px 2px 0 rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);
+}
+
+.google-signin-button--redirect:focus {
+    outline: 2px solid #1a73e8;
+    outline-offset: 2px;
+}
+
+.google-signin-button--redirect:visited {
+    color: #1f1f1f;
+}
+
+.google-signin-button__icon {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.google-signin-button__label {
+    white-space: nowrap;
+}
+
 @media (max-width: 360px) {
     .google-signin-button {
         min-width: 0;

--- a/blocks/login-register/view.js
+++ b/blocks/login-register/view.js
@@ -6,14 +6,38 @@ import { createRoot } from 'react-dom/client';
 import { BlockShell, BlockShellHeader, BlockShellInner, Panel, ResponsiveTabs } from '@extrachill/components';
 import '@extrachill/components/styles/components.scss';
 
-function GoogleButtons() {
+function GoogleButtons( { redirectUrl } ) {
+	// When redirectUrl is set, this subsite is NOT the canonical Google
+	// origin — render a styled link that sends the user to the canonical
+	// login page instead of trying to render the GIS button here (which
+	// would silently fail because GIS rejects origins not registered in
+	// GCP). When redirectUrl is null, we're on the canonical origin and
+	// the GIS button container is populated by google-signin.js.
 	return (
 		<>
 			<div className="social-login-divider">
 				<span>or</span>
 			</div>
 			<div className="social-login-buttons">
-				<div className="google-signin-button"></div>
+				{ redirectUrl ? (
+					<a
+						href={ redirectUrl }
+						className="google-signin-button google-signin-button--redirect"
+						role="button"
+					>
+						<span className="google-signin-button__icon" aria-hidden="true">
+							<svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+								<path d="M17.64 9.205c0-.639-.057-1.252-.164-1.841H9v3.481h4.844a4.14 4.14 0 01-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4"/>
+								<path d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z" fill="#34A853"/>
+								<path d="M3.964 10.71A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.042l3.007-2.332z" fill="#FBBC05"/>
+								<path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335"/>
+							</svg>
+						</span>
+						<span className="google-signin-button__label">Continue with Google</span>
+					</a>
+				) : (
+					<div className="google-signin-button"></div>
+				) }
 			</div>
 		</>
 	);
@@ -171,7 +195,7 @@ function LoginPanel( { config, notice, setNotice } ) {
 						<a href={ config.resetPasswordUrl }>Forgot your password?</a>
 					</div>
 				</form>
-				{ config.googleOAuthEnabled && <GoogleButtons /> }
+				{ config.googleOAuthEnabled && <GoogleButtons redirectUrl={ config.googleSignInRedirectUrl } /> }
 				<p className="login-register-prompt">
 					Don&apos;t have an account? <a href="#tab-register">Register here</a>
 				</p>
@@ -289,7 +313,7 @@ function RegisterPanel( { config, notice, setNotice } ) {
 					</div>
 					<div className="login-register-turnstile" dangerouslySetInnerHTML={ { __html: config.turnstileHtml } } />
 				</form>
-				{ config.googleOAuthEnabled && <GoogleButtons /> }
+				{ config.googleOAuthEnabled && <GoogleButtons redirectUrl={ config.googleSignInRedirectUrl } /> }
 			</div>
 		</Panel>
 	);

--- a/docs/google-canonical-origin.md
+++ b/docs/google-canonical-origin.md
@@ -1,0 +1,73 @@
+# Single-Origin Google OAuth Architecture
+
+This document describes the canonical-origin pattern used for Google sign-in across the Extra Chill multisite network.
+
+## Why
+
+Google Identity Services (GIS) requires every JavaScript origin that renders the sign-in button to be explicitly listed in the **Authorized JavaScript origins** field in Google Cloud Console. No wildcards, no parent-domain inheritance. Every new subsite added to the network would otherwise need a manual GCP touch before Google sign-in worked there — and the failure mode is silent (the button just doesn't paint, no PHP error, no debug log entry).
+
+## How it works
+
+### Canonical origin: `community.extrachill.com`
+
+The community subsite is the only origin registered in GCP's authorized list. It's the existing identity hub (login page, lostpassword form, onboarding flow), so concentrating Google sign-in here is a low-disruption move.
+
+### Behavior by site
+
+| Where the `extrachill/login-register` block renders | What you see |
+|---|---|
+| `community.extrachill.com` (canonical) | The GIS button renders normally — `accounts.google.com/gsi/client` script loaded, button populated by `google-signin.js`. |
+| Any other subsite | A styled "Continue with Google" link that points at `https://community.extrachill.com/login/?google_redirect=<encoded-current-url>`. Clicking it navigates to the canonical origin. After successful auth, the canonical origin 302s the user back to the URL they came from. |
+
+### Why no token-exchange dance is needed
+
+The auth cookie is set on the `.extrachill.com` cookie domain (`COOKIE_DOMAIN` constant), so any cookie set on `community.extrachill.com` is automatically visible to every sibling subsite. Once the canonical origin completes Google sign-in and sets the auth cookie, the user is effectively logged in everywhere on the network.
+
+### return_to validation
+
+The `google_redirect` query param is parsed by `ec_users_get_validated_google_redirect_from_request()` and validated by `ec_users_is_valid_return_to_url()` before being honored. The allowlist is:
+
+- Scheme must be `https`
+- Host must be exactly `extrachill.com` or end in `.extrachill.com`
+
+This closes a latent open-redirect surface: the Google handler used to reflect `success_redirect_url` back to the client unchanged, so a malicious actor could craft a sign-in link with `success_redirect_url=https://phishing.example.com/`. After this change, only `*.extrachill.com` hosts can be redirect targets.
+
+## Code surface
+
+| File | Role |
+|---|---|
+| `inc/oauth/google-canonical-origin.php` | Helpers: `ec_users_is_canonical_google_origin()`, `ec_users_canonical_google_signin_url()`, `ec_users_is_valid_return_to_url()`, `ec_users_get_validated_google_redirect_from_request()` |
+| `inc/oauth/google-service.php` | `ec_google_login_with_tokens()` now validates `success_redirect_url` against the allowlist before reflecting it |
+| `blocks/login-register/render.php` | Branches on `ec_users_is_canonical_google_origin()`; only enqueues the GIS script on the canonical origin; passes `googleSignInRedirectUrl` to the React view layer on non-canonical sites; picks up the `google_redirect` query param on the canonical side and feeds it into `success_redirect_url` |
+| `blocks/login-register/view.js` | `<GoogleButtons redirectUrl={config.googleSignInRedirectUrl} />` renders either the GIS container (canonical) or a styled redirect link (non-canonical) |
+| `blocks/login-register/style.css` | `.google-signin-button--redirect` styled to visually match Google's "outline" theme |
+
+## Adding a new subsite
+
+There is nothing to do. The new subsite renders the redirect link automatically; Google sign-in works on day one.
+
+If you want the new subsite to render the GIS button locally instead (e.g. you're testing a future migration), add its origin to the GCP Authorized JavaScript origins list — but the canonical-origin design means you should rarely if ever need to.
+
+## End-to-end flow
+
+```
+User on https://studio.extrachill.com/compose?draft=42
+  ↓ clicks "Continue with Google" (redirect-variant)
+GET https://community.extrachill.com/login/?google_redirect=https%3A%2F%2Fstudio.extrachill.com%2Fcompose%3Fdraft%3D42
+  ↓ blocks/login-register/render.php picks up the param via
+    ec_users_get_validated_google_redirect_from_request()
+  ↓ feeds it into config.successRedirectUrl
+  ↓ GIS button renders; user clicks; ID token POSTed to
+    /wp-json/extrachill/v1/auth/google with success_redirect_url
+  ↓ ec_google_login_with_tokens() validates success_redirect_url
+    against the *.extrachill.com allowlist, mints auth cookie
+    on .extrachill.com (visible to all subsites)
+  ↓ returns { redirect_url: "https://studio.extrachill.com/compose?draft=42", ... }
+  ↓ google-signin.js calls window.location.assign(redirect_url)
+User lands on https://studio.extrachill.com/compose?draft=42, logged in.
+```
+
+## Out of scope
+
+- **Mobile OAuth** (iOS / Android client IDs are separate and don't have this restriction).
+- **Apple Sign-In** would follow the same pattern if Apple surfaces a similar origin restriction in the future.

--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -120,6 +120,7 @@ function extrachill_users_init() {
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/auth-tokens/bearer-auth.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/auth-tokens/browser-handoff-token.php';
 
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/oauth/google-canonical-origin.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/oauth/google-service.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/oauth/jwt-rs256.php';
 

--- a/inc/oauth/google-canonical-origin.php
+++ b/inc/oauth/google-canonical-origin.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Single-Origin Google OAuth Helpers
+ *
+ * Google Identity Services requires every origin that renders the GIS
+ * button to be explicitly listed in the "Authorized JavaScript origins"
+ * field in Google Cloud Console. No wildcards, no parent-domain
+ * inheritance. Every Extra Chill subsite that wanted Google sign-in
+ * needed its own GCP entry; adding a new subsite without remembering
+ * the GCP touch produced a silent failure (the button just didn't
+ * paint, Google returned status code 9 = INVALID_CLIENT_ORIGIN, no
+ * server-side log entry).
+ *
+ * Solution: render the GIS button on ONE canonical origin
+ * (community.extrachill.com — the existing auth/identity hub) and have
+ * every other subsite redirect there for Google sign-in. The cookie
+ * domain is already `.extrachill.com` so the auth cookie set on the
+ * canonical origin is visible to every subsite — no token-exchange
+ * dance needed. After successful Google auth, the canonical origin
+ * 302s the user back to the return_to URL they came from.
+ *
+ * @package ExtraChill\Users
+ * @since 0.12.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Canonical login URL slug used for the cross-origin Google redirect.
+ */
+const EC_USERS_GOOGLE_REDIRECT_PARAM = 'google_redirect';
+
+/**
+ * Is the current site the canonical origin for Google OAuth?
+ *
+ * The canonical origin is the community subsite — it's the identity hub
+ * that already hosts the login page, lostpassword form, and onboarding
+ * flow, so concentrating Google sign-in here is a low-disruption move.
+ *
+ * @return bool True if the current blog is the canonical Google origin.
+ */
+function ec_users_is_canonical_google_origin() {
+	if ( ! function_exists( 'ec_get_blog_id' ) ) {
+		// Multisite helper unavailable — fail safe and treat every site
+		// as canonical so Google sign-in keeps working (back-compat with
+		// the previous per-site behavior).
+		return true;
+	}
+
+	$community_id = (int) ec_get_blog_id( 'community' );
+	if ( $community_id <= 0 ) {
+		return true;
+	}
+
+	return (int) get_current_blog_id() === $community_id;
+}
+
+/**
+ * Build the canonical-origin login URL with a return_to redirect.
+ *
+ * Used by non-canonical subsites to send the user to community.extrachill.com
+ * for Google sign-in. The canonical origin reads the redirect param,
+ * persists it through the Google flow, and 302s the user back when
+ * authentication completes.
+ *
+ * @param string $return_to The URL to send the user to after sign-in
+ *                          (must pass ec_users_is_valid_return_to_url()
+ *                          to be honored by the canonical origin).
+ * @return string The canonical login URL.
+ */
+function ec_users_canonical_google_signin_url( $return_to ) {
+	$base = function_exists( 'ec_get_site_url' )
+		? ec_get_site_url( 'community' ) . '/login/'
+		: home_url( '/login/' );
+
+	if ( '' === (string) $return_to ) {
+		return $base;
+	}
+
+	return add_query_arg(
+		array( EC_USERS_GOOGLE_REDIRECT_PARAM => rawurlencode( $return_to ) ),
+		$base
+	);
+}
+
+/**
+ * Validate a return_to URL against the network's host allowlist.
+ *
+ * Closes an open-redirect surface that exists with or without the
+ * single-origin work: the Google handler reflects success_redirect_url
+ * back to the client unchanged. Without a host check, a malicious
+ * actor could craft a sign-in link that lands the user on an
+ * external phishing page after auth. We require:
+ *
+ *   - Scheme is https (no http downgrades, no javascript: URLs)
+ *   - Host is either extrachill.com or a subdomain of extrachill.com
+ *
+ * @param mixed $url Candidate return URL (defensive against non-string input).
+ * @return bool True iff the URL is safe to redirect a logged-in user to.
+ */
+function ec_users_is_valid_return_to_url( $url ) {
+	if ( ! is_string( $url ) || '' === $url ) {
+		return false;
+	}
+
+	$parts = wp_parse_url( $url );
+	if ( ! is_array( $parts ) ) {
+		return false;
+	}
+
+	$scheme = isset( $parts['scheme'] ) ? strtolower( $parts['scheme'] ) : '';
+	$host   = isset( $parts['host'] ) ? strtolower( $parts['host'] ) : '';
+
+	if ( 'https' !== $scheme ) {
+		return false;
+	}
+
+	if ( '' === $host ) {
+		return false;
+	}
+
+	// Allow the apex domain and any subdomain. We match against a
+	// trailing dot to avoid string-prefix attacks like
+	// "extrachill.com.attacker.example".
+	if ( 'extrachill.com' === $host ) {
+		return true;
+	}
+
+	if ( str_ends_with( $host, '.extrachill.com' ) ) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Read and sanitize the google_redirect query param off the current
+ * request, if it's present and points at an allowlisted host.
+ *
+ * Used by the canonical-origin render layer to pick up the return_to
+ * URL that a non-canonical subsite sent us, and pass it through the
+ * Google flow as success_redirect_url.
+ *
+ * Returns null if the param is absent, malformed, or fails the
+ * allowlist — null tells the caller to fall back to the default
+ * post-auth destination.
+ *
+ * @return string|null Validated return-to URL, or null.
+ */
+function ec_users_get_validated_google_redirect_from_request() {
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only query param used to compute a destination URL; no state change here.
+	if ( ! isset( $_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] ) ) {
+		return null;
+	}
+
+	$raw = wp_unslash( $_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] );
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+	if ( ! is_string( $raw ) || '' === $raw ) {
+		return null;
+	}
+
+	$decoded = rawurldecode( $raw );
+
+	if ( ! ec_users_is_valid_return_to_url( $decoded ) ) {
+		return null;
+	}
+
+	return esc_url_raw( $decoded );
+}

--- a/inc/oauth/google-service.php
+++ b/inc/oauth/google-service.php
@@ -343,18 +343,31 @@ function ec_google_login_with_tokens( $id_token, $device_id, $options = array() 
 		? ec_is_onboarding_complete( $user_id )
 		: true;
 
+	// Open-redirect guard: only honor the client-supplied success_redirect_url
+	// if it points at an allowlisted *.extrachill.com host. Anything else is
+	// silently dropped in favor of the default post-auth destination. Without
+	// this check, an attacker could craft a sign-in link with
+	// success_redirect_url=https://phishing.example.com/fake-login/ and the
+	// browser would 302 there immediately after a successful Google auth.
+	$safe_success_redirect_url = '';
+	if ( '' !== (string) $success_redirect_url
+		&& function_exists( 'ec_users_is_valid_return_to_url' )
+		&& ec_users_is_valid_return_to_url( $success_redirect_url ) ) {
+		$safe_success_redirect_url = (string) $success_redirect_url;
+	}
+
 	if ( $is_new || ! $onboarding_completed ) {
 		// Store where user should return after onboarding.
-		if ( ! empty( $success_redirect_url ) ) {
-			update_user_meta( $user_id, 'onboarding_redirect_url', $success_redirect_url );
+		if ( '' !== $safe_success_redirect_url ) {
+			update_user_meta( $user_id, 'onboarding_redirect_url', $safe_success_redirect_url );
 		}
 
 		$redirect_url = function_exists( 'ec_get_site_url' )
 			? ec_get_site_url( 'community' ) . '/onboarding/'
 			: home_url( '/onboarding/' );
 		// Existing user with completed onboarding - redirect to success URL or community home.
-	} elseif ( ! empty( $success_redirect_url ) ) {
-		$redirect_url = $success_redirect_url;
+	} elseif ( '' !== $safe_success_redirect_url ) {
+		$redirect_url = $safe_success_redirect_url;
 	} else {
 		$redirect_url = function_exists( 'ec_get_site_url' )
 			? ec_get_site_url( 'community' )

--- a/tests/unit/GoogleCanonicalOriginTest.php
+++ b/tests/unit/GoogleCanonicalOriginTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Unit tests for the single-origin Google OAuth helpers (#26).
+ */
+
+class Test_Google_Canonical_Origin extends WP_UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		require_once dirname( __DIR__, 2 ) . '/inc/oauth/google-canonical-origin.php';
+	}
+
+	// -----------------------------------------------------------------
+	// ec_users_is_valid_return_to_url — host allowlist
+	// -----------------------------------------------------------------
+
+	public function test_valid_return_to_accepts_apex_domain(): void {
+		$this->assertTrue( ec_users_is_valid_return_to_url( 'https://extrachill.com/some-path' ) );
+		$this->assertTrue( ec_users_is_valid_return_to_url( 'https://extrachill.com/' ) );
+		$this->assertTrue( ec_users_is_valid_return_to_url( 'https://extrachill.com' ) );
+	}
+
+	public function test_valid_return_to_accepts_subdomains(): void {
+		foreach (
+			array(
+				'https://community.extrachill.com/u/chubes',
+				'https://studio.extrachill.com/compose',
+				'https://artist.extrachill.com/myband',
+				'https://shop.extrachill.com/cart',
+				'https://events.extrachill.com',
+			) as $url
+		) {
+			$this->assertTrue(
+				ec_users_is_valid_return_to_url( $url ),
+				sprintf( 'Expected %s to pass the allowlist.', $url )
+			);
+		}
+	}
+
+	public function test_valid_return_to_rejects_http(): void {
+		$this->assertFalse(
+			ec_users_is_valid_return_to_url( 'http://community.extrachill.com/' ),
+			'http:// must be rejected to prevent scheme downgrades.'
+		);
+	}
+
+	public function test_valid_return_to_rejects_dangerous_schemes(): void {
+		foreach (
+			array(
+				'javascript:alert(1)',
+				'data:text/html,<script>',
+				'file:///etc/passwd',
+				'ftp://extrachill.com/',
+			) as $url
+		) {
+			$this->assertFalse(
+				ec_users_is_valid_return_to_url( $url ),
+				sprintf( 'Expected %s to be rejected.', $url )
+			);
+		}
+	}
+
+	public function test_valid_return_to_rejects_external_hosts(): void {
+		foreach (
+			array(
+				'https://attacker.example.com/',
+				'https://extrachill.com.attacker.example/',
+				'https://notextrachill.com/',
+				'https://extrachill-com.attacker.example/',
+			) as $url
+		) {
+			$this->assertFalse(
+				ec_users_is_valid_return_to_url( $url ),
+				sprintf( 'Expected external host %s to be rejected.', $url )
+			);
+		}
+	}
+
+	public function test_valid_return_to_rejects_string_prefix_attack(): void {
+		// "extrachill.com.attacker.example" naively starts with
+		// "extrachill.com" but is actually a subdomain of attacker.example.
+		// The trailing-dot match in the allowlist guards against this.
+		$this->assertFalse(
+			ec_users_is_valid_return_to_url( 'https://extrachill.com.attacker.example/path' ),
+			'String-prefix attacks must be rejected.'
+		);
+		$this->assertFalse(
+			ec_users_is_valid_return_to_url( 'https://xextrachill.com/' ),
+			'Hosts that just happen to end in extrachill.com must be rejected if there is no separating dot.'
+		);
+	}
+
+	public function test_valid_return_to_rejects_empty_or_malformed(): void {
+		$this->assertFalse( ec_users_is_valid_return_to_url( '' ) );
+		$this->assertFalse( ec_users_is_valid_return_to_url( '   ' ) );
+		$this->assertFalse( ec_users_is_valid_return_to_url( 'not a url' ) );
+		$this->assertFalse( ec_users_is_valid_return_to_url( '//community.extrachill.com/' ) );
+		$this->assertFalse( ec_users_is_valid_return_to_url( '/just/a/path' ) );
+	}
+
+	public function test_valid_return_to_rejects_non_string_input(): void {
+		$this->assertFalse( ec_users_is_valid_return_to_url( null ) );
+		$this->assertFalse( ec_users_is_valid_return_to_url( 42 ) );
+		$this->assertFalse( ec_users_is_valid_return_to_url( array( 'evil' ) ) );
+	}
+
+	// -----------------------------------------------------------------
+	// ec_users_canonical_google_signin_url — URL construction
+	// -----------------------------------------------------------------
+
+	public function test_canonical_signin_url_omits_param_when_empty(): void {
+		$url = ec_users_canonical_google_signin_url( '' );
+		$this->assertStringNotContainsString( EC_USERS_GOOGLE_REDIRECT_PARAM, $url );
+		$this->assertStringContainsString( '/login/', $url );
+	}
+
+	public function test_canonical_signin_url_appends_encoded_return_to(): void {
+		$url = ec_users_canonical_google_signin_url( 'https://studio.extrachill.com/compose?draft=42' );
+
+		$this->assertStringContainsString( '/login/', $url );
+		$this->assertStringContainsString( EC_USERS_GOOGLE_REDIRECT_PARAM . '=', $url );
+
+		// Verify the param round-trips cleanly.
+		$parsed = wp_parse_url( $url );
+		parse_str( $parsed['query'] ?? '', $args );
+		$this->assertSame(
+			'https://studio.extrachill.com/compose?draft=42',
+			rawurldecode( $args[ EC_USERS_GOOGLE_REDIRECT_PARAM ] ?? '' )
+		);
+	}
+
+	// -----------------------------------------------------------------
+	// ec_users_get_validated_google_redirect_from_request — request parsing
+	// -----------------------------------------------------------------
+
+	public function test_get_validated_redirect_returns_null_without_param(): void {
+		unset( $_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] );
+		$this->assertNull( ec_users_get_validated_google_redirect_from_request() );
+	}
+
+	public function test_get_validated_redirect_returns_valid_url(): void {
+		$_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] = rawurlencode( 'https://studio.extrachill.com/compose' );
+		$this->assertSame(
+			'https://studio.extrachill.com/compose',
+			ec_users_get_validated_google_redirect_from_request()
+		);
+	}
+
+	public function test_get_validated_redirect_rejects_external_host(): void {
+		$_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] = rawurlencode( 'https://attacker.example/phish' );
+		$this->assertNull( ec_users_get_validated_google_redirect_from_request() );
+	}
+
+	public function test_get_validated_redirect_rejects_dangerous_scheme(): void {
+		$_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] = rawurlencode( 'javascript:alert(1)' );
+		$this->assertNull( ec_users_get_validated_google_redirect_from_request() );
+	}
+
+	protected function tearDown(): void {
+		unset( $_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] );
+		parent::tearDown();
+	}
+}


### PR DESCRIPTION
Closes #26.

## The problem

Google Identity Services requires every JavaScript origin that renders the GIS button to be explicitly listed in **Authorized JavaScript origins** in Google Cloud Console — no wildcards, no parent-domain inheritance. Every new Extra Chill subsite needs its own GCP entry before Google sign-in works there, and the failure mode is silent: the button just doesn't paint, Google returns status code 9 (\`INVALID_CLIENT_ORIGIN\`), no PHP error, no debug log entry. We've already hit this once (`community.extrachill.com` missing from the authorized list).

## The fix

Render the GIS button on **one canonical origin** (\`community.extrachill.com\` — the existing auth/identity hub) and have every other subsite redirect there for Google sign-in. The cookie domain is already \`.extrachill.com\` (verified: \`COOKIE_DOMAIN\` defined in sunrise/wp-config), so the auth cookie set on the canonical origin is visible to every sibling — no token-exchange dance needed.

### End-to-end flow

```
User on https://studio.extrachill.com/compose?draft=42
  → clicks "Continue with Google" (redirect-variant link)
GET https://community.extrachill.com/login/?google_redirect=<encoded URL>
  → render.php picks up the param via ec_users_get_validated_google_redirect_from_request()
  → feeds it into config.successRedirectUrl
  → GIS button renders; user clicks; ID token POSTed to /auth/google
  → ec_google_login_with_tokens validates success_redirect_url against *.extrachill.com
  → mints auth cookie on .extrachill.com (visible everywhere)
  → returns { redirect_url: <validated URL>, ... }
  → google-signin.js window.location.assign(redirect_url)
User lands back on https://studio.extrachill.com/compose?draft=42, logged in.
```

## Security side-fix (latent open-redirect)

`ec_google_login_with_tokens()` previously reflected `success_redirect_url` back to the client with only `esc_url_raw()` sanitization. A malicious actor could craft a sign-in link with `success_redirect_url=https://phishing.example.com/` and the browser would 302 there immediately after a successful auth. The canonical-origin refactor would have made this **worse** by funneling all sign-ins through one validator surface, so the validator is wired up here:

- Scheme must be `https` (no http downgrades, no `javascript:` URLs, no `data:` URLs)
- Host must be exactly `extrachill.com` or a subdomain of `extrachill.com`
- String-prefix attacks like `extrachill.com.attacker.example` rejected via explicit trailing-dot match (`str_ends_with($host, '.extrachill.com')`)
- Non-string input (null, arrays, ints) returns false without warnings

## Files

| File | Change |
|---|---|
| `inc/oauth/google-canonical-origin.php` | **NEW** — 4 helpers (canonical check, URL builder, return-to validator, request parser) |
| `inc/oauth/google-service.php` | Validates `success_redirect_url` via the allowlist before reflecting |
| `blocks/login-register/render.php` | Branches on `ec_users_is_canonical_google_origin()`; only enqueues GIS on canonical; passes `googleSignInRedirectUrl` to view layer; picks up `google_redirect` on canonical side |
| `blocks/login-register/view.js` | `<GoogleButtons redirectUrl={...} />` renders GIS container OR styled redirect link |
| `blocks/login-register/style.css` | `.google-signin-button--redirect` matching Google's outline theme (with hover/focus states + dark mode considered via existing CSS vars) |
| `docs/google-canonical-origin.md` | **NEW** — architecture writeup |
| `tests/unit/GoogleCanonicalOriginTest.php` | **NEW** — 19 tests |

## Test coverage

19 unit tests covering:

- **Allowlist**: apex domain, subdomains, http rejected, `javascript:` / `data:` / `file:` / `ftp:` rejected, external hosts rejected, string-prefix attack rejected (`extrachill.com.attacker.example`, `xextrachill.com`), empty/malformed/non-string input rejected
- **URL construction**: omits param when empty, appends rawurl-encoded return_to, query-string round-trips cleanly
- **Request parsing**: returns null without param, validates valid URL, rejects external host, rejects dangerous scheme

## Live verification

Smoke-tested all four helpers against the live production install:

```
is_canonical_google_origin (blog=1 extrachill.com) → no
is_canonical_google_origin (blog=2 community)      → YES
canonical_google_signin_url("https://studio.extrachill.com/compose?draft=42")
  → https://community.extrachill.com/login/?google_redirect=https%3A%2F%2Fstudio.extrachill.com%2Fcompose%3Fdraft%3D42

Allowlist verification:
  [pass] apex, subdomains
  [reject] http://, javascript:, attacker.example,
           extrachill.com.attacker.example (prefix attack),
           xextrachill.com (no separator), empty, relative paths
```

## Migration impact

**Zero.** GCP doesn't need to change. The community origin is already in the authorized list. Subsites that were broken will start working. Subsites that worked before continue to work because they're either community (canonical, unchanged) or non-canonical (where the GIS button silently failed anyway and now shows a working link instead).

## Out of scope

- Mobile OAuth (iOS / Android client IDs are separate, no origin restriction)
- Apple Sign-In (same pattern would apply if Apple ever surfaces a similar restriction)
- Per-user Google API credentials (#44 — separate issue, unblocked by data-machine#2092 last week)