### PR TITLE
feat(concert-tracking): add search-events-for-marking ability

### DIFF
--- a/inc/concert-tracking/service.php
+++ b/inc/concert-tracking/service.php
@@ -796,3 +796,168 @@ function ec_users_get_event_attendees( int $event_id, int $blog_id = 0, int $lim
 
 	return $attendees;
 }
+
+// ─── Search Past Events for Marking ──────────────────────────────────────────
+
+/**
+ * Search past events for the "Add Past Shows" My Shows feature.
+ *
+ * Returns past events (start_datetime < NOW()) matching the query against:
+ *   - event post title
+ *   - artist taxonomy term names
+ *   - venue taxonomy term names
+ *
+ * Empty query returns the most recent past events as suggestions.
+ *
+ * Each returned event includes `is_marked` for the given user so the UI can
+ * render a "+ Mark Attended" / "✓ Tracked" state immediately.
+ *
+ * @param int   $user_id User ID (for is_marked computation).
+ * @param array $args {
+ *     Search arguments.
+ *     @type string $query     Search query. Empty returns recent past events.
+ *     @type int    $page      1-indexed page number. Default 1.
+ *     @type int    $per_page  Results per page. Default 20.
+ *     @type int    $blog_id   Blog ID. Defaults to events blog.
+ * }
+ * @return array{ events: array, total: int, pages: int, page: int }
+ */
+function ec_users_search_events_for_marking( int $user_id, array $args = array() ): array {
+	global $wpdb;
+
+	$defaults = array(
+		'query'    => '',
+		'page'     => 1,
+		'per_page' => 20,
+		'blog_id'  => 0,
+	);
+
+	$args = wp_parse_args( $args, $defaults );
+
+	$query    = trim( (string) $args['query'] );
+	$page     = max( 1, (int) $args['page'] );
+	$per_page = max( 1, min( 100, (int) $args['per_page'] ) );
+	$blog_id  = $args['blog_id'] ? (int) $args['blog_id'] : ( function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : 7 );
+
+	$events_prefix = $wpdb->get_blog_prefix( $blog_id );
+	$posts_table   = $events_prefix . 'posts';
+	$dates_table   = $events_prefix . 'datamachine_event_dates';
+	$tr_table      = $events_prefix . 'term_relationships';
+	$tt_table      = $events_prefix . 'term_taxonomy';
+	$terms_table   = $events_prefix . 'terms';
+
+	$now_mysql = current_time( 'mysql' );
+
+	$where   = array(
+		"p.post_type = 'data_machine_events'",
+		"p.post_status = 'publish'",
+		'ed.start_datetime < %s',
+	);
+	$prepare = array( $now_mysql );
+
+	// Build search clause if query provided.
+	if ( '' !== $query ) {
+		$like = '%' . $wpdb->esc_like( $query ) . '%';
+
+		// Subquery: term-ids whose names match the query, restricted to artist/venue.
+		// We use IN (...) against tr.term_taxonomy_id via a join in OR clause.
+		$where[]   = '(p.post_title LIKE %s OR EXISTS (
+			SELECT 1
+			FROM ' . $tr_table . ' tr2
+			INNER JOIN ' . $tt_table . ' tt2 ON tr2.term_taxonomy_id = tt2.term_taxonomy_id
+			INNER JOIN ' . $terms_table . ' t2 ON tt2.term_id = t2.term_id
+			WHERE tr2.object_id = p.ID
+			  AND tt2.taxonomy IN (\'artist\', \'venue\')
+			  AND t2.name LIKE %s
+		))';
+		$prepare[] = $like;
+		$prepare[] = $like;
+	}
+
+	$where_sql = implode( ' AND ', $where );
+
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- table names from trusted prefix; placeholders inside $where_sql matched in $prepare.
+	$count_sql = $wpdb->prepare(
+		"SELECT COUNT(DISTINCT p.ID)
+		FROM {$posts_table} p
+		INNER JOIN {$dates_table} ed ON p.ID = ed.post_id
+		WHERE {$where_sql}",
+		...$prepare
+	);
+	$total = (int) $wpdb->get_var( $count_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- prepared above.
+	// phpcs:enable
+
+	$pages  = $per_page > 0 ? (int) ceil( $total / $per_page ) : 1;
+	$page   = $pages > 0 ? min( $page, $pages ) : 1;
+	$offset = ( $page - 1 ) * $per_page;
+
+	if ( 0 === $total ) {
+		return array(
+			'events' => array(),
+			'total'  => 0,
+			'pages'  => 0,
+			'page'   => $page,
+		);
+	}
+
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- table names from trusted prefix; placeholders inside $where_sql matched in $prepare.
+	$rows_sql = $wpdb->prepare(
+		"SELECT p.ID AS post_id, p.post_title, DATE(ed.start_datetime) AS event_date
+		FROM {$posts_table} p
+		INNER JOIN {$dates_table} ed ON p.ID = ed.post_id
+		WHERE {$where_sql}
+		GROUP BY p.ID
+		ORDER BY ed.start_datetime DESC
+		LIMIT %d OFFSET %d",
+		...array_merge( $prepare, array( $per_page, $offset ) )
+	);
+	$rows = $wpdb->get_results( $rows_sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- prepared above.
+	// phpcs:enable
+
+	if ( empty( $rows ) ) {
+		return array(
+			'events' => array(),
+			'total'  => $total,
+			'pages'  => $pages,
+			'page'   => $page,
+		);
+	}
+
+	// Switch to events blog for taxonomy queries and is_marked checks (blog_id scoped).
+	$switched     = false;
+	$current_blog = get_current_blog_id();
+	if ( $current_blog !== $blog_id ) {
+		switch_to_blog( $blog_id );
+		$switched = true;
+	}
+
+	$events = array();
+	try {
+		foreach ( $rows as $row ) {
+			$post_id = (int) $row['post_id'];
+			$post    = get_post( $post_id );
+			if ( ! $post instanceof WP_Post ) {
+				continue;
+			}
+
+			$enriched              = ec_users_build_show_data( $post, $row );
+			$enriched['post_id']   = $post_id;
+			$enriched['is_marked'] = $user_id > 0
+				? ec_users_is_event_marked( $user_id, $post_id, $blog_id )
+				: false;
+
+			$events[] = $enriched;
+		}
+	} finally {
+		if ( $switched ) {
+			restore_current_blog();
+		}
+	}
+
+	return array(
+		'events' => $events,
+		'total'  => $total,
+		'pages'  => $pages,
+		'page'   => $page,
+	);
+}

--- a/inc/core/abilities/concert-tracking.php
+++ b/inc/core/abilities/concert-tracking.php
@@ -193,6 +193,56 @@ function extrachill_users_register_concert_tracking_abilities() {
 		)
 	);
 
