### PR TITLE
feat(concert-import): import framework + setlist.fm + phish.net adapters

### DIFF
--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -141,6 +141,8 @@ function extrachill_users_init() {
 
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/service.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/buttons.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/import-db.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/import/bootstrap.php';
 
 	// wp-native-auth bridge: layer EC policy (membership, blocking, Turnstile)
 	// onto the generic wp-native-auth filter surface when both plugins are active.

--- a/inc/concert-tracking/import-db.php
+++ b/inc/concert-tracking/import-db.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Concert import runs table + installer.
+ *
+ * Tracks a single end-to-end import attempt per user per source. The row is
+ * the durable state for the resume-across-days semantics: the Action Scheduler
+ * worker reads it to know which page to fetch next, updates counters as it
+ * processes results, and the React UI polls it for progress.
+ *
+ * @package ExtraChill\Users
+ * @since 0.13.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Get the concert import runs table name.
+ *
+ * Network-scoped (lives under $wpdb->base_prefix) so a single user can have
+ * one import history across the whole platform — concert tracking itself is
+ * also network-scoped.
+ *
+ * @return string
+ */
+function extrachill_users_concert_import_runs_table_name() {
+	global $wpdb;
+	return $wpdb->base_prefix . 'ec_concert_import_runs';
+}
+
+/**
+ * Install/upgrade the concert import runs table.
+ *
+ * Schema notes:
+ * - `next_page` is the 1-indexed page number to fetch next; null when complete.
+ * - `next_attempt_at` is a UTC datetime; when not null, the AS worker is
+ *   scheduled (or should be re-scheduled) for that timestamp.
+ * - `rate_limit_*` counters cover the rolling daily-quota accounting per
+ *   source-defined window; we record requests issued today so resume logic
+ *   can re-check whether we still have quota left.
+ */
+function extrachill_users_install_concert_import_runs_table() {
+	global $wpdb;
+
+	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+	$table_name      = extrachill_users_concert_import_runs_table_name();
+	$charset_collate = $wpdb->get_charset_collate();
+
+	$sql = "CREATE TABLE {$table_name} (
+		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+		user_id bigint(20) unsigned NOT NULL,
+		source_slug varchar(64) NOT NULL,
+		status varchar(32) NOT NULL DEFAULT 'pending',
+		external_username varchar(190) DEFAULT NULL,
+		next_page int unsigned DEFAULT 1,
+		next_attempt_at datetime DEFAULT NULL,
+		requests_today int unsigned NOT NULL DEFAULT 0,
+		requests_today_date date DEFAULT NULL,
+		total_events_seen int unsigned NOT NULL DEFAULT 0,
+		total_events_matched int unsigned NOT NULL DEFAULT 0,
+		total_events_unmatched int unsigned NOT NULL DEFAULT 0,
+		total_events_skipped int unsigned NOT NULL DEFAULT 0,
+		total_pages int unsigned DEFAULT NULL,
+		error_message text DEFAULT NULL,
+		started_at datetime DEFAULT NULL,
+		updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		completed_at datetime DEFAULT NULL,
+		PRIMARY KEY  (id),
+		KEY idx_user_started (user_id, started_at),
+		KEY idx_status (status),
+		KEY idx_user_source_status (user_id, source_slug, status)
+	) {$charset_collate};";
+
+	dbDelta( $sql );
+}

--- a/inc/concert-tracking/import/EventMatcher.php
+++ b/inc/concert-tracking/import/EventMatcher.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Match an ExternalEvent against the internal `data_machine_events` post type.
+ *
+ * Strategy:
+ *  1. Use the events blog's `datamachine_event_dates` table to find all
+ *     events whose `start_datetime` falls on the external event's date
+ *     (inclusive day window).
+ *  2. Score each candidate by combined venue-name similarity + headliner
+ *     similarity (via similar_text() percentage).
+ *  3. Return the highest-scoring candidate above the configured threshold,
+ *     or null.
+ *
+ * The matcher runs in the events-blog context (callers switch_to_blog before
+ * invoking). All taxonomy lookups happen against the events blog's tables.
+ *
+ * Documented threshold: 85% on the combined score. Venue-name similarity is
+ * weighted higher (0.6) than headliner similarity (0.4) because venue+date
+ * uniquely identifies most shows already, while headliner names drift across
+ * sources due to formatting (feat./with/&).
+ *
+ * @package ExtraChill\Users\Concert_Import
+ * @since 0.13.0
+ */
+
+namespace ExtraChill\Users\Concert_Import;
+
+defined( 'ABSPATH' ) || exit;
+
+final class EventMatcher {
+
+	/**
+	 * Default minimum combined similarity score (0-100).
+	 */
+	public const DEFAULT_THRESHOLD = 85;
+
+	/**
+	 * Events blog ID (data_machine_events lives here).
+	 *
+	 * @var int
+	 */
+	private int $blog_id;
+
+	/**
+	 * Minimum combined score to accept a match.
+	 *
+	 * @var int
+	 */
+	private int $threshold;
+
+	public function __construct( int $blog_id = 0, int $threshold = self::DEFAULT_THRESHOLD ) {
+		if ( ! $blog_id ) {
+			$blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'events' ) : 7;
+		}
+		$this->blog_id   = $blog_id;
+		$this->threshold = $threshold;
+	}
+
+	public function blog_id(): int {
+		return $this->blog_id;
+	}
+
+	public function threshold(): int {
+		return $this->threshold;
+	}
+
+	/**
+	 * Attempt to match an ExternalEvent to an internal post.
+	 *
+	 * @param ExternalEvent $event
+	 * @return int|null Internal post ID, or null when no candidate clears the threshold.
+	 */
+	public function match( ExternalEvent $event ): ?int {
+		if ( ! $event->is_matchable() ) {
+			return null;
+		}
+
+		$candidates = $this->find_candidates_for_date( $event->date );
+		if ( empty( $candidates ) ) {
+			return null;
+		}
+
+		$switched     = false;
+		$current_blog = get_current_blog_id();
+		if ( $current_blog !== $this->blog_id ) {
+			switch_to_blog( $this->blog_id );
+			$switched = true;
+		}
+
+		try {
+			$best_score = 0;
+			$best_id    = null;
+
+			foreach ( $candidates as $candidate_post_id ) {
+				$score = $this->score_candidate( $candidate_post_id, $event );
+				if ( $score > $best_score ) {
+					$best_score = $score;
+					$best_id    = $candidate_post_id;
+				}
+			}
+		} finally {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+		}
+
+		if ( $best_id && $best_score >= $this->threshold ) {
+			return (int) $best_id;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Return all candidate event post IDs whose start_datetime falls on $date.
+	 *
+	 * @param string $date YYYY-MM-DD.
+	 * @return int[]
+	 */
+	private function find_candidates_for_date( string $date ): array {
+		global $wpdb;
+
+		$prefix = $wpdb->get_blog_prefix( $this->blog_id );
+		$table  = $prefix . 'datamachine_event_dates';
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from $wpdb->get_blog_prefix
+		$rows = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT post_id FROM {$table}
+				WHERE DATE(start_datetime) = %s
+				  AND post_status = 'publish'",
+				$date
+			)
+		);
+		// phpcs:enable
+
+		return array_map( 'intval', $rows ? $rows : array() );
+	}
+
+	/**
+	 * Score a candidate post against an external event.
+	 *
+	 * Returns a value in [0, 100] — combined weighted similarity of the
+	 * venue name and headliner artist.
+	 *
+	 * Must be called within the events-blog switch_to_blog context.
+	 */
+	private function score_candidate( int $post_id, ExternalEvent $event ): int {
+		$venue_terms  = wp_get_post_terms( $post_id, 'venue' );
+		$artist_terms = wp_get_post_terms( $post_id, 'artist' );
+
+		$venue_score    = 0;
+		$artist_score   = 0;
+		$venue_weight   = 0.6;
+		$artist_weight  = 0.4;
+
+		if ( ! is_wp_error( $venue_terms ) && ! empty( $venue_terms ) ) {
+			$best = 0;
+			foreach ( $venue_terms as $term ) {
+				$s = self::name_similarity( $term->name, $event->venue_name );
+				if ( $s > $best ) {
+					$best = $s;
+				}
+			}
+			$venue_score = $best;
+		}
+
+		if ( '' === $event->headliner ) {
+			// No headliner reported by source — give artist axis full
+			// credit so we don't penalize valid venue+date matches.
+			$artist_score = 100;
+		} elseif ( ! is_wp_error( $artist_terms ) && ! empty( $artist_terms ) ) {
+			$best = 0;
+			foreach ( $artist_terms as $term ) {
+				$s = self::name_similarity( $term->name, $event->headliner );
+				if ( $s > $best ) {
+					$best = $s;
+				}
+			}
+			$artist_score = $best;
+		}
+
+		$combined = ( $venue_score * $venue_weight ) + ( $artist_score * $artist_weight );
+		return (int) round( $combined );
+	}
+
+	/**
+	 * Normalize a name for similarity comparison.
+	 *
+	 * Lowercase, strip diacritics where ASCII fallback is sensible, collapse
+	 * whitespace, drop common venue noise words (the, a, an).
+	 */
+	public static function normalize_name( string $name ): string {
+		$name = wp_strip_all_tags( $name );
+		$name = function_exists( 'remove_accents' ) ? remove_accents( $name ) : $name;
+		$name = strtolower( $name );
+		// Drop punctuation we don't want to penalize.
+		$name = preg_replace( '/[\'`"\.,&]/', '', $name );
+		// Collapse whitespace.
+		$name = preg_replace( '/\s+/', ' ', $name );
+		// Trim leading articles.
+		$name = preg_replace( '/^(the |a |an )/i', '', (string) $name );
+		return trim( (string) $name );
+	}
+
+	/**
+	 * Compute a 0-100 similarity score between two names.
+	 *
+	 * Uses similar_text() in percent mode after normalization. Identical
+	 * strings score 100; completely disjoint strings score 0.
+	 */
+	public static function name_similarity( string $a, string $b ): int {
+		$a = self::normalize_name( $a );
+		$b = self::normalize_name( $b );
+
+		if ( '' === $a || '' === $b ) {
+			return 0;
+		}
+		if ( $a === $b ) {
+			return 100;
+		}
+
+		$percent = 0.0;
+		similar_text( $a, $b, $percent );
+		return (int) round( $percent );
+	}
+}

--- a/inc/concert-tracking/import/ExternalEvent.php
+++ b/inc/concert-tracking/import/ExternalEvent.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Normalized external event value object.
+ *
+ * Every ImportSource yields ExternalEvent instances; EventMatcher consumes
+ * them. This is the shared shape across all adapters — no source-specific
+ * shape leaks into the matcher or orchestrator.
+ *
+ * @package ExtraChill\Users\Concert_Import
+ * @since 0.13.0
+ */
+
+namespace ExtraChill\Users\Concert_Import;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Value object representing a single attended event as reported by an
+ * external source (setlist.fm, phish.net, etc.).
+ */
+final class ExternalEvent {
+
+	/**
+	 * Event date in YYYY-MM-DD (source-local — caller treats it as the
+	 * calendar date the show happened on).
+	 *
+	 * @var string
+	 */
+	public string $date;
+
+	/**
+	 * Venue name as reported by the source.
+	 *
+	 * @var string
+	 */
+	public string $venue_name;
+
+	/**
+	 * Venue city (best-effort, may be empty).
+	 *
+	 * @var string
+	 */
+	public string $city;
+
+	/**
+	 * Venue state or region (best-effort, may be empty).
+	 *
+	 * @var string
+	 */
+	public string $state;
+
+	/**
+	 * Venue country (best-effort, may be empty).
+	 *
+	 * @var string
+	 */
+	public string $country;
+
+	/**
+	 * Headliner / primary artist name as reported by the source.
+	 *
+	 * @var string
+	 */
+	public string $headliner;
+
+	/**
+	 * Stable source-side identifier (e.g. setlist.fm setlist ID or
+	 * phish.net showid). Used for logs + audit, not matching.
+	 *
+	 * @var string
+	 */
+	public string $source_id;
+
+	/**
+	 * Raw payload as returned by the source — kept around for debugging
+	 * unmatched events.
+	 *
+	 * @var array<string, mixed>
+	 */
+	public array $raw;
+
+	/**
+	 * @param array{
+	 *   date: string,
+	 *   venue_name?: string,
+	 *   city?: string,
+	 *   state?: string,
+	 *   country?: string,
+	 *   headliner?: string,
+	 *   source_id?: string,
+	 *   raw?: array<string, mixed>,
+	 * } $args
+	 */
+	public function __construct( array $args ) {
+		$this->date       = (string) ( $args['date'] ?? '' );
+		$this->venue_name = (string) ( $args['venue_name'] ?? '' );
+		$this->city       = (string) ( $args['city'] ?? '' );
+		$this->state      = (string) ( $args['state'] ?? '' );
+		$this->country    = (string) ( $args['country'] ?? '' );
+		$this->headliner  = (string) ( $args['headliner'] ?? '' );
+		$this->source_id  = (string) ( $args['source_id'] ?? '' );
+		$this->raw        = isset( $args['raw'] ) && is_array( $args['raw'] ) ? $args['raw'] : array();
+	}
+
+	/**
+	 * Whether the event has enough data to attempt a match.
+	 */
+	public function is_matchable(): bool {
+		return '' !== $this->date && '' !== $this->venue_name;
+	}
+
+	/**
+	 * Render a short human-readable label for logs / unmatched reports.
+	 */
+	public function label(): string {
+		$parts = array_filter(
+			array(
+				$this->date,
+				$this->headliner,
+				$this->venue_name,
+				$this->city,
+			),
+			static function ( $v ) {
+				return '' !== $v;
+			}
+		);
+		return implode( ' · ', $parts );
+	}
+}