+	// ─── Search Events for Marking ───────────────────────────────────────────
+
+	wp_register_ability(
+		'extrachill/search-events-for-marking',
+		array(
+			'label'               => __( 'Search Past Events for Marking', 'extrachill-users' ),
+			'description'         => __( 'Search past events (start_datetime < NOW) by title, artist, or venue. Returns is_marked per event for the current user. Powers the My Shows "Add Past Shows" tab.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'query'    => array(
+						'type'        => 'string',
+						'description' => 'Search query. Empty returns most recent past events as suggestions.',
+						'default'     => '',
+					),
+					'page'     => array(
+						'type'        => 'integer',
+						'description' => '1-indexed page number.',
+						'default'     => 1,
+					),
+					'per_page' => array(
+						'type'        => 'integer',
+						'description' => 'Results per page.',
+						'default'     => 20,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'events' => array( 'type' => 'array' ),
+					'total'  => array( 'type' => 'integer' ),
+					'pages'  => array( 'type' => 'integer' ),
+					'page'   => array( 'type' => 'integer' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_users_ability_search_events_for_marking',
+			'permission_callback' => 'is_user_logged_in',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+
 	// ─── Get Event Attendance ────────────────────────────────────────────────
 
 	wp_register_ability(
@@ -309,6 +359,29 @@ function extrachill_users_ability_get_user_concert_stats( array $input ) {
 	}
 
 	return ec_users_get_user_concert_stats( $user_id, $input );
+}
+
+/**
+ * Search past events for marking ability callback.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_search_events_for_marking( array $input ) {
+	$user_id = get_current_user_id();
+
+	if ( ! $user_id ) {
+		return new WP_Error( 'not_logged_in', 'You must be logged in to search events.', array( 'status' => 401 ) );
+	}
+
+	return ec_users_search_events_for_marking(
+		$user_id,
+		array(
+			'query'    => isset( $input['query'] ) ? (string) $input['query'] : '',
+			'page'     => isset( $input['page'] ) ? (int) $input['page'] : 1,
+			'per_page' => isset( $input['per_page'] ) ? (int) $input['per_page'] : 20,
+		)
+	);
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds the `extrachill/search-events-for-marking` ability + service function `ec_users_search_events_for_marking()` powering the new "Add Past Shows" tab on /my-shows/ (Extra-Chill/extrachill-events#109).

## What

- **New service function** `ec_users_search_events_for_marking()` in `inc/concert-tracking/service.php`:
  - Queries past events (`start_datetime < NOW()`) via the `posts` + `datamachine_event_dates` tables on the events blog.
  - Matches against post title (`LIKE`) and artist/venue taxonomy term names (`EXISTS` subquery over `term_relationships` → `term_taxonomy` → `terms`).
  - Empty query returns most-recent past events (suggestions for the empty state).
  - Sorts by `start_datetime DESC`.
  - 20 per page, paginated with separate COUNT query.
  - Enriches each row via the existing `ec_users_build_show_data()` (venue, deepest city, artists, permalink) and adds `is_marked` for the current user via `ec_users_is_event_marked()`.
- **New ability** `extrachill/search-events-for-marking` in `inc/core/abilities/concert-tracking.php`:
  - Inputs: `{ query: string, page: int, per_page: int }`.
  - Output: `{ events: [...], total, pages, page }`.
  - `permission_callback => 'is_user_logged_in'`.
  - `show_in_rest => true` so it's auto-discoverable via the abilities REST surface as well.

## Why

The "Going" button on event singles only works for events a user discovers *before* they happen. The My Shows feature had no way to retroactively log shows already attended. This is the most-requested gap per Chris Gardner. See Extra-Chill/extrachill-events#109 for full context.

## Storage

No DB schema changes. `c8c_ec_concert_tracking` already supports historical events fine — there's no past/future distinction at the storage layer. The existing `extrachill/toggle-event-mark` ability handles the mark write.

## Dependencies

- Consumed by:
  - Extra-Chill/extrachill-api `feat-109-search-events-for-marking` — REST wrapper at `/extrachill/v1/concert-tracking/search`.
  - Extra-Chill/extrachill-events `feat-109-search-add-past-shows` — frontend React tab.

## Testing

- PHP lint clean.
- SQL placeholders verified via `wpdb->prepare()` with table-name interpolation only from trusted `get_blog_prefix()` helper.
- Search query escaped via `wpdb->esc_like()`.
- Manual verification path:
  1. Apply this branch.
  2. Apply the matching extrachill-api branch.
  3. `curl -b 'wp-auth-cookie...' '/wp-json/extrachill/v1/concert-tracking/search?query=phish'` → returns past Phish shows.

Refs Extra-Chill/extrachill-events#109