--- a/inc/concert-tracking/import/ImportOrchestrator.php
+++ b/inc/concert-tracking/import/ImportOrchestrator.php
@@ -1,0 +1,490 @@
+<?php
+/**
+ * ImportOrchestrator — drives a single import run end-to-end.
+ *
+ * Lifecycle:
+ *   1. start()   — Insert a row in ec_concert_import_runs (status=pending),
+ *                  enqueue the first async action.
+ *   2. process() — Action Scheduler worker. Fetch ONE page, match each event,
+ *                  call ec_users_mark_event() for matches, update counters.
+ *                  Decide next move:
+ *                    - More pages + quota remaining: enqueue next page now.
+ *                    - More pages + rate limit hit:  enqueue with backoff delay.
+ *                    - More pages + daily quota hit: enqueue at tomorrow's UTC.
+ *                    - Done: mark status=complete.
+ *
+ * The run row is the single source of truth for resume state. The Action
+ * Scheduler hook payload only carries the run id; everything else is read
+ * from the row. This is what makes multi-day resume safe: even if Action
+ * Scheduler loses or duplicates the action, the row's state determines what
+ * happens next.
+ *
+ * @package ExtraChill\Users\Concert_Import
+ * @since 0.13.0
+ */
+
+namespace ExtraChill\Users\Concert_Import;
+
+defined( 'ABSPATH' ) || exit;
+
+final class ImportOrchestrator {
+
+	public const HOOK         = 'extrachill_concert_import_process';
+	public const GROUP        = 'extrachill-concert-import';
+	public const STATUS_PENDING  = 'pending';
+	public const STATUS_RUNNING  = 'running';
+	public const STATUS_COMPLETE = 'complete';
+	public const STATUS_FAILED   = 'failed';
+	public const STATUS_PAUSED   = 'paused';
+
+	/**
+	 * Register the Action Scheduler hook.
+	 *
+	 * Called from the plugin bootstrap so the worker is wired even if no
+	 * import is currently running.
+	 */
+	public static function register_hooks(): void {
+		add_action( self::HOOK, array( __CLASS__, 'process' ), 10, 1 );
+	}
+
+	/**
+	 * Start a new import run.
+	 *
+	 * @param int    $user_id  WP user ID initiating the import.
+	 * @param string $slug     Source slug (e.g. 'setlist-fm').
+	 * @param string $username External-platform username.
+	 *
+	 * @return array{ run_id: int }|\WP_Error
+	 */
+	public static function start( int $user_id, string $slug, string $username ) {
+		$source = self::get_source( $slug );
+		if ( ! $source ) {
+			return new \WP_Error( 'unknown_source', 'Unknown import source.', array( 'status' => 400 ) );
+		}
+		if ( ! $source->is_configured() ) {
+			return new \WP_Error(
+				'source_not_configured',
+				sprintf( 'The %s import is not configured on this platform yet.', $source->label() ),
+				array( 'status' => 503 )
+			);
+		}
+		if ( '' === trim( $username ) ) {
+			return new \WP_Error( 'missing_username', 'Username is required.', array( 'status' => 400 ) );
+		}
+
+		// Block concurrent runs for (user, source) — only one active run at a time.
+		$active = self::get_active_run( $user_id, $slug );
+		if ( $active ) {
+			return new \WP_Error(
+				'import_in_progress',
+				'An import for this source is already in progress.',
+				array(
+					'status' => 409,
+					'run_id' => (int) $active['id'],
+				)
+			);
+		}
+
+		// Persist the per-user username for future re-runs.
+		update_user_meta( $user_id, self::username_meta_key( $slug ), sanitize_text_field( $username ) );
+
+		global $wpdb;
+		$table = extrachill_users_concert_import_runs_table_name();
+		$now   = current_time( 'mysql', true );
+
+		$wpdb->insert(
+			$table,
+			array(
+				'user_id'           => $user_id,
+				'source_slug'       => $slug,
+				'status'            => self::STATUS_PENDING,
+				'external_username' => $username,
+				'next_page'         => 1,
+				'started_at'        => $now,
+				'updated_at'        => $now,
+			),
+			array( '%d', '%s', '%s', '%s', '%d', '%s', '%s' )
+		);
+
+		$run_id = (int) $wpdb->insert_id;
+		if ( ! $run_id ) {
+			return new \WP_Error( 'insert_failed', 'Could not create import run row.', array( 'status' => 500 ) );
+		}
+
+		self::enqueue( $run_id, 0 );
+
+		return array( 'run_id' => $run_id );
+	}
+
+	/**
+	 * Action Scheduler entry point.
+	 *
+	 * @param int $run_id Import run row ID.
+	 */
+	public static function process( int $run_id ): void {
+		$run = self::get_run( $run_id );
+		if ( ! $run ) {
+			return;
+		}
+		if ( in_array( $run['status'], array( self::STATUS_COMPLETE, self::STATUS_FAILED ), true ) ) {
+			return;
+		}
+
+		$source = self::get_source( $run['source_slug'] );
+		if ( ! $source ) {
+			self::mark_failed( $run_id, 'Source adapter is no longer available.' );
+			return;
+		}
+		if ( ! $source->is_configured() ) {
+			self::mark_failed( $run_id, 'Source is no longer configured.' );
+			return;
+		}
+
+		self::update_run(
+			$run_id,
+			array(
+				'status'          => self::STATUS_RUNNING,
+				'next_attempt_at' => null,
+			)
+		);
+
+		// Reset per-day request counter when the calendar date rolls over (UTC).
+		$today = gmdate( 'Y-m-d' );
+		if ( $run['requests_today_date'] !== $today ) {
+			self::update_run(
+				$run_id,
+				array(
+					'requests_today'      => 0,
+					'requests_today_date' => $today,
+				)
+			);
+			$run['requests_today']      = 0;
+			$run['requests_today_date'] = $today;
+		}
+
+		$rate    = $source->rate_limit();
+		$max_day = isset( $rate['requests_per_day'] ) ? (int) $rate['requests_per_day'] : 0;
+		if ( $max_day && $run['requests_today'] >= $max_day ) {
+			self::reschedule_tomorrow( $run_id );
+			return;
+		}
+
+		$page   = (int) ( $run['next_page'] ?: 1 );
+		$result = $source->fetch_page( (string) $run['external_username'], $page );
+
+		// Always count the request attempt against today's quota.
+		self::increment_requests_today( $run_id );
+
+		if ( is_wp_error( $result ) ) {
+			$code = $result->get_error_code();
+			if ( 'rate_limit' === $code ) {
+				// Source-specific backoff (seconds) from error_data, default 60s.
+				$data  = $result->get_error_data();
+				$retry = is_array( $data ) && isset( $data['retry_after'] ) ? max( 1, (int) $data['retry_after'] ) : 60;
+				self::reschedule( $run_id, $retry );
+				return;
+			}
+			if ( 'daily_quota' === $code ) {
+				self::reschedule_tomorrow( $run_id );
+				return;
+			}
+			self::mark_failed( $run_id, $result->get_error_message() );
+			return;
+		}
+
+		$events       = isset( $result['events'] ) && is_array( $result['events'] ) ? $result['events'] : array();
+		$total_pages  = isset( $result['total_pages'] ) ? max( 1, (int) $result['total_pages'] ) : $page;
+		$matcher      = new EventMatcher();
+		$events_blog  = $matcher->blog_id();
+
+		$seen      = 0;
+		$matched   = 0;
+		$unmatched = 0;
+		$skipped   = 0;
+
+		foreach ( $events as $external ) {
+			if ( ! $external instanceof ExternalEvent ) {
+				++$skipped;
+				continue;
+			}
+			++$seen;
+
+			if ( ! $external->is_matchable() ) {
+				++$skipped;
+				continue;
+			}
+
+			$matched_id = $matcher->match( $external );
+			if ( null === $matched_id ) {
+				++$unmatched;
+				continue;
+			}
+
+			$newly_marked = ec_users_mark_event( (int) $run['user_id'], $matched_id, $events_blog );
+			if ( $newly_marked ) {
+				++$matched;
+			} else {
+				// Already marked — still counts toward "matched" totals so the
+				// user-facing summary reports an honest match count.
+				++$matched;
+			}
+		}
+
+		self::increment_counters( $run_id, $seen, $matched, $unmatched, $skipped );
+		self::update_run(
+			$run_id,
+			array(
+				'total_pages' => $total_pages,
+			)
+		);
+
+		if ( $page >= $total_pages ) {
+			self::mark_complete( $run_id );
+			return;
+		}
+
+		self::update_run( $run_id, array( 'next_page' => $page + 1 ) );
+
+		// Re-read the row so we use the freshly-incremented requests_today.
+		$run = self::get_run( $run_id );
+		if ( ! $run ) {
+			return;
+		}
+
+		$max_day = isset( $rate['requests_per_day'] ) ? (int) $rate['requests_per_day'] : 0;
+		if ( $max_day && (int) $run['requests_today'] >= $max_day ) {
+			self::reschedule_tomorrow( $run_id );
+			return;
+		}
+
+		$per_sec = isset( $rate['requests_per_second'] ) ? (float) $rate['requests_per_second'] : 0.0;
+		$delay   = $per_sec > 0 ? (int) max( 1, ceil( 1.0 / $per_sec ) ) : 1;
+		self::reschedule( $run_id, $delay );
+	}
+
+	// ─── Source registry ──────────────────────────────────────────────
+
+	/**
+	 * Return all registered ImportSource instances keyed by slug.
+	 *
+	 * @return array<string, ImportSource>
+	 */
+	public static function sources(): array {
+		$sources = apply_filters( 'extrachill_concert_import_sources', array() );
+		$out     = array();
+		foreach ( (array) $sources as $source ) {
+			if ( $source instanceof ImportSource ) {
+				$out[ $source->slug() ] = $source;
+			}
+		}
+		return $out;
+	}
+
+	public static function get_source( string $slug ): ?ImportSource {
+		$sources = self::sources();
+		return $sources[ $slug ] ?? null;
+	}
+
+	// ─── DB helpers ───────────────────────────────────────────────────
+
+	/**
+	 * Build the user-meta key holding the per-user username for a source.
+	 */
+	public static function username_meta_key( string $slug ): string {
+		// Normalize slug to a meta-safe key.
+		$key = preg_replace( '/[^a-z0-9_]/', '_', strtolower( $slug ) );
+		return 'ec_concert_import_' . $key . '_username';
+	}
+
+	/**
+	 * Fetch a single run row as an assoc array.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function get_run( int $run_id ): ?array {
+		global $wpdb;
+		$table = extrachill_users_concert_import_runs_table_name();
+		$row   = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM {$table} WHERE id = %d LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$run_id
+			),
+			ARRAY_A
+		);
+		return $row ? $row : null;
+	}
+
+	/**
+	 * Get the active (pending/running/paused) run for a (user, source) pair.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function get_active_run( int $user_id, string $slug ): ?array {
+		global $wpdb;
+		$table = extrachill_users_concert_import_runs_table_name();
+		$row   = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM {$table}
+				WHERE user_id = %d AND source_slug = %s
+				AND status IN ( 'pending', 'running', 'paused' )
+				ORDER BY id DESC LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$user_id,
+				$slug
+			),
+			ARRAY_A
+		);
+		return $row ? $row : null;
+	}
+
+	/**
+	 * Get a user's recent import runs (any status) across all sources.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function get_user_runs( int $user_id, int $limit = 20 ): array {
+		global $wpdb;
+		$table = extrachill_users_concert_import_runs_table_name();
+		$rows  = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM {$table}
+				WHERE user_id = %d
+				ORDER BY id DESC
+				LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$user_id,
+				$limit
+			),
+			ARRAY_A
+		);
+		return $rows ? $rows : array();
+	}
+
+	private static function update_run( int $run_id, array $changes ): void {
+		global $wpdb;
+		$table             = extrachill_users_concert_import_runs_table_name();
+		$changes['updated_at'] = current_time( 'mysql', true );
+		$wpdb->update( $table, $changes, array( 'id' => $run_id ) );
+	}
+
+	private static function increment_counters( int $run_id, int $seen, int $matched, int $unmatched, int $skipped ): void {
+		global $wpdb;
+		$table = extrachill_users_concert_import_runs_table_name();
+		$now   = current_time( 'mysql', true );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table}
+				SET total_events_seen      = total_events_seen      + %d,
+				    total_events_matched   = total_events_matched   + %d,
+				    total_events_unmatched = total_events_unmatched + %d,
+				    total_events_skipped   = total_events_skipped   + %d,
+				    updated_at             = %s
+				WHERE id = %d",
+				$seen,
+				$matched,
+				$unmatched,
+				$skipped,
+				$now,
+				$run_id
+			)
+		);
+		// phpcs:enable
+	}
+
+	private static function increment_requests_today( int $run_id ): void {
+		global $wpdb;
+		$table = extrachill_users_concert_import_runs_table_name();
+		$today = gmdate( 'Y-m-d' );
+		$now   = current_time( 'mysql', true );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table}
+				SET requests_today      = CASE WHEN requests_today_date = %s THEN requests_today + 1 ELSE 1 END,
+				    requests_today_date = %s,
+				    updated_at          = %s
+				WHERE id = %d",
+				$today,
+				$today,
+				$now,
+				$run_id
+			)
+		);
+		// phpcs:enable
+	}
+
+	private static function mark_complete( int $run_id ): void {
+		self::update_run(
+			$run_id,
+			array(
+				'status'          => self::STATUS_COMPLETE,
+				'next_page'       => null,
+				'next_attempt_at' => null,
+				'completed_at'    => current_time( 'mysql', true ),
+			)
+		);
+	}
+
+	private static function mark_failed( int $run_id, string $message ): void {
+		self::update_run(
+			$run_id,
+			array(
+				'status'          => self::STATUS_FAILED,
+				'next_attempt_at' => null,
+				'error_message'   => $message,
+				'completed_at'    => current_time( 'mysql', true ),
+			)
+		);
+	}
+
+	// ─── Scheduling ───────────────────────────────────────────────────
+
+	/**
+	 * Enqueue an immediate async action.
+	 */
+	private static function enqueue( int $run_id, int $delay_seconds ): void {
+		if ( ! function_exists( 'as_enqueue_async_action' ) ) {
+			return;
+		}
+
+		if ( $delay_seconds <= 0 ) {
+			as_enqueue_async_action( self::HOOK, array( $run_id ), self::GROUP );
+			return;
+		}
+		if ( function_exists( 'as_schedule_single_action' ) ) {
+			as_schedule_single_action( time() + $delay_seconds, self::HOOK, array( $run_id ), self::GROUP );
+		}
+	}
+
+	private static function reschedule( int $run_id, int $delay_seconds ): void {
+		$ts = time() + max( 1, $delay_seconds );
+		self::update_run(
+			$run_id,
+			array(
+				'status'          => self::STATUS_PAUSED,
+				'next_attempt_at' => gmdate( 'Y-m-d H:i:s', $ts ),
+			)
+		);
+		if ( function_exists( 'as_schedule_single_action' ) ) {
+			as_schedule_single_action( $ts, self::HOOK, array( $run_id ), self::GROUP );
+		}
+	}
+
+	private static function reschedule_tomorrow( int $run_id ): void {
+		// Resume at 00:05 UTC tomorrow — small buffer so the source's daily
+		// counter has definitely rolled over.
+		$ts = strtotime( 'tomorrow 00:05:00 UTC' );
+		if ( ! $ts ) {
+			$ts = time() + DAY_IN_SECONDS;
+		}
+		self::update_run(
+			$run_id,
+			array(
+				'status'          => self::STATUS_PAUSED,
+				'next_attempt_at' => gmdate( 'Y-m-d H:i:s', $ts ),
+			)
+		);
+		if ( function_exists( 'as_schedule_single_action' ) ) {
+			as_schedule_single_action( $ts, self::HOOK, array( $run_id ), self::GROUP );
+		}
+	}
+}

--- a/inc/concert-tracking/import/ImportSource.php
+++ b/inc/concert-tracking/import/ImportSource.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * ImportSource interface — contract for every concert-import adapter.
+ *
+ * The framework knows nothing about specific external services. Each adapter
+ * (SetlistFmImportSource, PhishNetImportSource, ...) implements this interface
+ * and is registered via the `extrachill_concert_import_sources` filter so the
+ * orchestrator can discover it at runtime.
+ *
+ * @package ExtraChill\Users\Concert_Import
+ * @since 0.13.0
+ */
+
+namespace ExtraChill\Users\Concert_Import;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Adapter contract for an external concert-history source.
+ */
+interface ImportSource {
+
+	/**
+	 * Unique source slug (e.g. 'setlist-fm', 'phish-net'). Used as the
+	 * primary key in the import runs table and the React UI.
+	 */
+	public function slug(): string;
+
+	/**
+	 * Human-readable label (e.g. 'setlist.fm').
+	 */
+	public function label(): string;
+
+	/**
+	 * Per-source rate limit descriptor.
+	 *
+	 * @return array{ requests_per_second?: float, requests_per_day?: int }
+	 */
+	public function rate_limit(): array;
+
+	/**
+	 * Whether the platform-side credential (API key) is configured.
+	 *
+	 * Used to disable the source in the UI before Chris provisions it.
+	 */
+	public function is_configured(): bool;
+
+	/**
+	 * Probe the source with the given username to verify it exists and
+	 * return a total event count to seed the confirmation dialog.
+	 *
+	 * @param string $username External-platform username.
+	 * @return array{ total: int, username: string }|\WP_Error
+	 */
+	public function preview( string $username );
+
+	/**
+	 * Fetch a single page of attended events for the given username.
+	 *
+	 * Implementations must:
+	 *  - Treat $page as 1-indexed.
+	 *  - Return up to `per_page` ExternalEvent instances in `events`.
+	 *  - Set `total_pages` based on the source's metadata so the orchestrator
+	 *    can decide whether to enqueue another page.
+	 *  - Return WP_Error with the special code 'rate_limit' when the source's
+	 *    rate limit is hit; the orchestrator backs off accordingly.
+	 *
+	 * @param string $username   External-platform username.
+	 * @param int    $page       1-indexed page number.
+	 * @return array{
+	 *   events: ExternalEvent[],
+	 *   total_pages: int,
+	 *   total: int,
+	 *   page: int,
+	 * }|\WP_Error
+	 */
+	public function fetch_page( string $username, int $page );
+}

--- a/inc/concert-tracking/import/Sources/PhishNetImportSource.php
+++ b/inc/concert-tracking/import/Sources/PhishNetImportSource.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * phish.net import adapter.
+ *
+ * API docs: https://docs.phish.net/
+ *  - GET /v5/attendance/username/{username}.json?apikey=KEY
+ *  - Returns ALL of a user's attended shows in a single response (no paging).
+ *  - Auth: apikey query param (platform-wide key).
+ *  - Rate limits: phish.net does not publish a strict per-day cap; their TOS
+ *    asks consumers to "be reasonable" and to identify the application via
+ *    User-Agent. We conservatively self-throttle at 1 req/sec and cap at
+ *    300 req/day per platform-wide policy — well under practical limits but
+ *    enough headroom for many concurrent imports.
+ *
+ * Because the response is not paginated, our orchestrator only makes one
+ * request per run. The framework still drives this through page=1 / total_pages=1.
+ *
+ * Platform-wide API key from network option
+ * `ec_concert_import_phishnet_api_key`. Constant
+ * `EC_CONCERT_IMPORT_PHISHNET_API_KEY` overrides in non-prod.
+ *
+ * @package ExtraChill\Users\Concert_Import
+ * @since 0.13.0
+ */
+
+namespace ExtraChill\Users\Concert_Import\Sources;
+
+use ExtraChill\Users\Concert_Import\ExternalEvent;
+use ExtraChill\Users\Concert_Import\ImportSource;
+
+defined( 'ABSPATH' ) || exit;
+
+final class PhishNetImportSource implements ImportSource {
+
+	public const SLUG             = 'phish-net';
+	public const API_BASE         = 'https://api.phish.net/v5';
+	public const OPTION_API_KEY   = 'ec_concert_import_phishnet_api_key';
+	public const CONSTANT_API_KEY = 'EC_CONCERT_IMPORT_PHISHNET_API_KEY';
+
+	public function slug(): string {
+		return self::SLUG;
+	}
+
+	public function label(): string {
+		return 'phish.net';
+	}
+
+	public function rate_limit(): array {
+		return array(
+			'requests_per_second' => 1.0,
+			'requests_per_day'    => 300,
+		);
+	}
+
+	public function is_configured(): bool {
+		return '' !== $this->get_api_key();
+	}
+
+	public function preview( string $username ) {
+		$username = trim( $username );
+		if ( '' === $username ) {
+			return new \WP_Error( 'missing_username', 'Username is required.' );
+		}
+
+		$result = $this->fetch_page( $username, 1 );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return array(
+			'total'    => (int) ( $result['total'] ?? 0 ),
+			'username' => $username,
+		);
+	}
+
+	public function fetch_page( string $username, int $page ) {
+		$api_key = $this->get_api_key();
+		if ( '' === $api_key ) {
+			return new \WP_Error(
+				'source_not_configured',
+				'phish.net API key is not configured.',
+				array( 'status' => 503 )
+			);
+		}
+
+		// phish.net returns all attendances in one response — we only hit
+		// the network on page 1 and treat subsequent calls as a no-op.
+		if ( $page > 1 ) {
+			return array(
+				'events'      => array(),
+				'total_pages' => 1,
+				'total'       => 0,
+				'page'        => $page,
+			);
+		}
+
+		$url = self::API_BASE . '/attendance/username/' . rawurlencode( $username ) . '.json?apikey=' . rawurlencode( $api_key );
+
+		$response = wp_remote_get(
+			$url,
+			array(
+				'timeout' => 15,
+				'headers' => array(
+					'Accept'     => 'application/json',
+					'User-Agent' => 'ExtraChill-Concert-Import/1.0 (+https://extrachill.com)',
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+		$body = wp_remote_retrieve_body( $response );
+
+		if ( 429 === $code ) {
+			$retry = (int) wp_remote_retrieve_header( $response, 'retry-after' );
+			return new \WP_Error(
+				'rate_limit',
+				'phish.net rate limit hit.',
+				array( 'retry_after' => $retry > 0 ? $retry : 60 )
+			);
+		}
+		if ( $code < 200 || $code >= 300 ) {
+			return new \WP_Error(
+				'http_error',
+				sprintf( 'phish.net API returned HTTP %d.', $code ),
+				array( 'status' => $code, 'body' => $body )
+			);
+		}
+
+		$payload = json_decode( $body, true );
+		if ( ! is_array( $payload ) ) {
+			return new \WP_Error( 'invalid_json', 'phish.net returned malformed JSON.' );
+		}
+
+		// phish.net v5 envelope: { error: false, error_message: "", data: [...] }
+		if ( ! empty( $payload['error'] ) ) {
+			$msg = isset( $payload['error_message'] ) ? (string) $payload['error_message'] : 'phish.net API error.';
+			return new \WP_Error( 'phishnet_error', $msg );
+		}
+
+		$rows   = isset( $payload['data'] ) && is_array( $payload['data'] ) ? $payload['data'] : array();
+		$events = array();
+
+		foreach ( $rows as $row ) {
+			$event = $this->row_to_external_event( $row );
+			if ( $event ) {
+				$events[] = $event;
+			}
+		}
+
+		return array(
+			'events'      => $events,
+			'total_pages' => 1,
+			'total'       => count( $events ),
+			'page'        => 1,
+		);
+	}
+
+	/**
+	 * Map a phish.net attendance row to an ExternalEvent.
+	 *
+	 * Expected fields per the v5 schema:
+	 *   - showdate: YYYY-MM-DD
+	 *   - venue: venue name
+	 *   - city, state, country: location parts
+	 *   - artist_name: typically "Phish" (or Trey/etc. for related projects)
+	 *   - showid: stable show identifier
+	 */
+	private function row_to_external_event( array $row ): ?ExternalEvent {
+		$date = isset( $row['showdate'] ) ? (string) $row['showdate'] : '';
+		if ( ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) ) {
+			return null;
+		}
+
+		return new ExternalEvent(
+			array(
+				'date'       => $date,
+				'venue_name' => isset( $row['venue'] ) ? (string) $row['venue'] : '',
+				'city'       => isset( $row['city'] ) ? (string) $row['city'] : '',
+				'state'      => isset( $row['state'] ) ? (string) $row['state'] : '',
+				'country'    => isset( $row['country'] ) ? (string) $row['country'] : '',
+				'headliner'  => isset( $row['artist_name'] ) ? (string) $row['artist_name'] : 'Phish',
+				'source_id'  => isset( $row['showid'] ) ? (string) $row['showid'] : '',
+				'raw'        => $row,
+			)
+		);
+	}
+
+	private function get_api_key(): string {
+		if ( defined( self::CONSTANT_API_KEY ) ) {
+			$constant_value = constant( self::CONSTANT_API_KEY );
+			if ( is_string( $constant_value ) && '' !== $constant_value ) {
+				return $constant_value;
+			}
+		}
+		$value = get_site_option( self::OPTION_API_KEY, '' );
+		return is_string( $value ) ? trim( $value ) : '';
+	}
+}

--- a/inc/concert-tracking/import/Sources/SetlistFmImportSource.php
+++ b/inc/concert-tracking/import/Sources/SetlistFmImportSource.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * setlist.fm import adapter.
+ *
+ * API docs: https://api.setlist.fm/docs/1.0/index.html
+ *  - GET /1.0/user/{userId}/attended?p={page}
+ *  - 20 setlists per page.
+ *  - Auth: x-api-key header (platform-wide key).
+ *  - Rate limits: 2 req/sec, 1440 req/day (free tier).
+ *  - Accept: application/json.
+ *
+ * Platform-wide API key is read from the network option
+ * `ec_concert_import_setlistfm_api_key` (admin UI to manage this is tracked
+ * in a follow-up issue; the constant `EC_CONCERT_IMPORT_SETLISTFM_API_KEY`
+ * is honored as an override for staging environments).
+ *
+ * @package ExtraChill\Users\Concert_Import
+ * @since 0.13.0
+ */
+
+namespace ExtraChill\Users\Concert_Import\Sources;
+
+use ExtraChill\Users\Concert_Import\ExternalEvent;
+use ExtraChill\Users\Concert_Import\ImportSource;
+
+defined( 'ABSPATH' ) || exit;
+
+final class SetlistFmImportSource implements ImportSource {
+
+	public const SLUG               = 'setlist-fm';
+	public const API_BASE           = 'https://api.setlist.fm/rest/1.0';
+	public const OPTION_API_KEY     = 'ec_concert_import_setlistfm_api_key';
+	public const CONSTANT_API_KEY   = 'EC_CONCERT_IMPORT_SETLISTFM_API_KEY';
+
+	public function slug(): string {
+		return self::SLUG;
+	}
+
+	public function label(): string {
+		return 'setlist.fm';
+	}
+
+	public function rate_limit(): array {
+		return array(
+			'requests_per_second' => 2.0,
+			'requests_per_day'    => 1440,
+		);
+	}
+
+	public function is_configured(): bool {
+		return '' !== $this->get_api_key();
+	}
+
+	public function preview( string $username ) {
+		$username = trim( $username );
+		if ( '' === $username ) {
+			return new \WP_Error( 'missing_username', 'Username is required.' );
+		}
+
+		$result = $this->fetch_page( $username, 1 );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return array(
+			'total'    => (int) ( $result['total'] ?? 0 ),
+			'username' => $username,
+		);
+	}
+
+	public function fetch_page( string $username, int $page ) {
+		$api_key = $this->get_api_key();
+		if ( '' === $api_key ) {
+			return new \WP_Error(
+				'source_not_configured',
+				'setlist.fm API key is not configured.',
+				array( 'status' => 503 )
+			);
+		}
+
+		$page = max( 1, $page );
+		$url  = self::API_BASE . '/user/' . rawurlencode( $username ) . '/attended?p=' . $page;
+
+		$response = wp_remote_get(
+			$url,
+			array(
+				'timeout' => 15,
+				'headers' => array(
+					'Accept'    => 'application/json',
+					'x-api-key' => $api_key,
+					'User-Agent' => 'ExtraChill-Concert-Import/1.0 (+https://extrachill.com)',
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+		$body = wp_remote_retrieve_body( $response );
+
+		if ( 404 === $code ) {
+			return new \WP_Error(
+				'username_not_found',
+				sprintf( 'No setlist.fm user named "%s" was found.', $username ),
+				array( 'status' => 404 )
+			);
+		}
+		if ( 429 === $code ) {
+			$retry = (int) wp_remote_retrieve_header( $response, 'retry-after' );
+			return new \WP_Error(
+				'rate_limit',
+				'setlist.fm rate limit hit.',
+				array( 'retry_after' => $retry > 0 ? $retry : 30 )
+			);
+		}
+		if ( $code < 200 || $code >= 300 ) {
+			return new \WP_Error(
+				'http_error',
+				sprintf( 'setlist.fm API returned HTTP %d.', $code ),
+				array( 'status' => $code, 'body' => $body )
+			);
+		}
+
+		$payload = json_decode( $body, true );
+		if ( ! is_array( $payload ) ) {
+			return new \WP_Error( 'invalid_json', 'setlist.fm returned malformed JSON.' );
+		}
+
+		$setlists = isset( $payload['setlist'] ) && is_array( $payload['setlist'] ) ? $payload['setlist'] : array();
+		$events   = array();
+
+		foreach ( $setlists as $setlist ) {
+			$event = $this->setlist_to_external_event( $setlist );
+			if ( $event ) {
+				$events[] = $event;
+			}
+		}
+
+		$total     = isset( $payload['total'] ) ? (int) $payload['total'] : count( $events );
+		$per_page  = isset( $payload['itemsPerPage'] ) ? max( 1, (int) $payload['itemsPerPage'] ) : 20;
+		$total_pgs = (int) max( 1, ceil( $total / $per_page ) );
+
+		return array(
+			'events'      => $events,
+			'total_pages' => $total_pgs,
+			'total'       => $total,
+			'page'        => isset( $payload['page'] ) ? (int) $payload['page'] : $page,
+		);
+	}
+
+	/**
+	 * Convert a setlist.fm setlist object to ExternalEvent.
+	 *
+	 * setlist.fm format reference:
+	 *   {
+	 *     "id": "...",
+	 *     "eventDate": "DD-MM-YYYY",
+	 *     "artist": { "name": "..." },
+	 *     "venue": {
+	 *       "name": "...",
+	 *       "city": { "name": "...", "state": "...", "country": { "code": "US", "name": "..." } }
+	 *     }
+	 *   }
+	 */
+	private function setlist_to_external_event( array $setlist ): ?ExternalEvent {
+		$event_date = isset( $setlist['eventDate'] ) ? $this->normalize_date( (string) $setlist['eventDate'] ) : '';
+		if ( '' === $event_date ) {
+			return null;
+		}
+
+		$venue   = isset( $setlist['venue'] ) && is_array( $setlist['venue'] ) ? $setlist['venue'] : array();
+		$city_a  = isset( $venue['city'] ) && is_array( $venue['city'] ) ? $venue['city'] : array();
+		$country = isset( $city_a['country'] ) && is_array( $city_a['country'] ) ? $city_a['country'] : array();
+		$artist  = isset( $setlist['artist'] ) && is_array( $setlist['artist'] ) ? $setlist['artist'] : array();
+
+		return new ExternalEvent(
+			array(
+				'date'       => $event_date,
+				'venue_name' => isset( $venue['name'] ) ? (string) $venue['name'] : '',
+				'city'       => isset( $city_a['name'] ) ? (string) $city_a['name'] : '',
+				'state'      => isset( $city_a['state'] ) ? (string) $city_a['state'] : '',
+				'country'    => isset( $country['name'] ) ? (string) $country['name'] : '',
+				'headliner'  => isset( $artist['name'] ) ? (string) $artist['name'] : '',
+				'source_id'  => isset( $setlist['id'] ) ? (string) $setlist['id'] : '',
+				'raw'        => $setlist,
+			)
+		);
+	}
+
+	/**
+	 * Convert setlist.fm's DD-MM-YYYY date format to YYYY-MM-DD.
+	 */
+	private function normalize_date( string $date ): string {
+		if ( preg_match( '/^(\d{2})-(\d{2})-(\d{4})$/', $date, $m ) ) {
+			return $m[3] . '-' . $m[2] . '-' . $m[1];
+		}
+		// Some payloads may already be ISO; pass through if so.
+		if ( preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) ) {
+			return $date;
+		}
+		return '';
+	}
+
+	private function get_api_key(): string {
+		if ( defined( self::CONSTANT_API_KEY ) ) {
+			$constant_value = constant( self::CONSTANT_API_KEY );
+			if ( is_string( $constant_value ) && '' !== $constant_value ) {
+				return $constant_value;
+			}
+		}
+		$value = get_site_option( self::OPTION_API_KEY, '' );
+		return is_string( $value ) ? trim( $value ) : '';
+	}
+}

--- a/inc/concert-tracking/import/bootstrap.php
+++ b/inc/concert-tracking/import/bootstrap.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Concert import framework bootstrap.
+ *
+ * Loads framework + adapters, wires the Action Scheduler hook, and registers
+ * the default setlist.fm + phish.net adapters via the
+ * `extrachill_concert_import_sources` filter. Third parties can add more
+ * adapters by hooking the same filter.
+ *
+ * @package ExtraChill\Users\Concert_Import
+ * @since 0.13.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/ExternalEvent.php';
+require_once __DIR__ . '/ImportSource.php';
+require_once __DIR__ . '/EventMatcher.php';
+require_once __DIR__ . '/ImportOrchestrator.php';
+require_once __DIR__ . '/Sources/SetlistFmImportSource.php';
+require_once __DIR__ . '/Sources/PhishNetImportSource.php';
+
+// Register the Action Scheduler worker hook.
+\ExtraChill\Users\Concert_Import\ImportOrchestrator::register_hooks();
+
+// Register default sources.
+add_filter(
+	'extrachill_concert_import_sources',
+	function ( $sources ) {
+		if ( ! is_array( $sources ) ) {
+			$sources = array();
+		}
+		$sources[] = new \ExtraChill\Users\Concert_Import\Sources\SetlistFmImportSource();
+		$sources[] = new \ExtraChill\Users\Concert_Import\Sources\PhishNetImportSource();
+		return $sources;
+	}
+);

--- a/inc/core/abilities/concert-import.php
+++ b/inc/core/abilities/concert-import.php
@@ -1,0 +1,320 @@
+<?php
+/**
+ * Concert import abilities.
+ *
+ * Surfaces the import framework to REST + chat + CLI. Three abilities:
+ *  - extrachill/list-concert-import-sources — enumerate registered sources
+ *    so the UI can render per-source cards.
+ *  - extrachill/preview-concert-import       — one-shot username probe used
+ *    by the confirmation dialog.
+ *  - extrachill/start-concert-import         — kicks off the background run.
+ *  - extrachill/get-concert-import-status    — polled by the React UI.
+ *
+ * @package ExtraChill\Users
+ * @since 0.13.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use ExtraChill\Users\Concert_Import\ImportOrchestrator;
+
+add_action( 'wp_abilities_api_init', 'extrachill_users_register_concert_import_abilities' );
+
+/**
+ * Register concert import abilities.
+ */
+function extrachill_users_register_concert_import_abilities() {
+
+	wp_register_ability(
+		'extrachill/list-concert-import-sources',
+		array(
+			'label'               => __( 'List Concert Import Sources', 'extrachill-users' ),
+			'description'         => __( 'List all registered concert-history import sources and the current user\'s saved username for each.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => new stdClass(),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'sources' => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_users_ability_list_concert_import_sources',
+			'permission_callback' => 'is_user_logged_in',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/preview-concert-import',
+		array(
+			'label'               => __( 'Preview Concert Import', 'extrachill-users' ),
+			'description'         => __( 'Validate the username against the external source and return the total event count so the user can confirm before kicking off the full import.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'source'   => array(
+						'type'        => 'string',
+						'description' => 'Source slug (e.g. "setlist-fm").',
+					),
+					'username' => array(
+						'type'        => 'string',
+						'description' => 'External-platform username for this user.',
+					),
+				),
+				'required'   => array( 'source', 'username' ),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'source'   => array( 'type' => 'string' ),
+					'username' => array( 'type' => 'string' ),
+					'total'    => array( 'type' => 'integer' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_users_ability_preview_concert_import',
+			'permission_callback' => 'is_user_logged_in',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => false,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/start-concert-import',
+		array(
+			'label'               => __( 'Start Concert Import', 'extrachill-users' ),
+			'description'         => __( 'Kick off a background import run for the current user from a registered source.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'source'   => array( 'type' => 'string' ),
+					'username' => array( 'type' => 'string' ),
+				),
+				'required'   => array( 'source', 'username' ),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'run_id' => array( 'type' => 'integer' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_users_ability_start_concert_import',
+			'permission_callback' => 'is_user_logged_in',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => false,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/get-concert-import-status',
+		array(
+			'label'               => __( 'Get Concert Import Status', 'extrachill-users' ),
+			'description'         => __( 'Return the current user\'s recent import runs with progress + summary counters.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'limit' => array(
+						'type'    => 'integer',
+						'default' => 20,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'runs' => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_users_ability_get_concert_import_status',
+			'permission_callback' => 'is_user_logged_in',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callbacks ───────────────────────────────────────────────────────
+
+/**
+ * Shape a single source for the UI.
+ *
+ * @param \ExtraChill\Users\Concert_Import\ImportSource $source
+ * @param int                                           $user_id
+ * @return array<string, mixed>
+ */
+function extrachill_users_shape_concert_import_source( $source, int $user_id ): array {
+	$slug     = $source->slug();
+	$username = (string) get_user_meta( $user_id, ImportOrchestrator::username_meta_key( $slug ), true );
+	$rate     = $source->rate_limit();
+
+	return array(
+		'slug'         => $slug,
+		'label'        => $source->label(),
+		'configured'   => $source->is_configured(),
+		'username'     => $username,
+		'rate_limit'   => array(
+			'requests_per_second' => isset( $rate['requests_per_second'] ) ? (float) $rate['requests_per_second'] : 0.0,
+			'requests_per_day'    => isset( $rate['requests_per_day'] ) ? (int) $rate['requests_per_day'] : 0,
+		),
+	);
+}
+
+/**
+ * Shape a run row for the UI.
+ *
+ * @param array<string, mixed> $run
+ * @return array<string, mixed>
+ */
+function extrachill_users_shape_concert_import_run( array $run ): array {
+	return array(
+		'id'                     => (int) $run['id'],
+		'source_slug'            => (string) $run['source_slug'],
+		'status'                 => (string) $run['status'],
+		'username'               => (string) $run['external_username'],
+		'next_page'              => isset( $run['next_page'] ) ? (int) $run['next_page'] : null,
+		'total_pages'            => isset( $run['total_pages'] ) ? (int) $run['total_pages'] : null,
+		'next_attempt_at'        => $run['next_attempt_at'] ?: null,
+		'requests_today'         => (int) ( $run['requests_today'] ?? 0 ),
+		'requests_today_date'    => $run['requests_today_date'] ?: null,
+		'total_events_seen'      => (int) ( $run['total_events_seen'] ?? 0 ),
+		'total_events_matched'   => (int) ( $run['total_events_matched'] ?? 0 ),
+		'total_events_unmatched' => (int) ( $run['total_events_unmatched'] ?? 0 ),
+		'total_events_skipped'   => (int) ( $run['total_events_skipped'] ?? 0 ),
+		'started_at'             => $run['started_at'] ?: null,
+		'updated_at'             => $run['updated_at'] ?: null,
+		'completed_at'           => $run['completed_at'] ?: null,
+		'error_message'          => $run['error_message'] ?: null,
+	);
+}
+
+/**
+ * @param array<string, mixed> $input
+ * @return array<string, mixed>|WP_Error
+ */
+function extrachill_users_ability_list_concert_import_sources( array $input ) {
+	$user_id = get_current_user_id();
+	if ( ! $user_id ) {
+		return new WP_Error( 'not_logged_in', 'You must be logged in.', array( 'status' => 401 ) );
+	}
+
+	$sources = ImportOrchestrator::sources();
+	$out     = array();
+	foreach ( $sources as $source ) {
+		$out[] = extrachill_users_shape_concert_import_source( $source, $user_id );
+	}
+
+	return array( 'sources' => $out );
+}
+
+/**
+ * @param array<string, mixed> $input
+ * @return array<string, mixed>|WP_Error
+ */
+function extrachill_users_ability_preview_concert_import( array $input ) {
+	$user_id = get_current_user_id();
+	if ( ! $user_id ) {
+		return new WP_Error( 'not_logged_in', 'You must be logged in.', array( 'status' => 401 ) );
+	}
+
+	$slug     = sanitize_text_field( (string) ( $input['source'] ?? '' ) );
+	$username = sanitize_text_field( (string) ( $input['username'] ?? '' ) );
+
+	$source = ImportOrchestrator::get_source( $slug );
+	if ( ! $source ) {
+		return new WP_Error( 'unknown_source', 'Unknown import source.', array( 'status' => 400 ) );
+	}
+	if ( ! $source->is_configured() ) {
+		return new WP_Error(
+			'source_not_configured',
+			sprintf( 'The %s import is not configured on this platform yet.', $source->label() ),
+			array( 'status' => 503 )
+		);
+	}
+	if ( '' === trim( $username ) ) {
+		return new WP_Error( 'missing_username', 'Username is required.', array( 'status' => 400 ) );
+	}
+
+	$result = $source->preview( $username );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return array(
+		'source'   => $slug,
+		'username' => isset( $result['username'] ) ? (string) $result['username'] : $username,
+		'total'    => isset( $result['total'] ) ? (int) $result['total'] : 0,
+	);
+}
+
+/**
+ * @param array<string, mixed> $input
+ * @return array<string, mixed>|WP_Error
+ */
+function extrachill_users_ability_start_concert_import( array $input ) {
+	$user_id = get_current_user_id();
+	if ( ! $user_id ) {
+		return new WP_Error( 'not_logged_in', 'You must be logged in.', array( 'status' => 401 ) );
+	}
+
+	$slug     = sanitize_text_field( (string) ( $input['source'] ?? '' ) );
+	$username = sanitize_text_field( (string) ( $input['username'] ?? '' ) );
+
+	$result = ImportOrchestrator::start( $user_id, $slug, $username );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return array( 'run_id' => (int) $result['run_id'] );
+}
+
+/**
+ * @param array<string, mixed> $input
+ * @return array<string, mixed>|WP_Error
+ */
+function extrachill_users_ability_get_concert_import_status( array $input ) {
+	$user_id = get_current_user_id();
+	if ( ! $user_id ) {
+		return new WP_Error( 'not_logged_in', 'You must be logged in.', array( 'status' => 401 ) );
+	}
+
+	$limit = isset( $input['limit'] ) ? (int) $input['limit'] : 20;
+	$limit = max( 1, min( 100, $limit ) );
+
+	$rows = ImportOrchestrator::get_user_runs( $user_id, $limit );
+	$out  = array();
+	foreach ( $rows as $row ) {
+		$out[] = extrachill_users_shape_concert_import_run( $row );
+	}
+
+	return array( 'runs' => $out );
+}

--- a/inc/core/abilities/register.php
+++ b/inc/core/abilities/register.php
@@ -36,6 +36,7 @@ require_once __DIR__ . '/user-settings.php';
 require_once __DIR__ . '/user-profile.php';
 require_once __DIR__ . '/subscriptions.php';
 require_once __DIR__ . '/concert-tracking.php';
+require_once __DIR__ . '/concert-import.php';
 require_once __DIR__ . '/users-leaderboard.php';
 require_once __DIR__ . '/users-search.php';
 require_once __DIR__ . '/get-user-by-id.php';

--- a/inc/core/activation.php
+++ b/inc/core/activation.php
@@ -32,6 +32,13 @@ function extrachill_users_run_activation() {
 
 	update_site_option( 'extrachill_users_concert_tracking_table_created', 1 );
 
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/import-db.php';
+	if ( function_exists( 'extrachill_users_install_concert_import_runs_table' ) ) {
+		extrachill_users_install_concert_import_runs_table();
+	}
+
+	update_site_option( 'extrachill_users_concert_import_runs_table_created', 1 );
+
 	extrachill_users_create_login_pages_network();
 
 	// Register extra_chill_team role on every site in the network and
@@ -230,6 +237,24 @@ function extrachill_users_maybe_create_concert_tracking_table() {
 	update_site_option( 'extrachill_users_concert_tracking_table_created', 1 );
 }
 add_action( 'admin_init', 'extrachill_users_maybe_create_concert_tracking_table' );
+
+/**
+ * Ensure concert import runs table exists.
+ * Fallback for existing installations where the table was added after activation.
+ */
+function extrachill_users_maybe_create_concert_import_runs_table() {
+	if ( get_site_option( 'extrachill_users_concert_import_runs_table_created' ) ) {
+		return;
+	}
+
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/import-db.php';
+	if ( function_exists( 'extrachill_users_install_concert_import_runs_table' ) ) {
+		extrachill_users_install_concert_import_runs_table();
+	}
+
+	update_site_option( 'extrachill_users_concert_import_runs_table_created', 1 );
+}
+add_action( 'admin_init', 'extrachill_users_maybe_create_concert_import_runs_table' );
 
 /**
  * Create onboarding page on community site only.


### PR DESCRIPTION
## Summary

Adds a generic **concert-history import framework** to extrachill-users, plus two adapters (setlist.fm, phish.net). Users can pull their existing concert history from external services and have shows automatically marked attended on matching internal events.

Part of Extra-Chill/extrachill-events#112. Frontend lives in extrachill-events (companion PR). REST routes live in extrachill-api (companion PR).

## Architecture

```
inc/concert-tracking/
├── import-db.php                  ← c8c_ec_concert_import_runs table installer
└── import/
    ├── ImportSource.php           ← interface every adapter implements
    ├── ExternalEvent.php          ← normalized value object yielded by adapters
    ├── EventMatcher.php           ← external event → internal post matcher
    ├── ImportOrchestrator.php     ← Action Scheduler driver + run state machine
    ├── bootstrap.php              ← loads files, wires AS hook, registers default sources
    └── Sources/
        ├── SetlistFmImportSource.php
        └── PhishNetImportSource.php
```

Adapters register themselves through the `extrachill_concert_import_sources` filter so third-party plugins can add more sources without touching the framework.

## Matching strategy

`EventMatcher` runs against the events blog's `datamachine_event_dates` table.

1. Find all candidates with `DATE(start_datetime) = $external_event->date` and `post_status='publish'`.
2. Score each candidate with a weighted similarity blend:
   - **venue name** similarity × **0.6**
   - **headliner artist** similarity × **0.4**
3. Names are normalized (lowercase, accent-stripped, leading article dropped, punctuation collapsed) before `similar_text()`.
4. **Threshold: 85%** combined score. Below threshold → unmatched (skipped, counted in run summary).

The headliner axis gets full credit when the source reports no artist (some events on phish.net are tagged only with venue+date), so we don't penalize otherwise-clean venue+date matches.

## Resume-across-days semantics

The orchestrator only carries the **run id** in Action Scheduler payloads. Everything else lives in the run row — that's the single source of truth so duplicate or lost AS actions still produce correct behavior.

Per page tick:
1. Mark run `running`, clear `next_attempt_at`.
2. Roll the per-day request counter if the calendar date (UTC) changed.
3. Bail out and reschedule for tomorrow if daily quota is already exhausted.
4. Fetch one page from the adapter (counts toward today's quota whether it succeeds or fails).
5. On `WP_Error` with code `rate_limit` → reschedule with adapter-supplied `retry_after` (default 60s).
6. On `WP_Error` with code `daily_quota` → reschedule at **00:05 UTC tomorrow** (small buffer past midnight).
7. On other errors → mark `failed` and stop.
8. On success: match each event, increment counters atomically, bump `next_page`, check if we've reached `total_pages`.
9. If more pages remain and we still have today's quota → enqueue the next page with a 1-tick delay derived from `requests_per_second`.

This means a setlist.fm power user with 5000+ shows (>1440/day API cap) can take multiple days to import; the run row stays `paused` between days and the React UI keeps showing live progress.

## Rate limits

| Source     | req/sec | req/day | Notes |
|------------|---------|---------|-------|
| setlist.fm | 2.0     | 1440    | Free-tier official limits. |
| phish.net  | 1.0     | 300     | Conservative self-throttle — phish.net doesn't publish a hard per-day cap, just asks consumers to "be reasonable" and identify via User-Agent. |

## API keys + admin UI

Platform-wide API keys live in **network options**:
- `ec_concert_import_setlistfm_api_key`
- `ec_concert_import_phishnet_api_key`

Environment overrides (for staging) via constants:
- `EC_CONCERT_IMPORT_SETLISTFM_API_KEY`
- `EC_CONCERT_IMPORT_PHISHNET_API_KEY`

A proper admin settings UI for these keys is tracked as a follow-up issue. Until then, set them via WP-CLI:
```bash
wp --allow-root --path=/var/www/extrachill.com network meta update 1 ec_concert_import_setlistfm_api_key 'YOUR_KEY'
```

Each adapter's `is_configured()` short-circuits the source in the UI so users see a "not yet available" state until the keys are provisioned.

## Idempotency

The `c8c_ec_concert_tracking` table's `UNIQUE KEY (user_id, event_id, blog_id)` makes re-marking a no-op. `ec_users_mark_event()` returns `false` when a match already exists; the orchestrator still counts those toward `total_events_matched` so the summary tells an honest "X shows in your history" story rather than splitting "new" vs "already there" hairs.

## Abilities (REST + chat + CLI surface)

| Ability slug | Purpose |
|---|---|
| `extrachill/list-concert-import-sources` | Enumerate registered sources + per-user saved username. |
| `extrachill/preview-concert-import` | One-shot username probe; returns total event count for the confirmation dialog. |
| `extrachill/start-concert-import` | Insert run row, enqueue first AS action. Blocks concurrent runs per (user, source). |
| `extrachill/get-concert-import-status` | Return current user's runs (polled by UI). |

## Schema

```sql
CREATE TABLE c8c_ec_concert_import_runs (
  id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
  user_id bigint(20) unsigned NOT NULL,
  source_slug varchar(64) NOT NULL,
  status varchar(32) NOT NULL DEFAULT 'pending', -- pending|running|paused|complete|failed
  external_username varchar(190) DEFAULT NULL,
  next_page int unsigned DEFAULT 1,
  next_attempt_at datetime DEFAULT NULL,
  requests_today int unsigned NOT NULL DEFAULT 0,
  requests_today_date date DEFAULT NULL,
  total_events_seen int unsigned NOT NULL DEFAULT 0,
  total_events_matched int unsigned NOT NULL DEFAULT 0,
  total_events_unmatched int unsigned NOT NULL DEFAULT 0,
  total_events_skipped int unsigned NOT NULL DEFAULT 0,
  total_pages int unsigned DEFAULT NULL,
  error_message text DEFAULT NULL,
  started_at datetime DEFAULT NULL,
  updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
  completed_at datetime DEFAULT NULL,
  PRIMARY KEY (id),
  KEY idx_user_started (user_id, started_at),
  KEY idx_status (status),
  KEY idx_user_source_status (user_id, source_slug, status)
);
```

Installed via `dbDelta` on activation and via the `admin_init` fallback for pre-existing installs (matches the pattern used by `c8c_ec_concert_tracking`).

## Per-user credentials

Username for each source lives in user meta:
- `ec_concert_import_setlistfm_username`
- `ec_concert_import_phishnet_username`

Auto-saved when the user first runs preview/start so re-runs prefill.

## Follow-ups (out of scope)

- Admin settings UI in extrachill-admin-tools for managing the network API keys.
- API key procurement (Chris): setlist.fm developer key + phish.net API key.
- Unmatched-events review UI (manual match / submit to moderation).
- Additional sources (last.fm, songkick, manual CSV).
- Continuous sync (auto-pull new attendances on a schedule).

## Companion PRs

- extrachill-api: REST routes wrapping these abilities.
- extrachill-events: Import tab UI in the concert-stats block.

## What NOT changed

- No edits to `wp-content/plugins/` directly.
- No edits to `CHANGELOG.md` (homeboy owns it).
- No version bumps (conventional commits feed homeboy at release time).
- No `ec_users_mark_event` changes — its existing idempotency contract is what makes re-imports safe.