### PR TITLE
fix(concert-import): scope sources to configured-only, create missing events, migrate to Data Machine auth (closes #54)

### DIFF
--- a/inc/concert-tracking/import-db.php
+++ b/inc/concert-tracking/import-db.php
@@ -14,6 +14,18 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
+ * Schema version. Bump whenever the table's column set changes so the
+ * `admin_init` fallback in activation.php re-runs dbDelta to apply the
+ * new columns on existing installs.
+ *
+ *  1 — initial schema (0.13.0)
+ *  2 — adds `total_events_created` column (0.14.0, fixes #54)
+ */
+if ( ! defined( 'EXTRACHILL_USERS_CONCERT_IMPORT_RUNS_SCHEMA_VERSION' ) ) {
+	define( 'EXTRACHILL_USERS_CONCERT_IMPORT_RUNS_SCHEMA_VERSION', '2' );
+}
+
+/**
  * Get the concert import runs table name.
  *
  * Network-scoped (lives under $wpdb->base_prefix) so a single user can have
@@ -58,6 +70,7 @@ function extrachill_users_install_concert_import_runs_table() {
 		requests_today_date date DEFAULT NULL,
 		total_events_seen int unsigned NOT NULL DEFAULT 0,
 		total_events_matched int unsigned NOT NULL DEFAULT 0,
+		total_events_created int unsigned NOT NULL DEFAULT 0,
 		total_events_unmatched int unsigned NOT NULL DEFAULT 0,
 		total_events_skipped int unsigned NOT NULL DEFAULT 0,
 		total_pages int unsigned DEFAULT NULL,

--- a/inc/concert-tracking/import/EventCreator.php
+++ b/inc/concert-tracking/import/EventCreator.php
@@ -1,0 +1,318 @@
+<?php
+/**
+ * Create internal `data_machine_events` posts from ExternalEvent payloads
+ * when the matcher finds nothing to link to.
+ *
+ * Why this exists:
+ *
+ * The whole point of importing a user's setlist.fm / phish.net history is to
+ * bring their attendance record into Extra Chill. Skipping shows we don't
+ * already have = silently losing data the user wanted us to import. Every
+ * other event-import path on the platform (Ticketmaster, Dice.fm,
+ * UniversalWebScraper) creates events. Concert-import does the same.
+ *
+ * The creator runs from the orchestrator after EventMatcher returns null AND
+ * after an external_id idempotency lookup against `_dm_import_external_id`
+ * post_meta also returns null. It always operates inside a
+ * `switch_to_blog( events_blog )` context — managed by the orchestrator.
+ *
+ * What the creator does NOT do:
+ *
+ * - Geocoding: venue addresses are written as `_venue_address` meta and the
+ *   data-machine-events background sweep picks them up. Inline geocoding
+ *   would block the import on a slow / unavailable Nominatim — not worth the
+ *   latency cost for an import that can take days anyway.
+ * - Schedule / rescheduling: the orchestrator owns Action Scheduler state.
+ *
+ * @package ExtraChill\Users\Concert_Import
+ * @since 0.14.0
+ */
+
+namespace ExtraChill\Users\Concert_Import;
+
+defined( 'ABSPATH' ) || exit;
+
+final class EventCreator {
+
+	public const META_IMPORT_SOURCE      = '_dm_import_source';
+	public const META_IMPORT_EXTERNAL_ID = '_dm_import_external_id';
+
+	/**
+	 * Look up a previously-imported event by stable (source, external_id).
+	 *
+	 * Used by the orchestrator BEFORE running EventMatcher's similarity-based
+	 * lookup. external_id is more authoritative than venue/artist similarity
+	 * because it's a direct round-trip identifier from the source. Re-imports
+	 * are no-ops as long as this check fires first.
+	 *
+	 * Caller must already be inside the events-blog switch_to_blog context.
+	 *
+	 * @param string $source_slug Source slug stored in `_dm_import_source`
+	 *                            (e.g. 'setlist-fm', 'phish-net').
+	 * @param string $external_id Stable external identifier from the source.
+	 * @return int|null Post ID, or null when no matching post exists.
+	 */
+	public static function find_by_external_id( string $source_slug, string $external_id ): ?int {
+		$source_slug = trim( $source_slug );
+		$external_id = trim( $external_id );
+
+		if ( '' === $source_slug || '' === $external_id ) {
+			return null;
+		}
+
+		$query = new \WP_Query(
+			array(
+				'post_type'              => 'data_machine_events',
+				'post_status'            => array( 'publish', 'draft', 'pending', 'future' ),
+				'posts_per_page'         => 1,
+				'fields'                 => 'ids',
+				'no_found_rows'          => true,
+				'update_post_term_cache' => false,
+				'update_post_meta_cache' => false,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Lookup must hit meta; the (source, external_id) pair is unique enough that the query is fast in practice.
+				'meta_query'             => array(
+					'relation' => 'AND',
+					array(
+						'key'   => self::META_IMPORT_SOURCE,
+						'value' => $source_slug,
+					),
+					array(
+						'key'   => self::META_IMPORT_EXTERNAL_ID,
+						'value' => $external_id,
+					),
+				),
+			)
+		);
+
+		if ( empty( $query->posts ) ) {
+			return null;
+		}
+
+		return (int) $query->posts[0];
+	}
+
+	/**
+	 * Create a `data_machine_events` post from an ExternalEvent.
+	 *
+	 * Caller must already be inside the events-blog switch_to_blog context.
+	 * Returns the new post ID on success, or null on failure.
+	 *
+	 * Side effects:
+	 *   - Inserts a `datamachine_event_dates` row at midnight UTC on the
+	 *     source-reported date (the source typically only carries a calendar
+	 *     date, not a time).
+	 *   - Find-or-creates the venue term and assigns it to the post. Uses
+	 *     `DataMachineEvents\Core\Venue_Taxonomy::find_or_create_venue()` when
+	 *     available so address-based dedupe matches the existing creation paths
+	 *     (Ticketmaster, Dice.fm, scraper) — and falls back to `wp_insert_term`
+	 *     when the helper is not loaded.
+	 *   - Find-or-creates the artist term and assigns it. The artist taxonomy
+	 *     has no public find-or-create helper, so we use `wp_insert_term`
+	 *     directly with smart-lookup variations.
+	 *   - Stamps `_dm_import_source` + `_dm_import_external_id` for audit and
+	 *     idempotency on re-import.
+	 *
+	 * @param ExternalEvent $event       Normalized source payload.
+	 * @param string        $source_slug Source slug (e.g. 'setlist-fm').
+	 * @return int|null Post ID on success, null on failure.
+	 */
+	public static function create( ExternalEvent $event, string $source_slug ): ?int {
+		if ( ! $event->is_matchable() ) {
+			return null;
+		}
+
+		$title = self::format_title( $event );
+		if ( '' === $title ) {
+			return null;
+		}
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'data_machine_events',
+				'post_status' => 'publish',
+				'post_title'  => $title,
+			),
+			true
+		);
+
+		if ( is_wp_error( $post_id ) || ! $post_id ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Concert import: failed to create event post',
+				array(
+					'source_slug' => $source_slug,
+					'event'       => $event->label(),
+					'error'       => is_wp_error( $post_id ) ? $post_id->get_error_message() : 'unknown',
+				)
+			);
+			return null;
+		}
+
+		$post_id = (int) $post_id;
+
+		// Stamp audit + idempotency meta FIRST so even a partial creation
+		// (no venue/artist) is still discoverable by external_id and won't be
+		// re-created on the next pass.
+		update_post_meta( $post_id, self::META_IMPORT_SOURCE, sanitize_text_field( $source_slug ) );
+		if ( '' !== $event->source_id ) {
+			update_post_meta( $post_id, self::META_IMPORT_EXTERNAL_ID, sanitize_text_field( $event->source_id ) );
+		}
+
+		// Insert the event-dates row. The source only carries a calendar
+		// date — we anchor at midnight UTC on that date. Downstream date
+		// rendering treats this as an all-day show.
+		$start_datetime = $event->date . ' 00:00:00';
+		if ( class_exists( '\\DataMachineEvents\\Core\\EventDatesTable' ) ) {
+			\DataMachineEvents\Core\EventDatesTable::upsert( $post_id, $start_datetime, null, 'publish' );
+		}
+
+		// Find-or-create the venue.
+		$venue_term_id = self::ensure_venue_term( $event );
+		if ( $venue_term_id ) {
+			wp_set_object_terms( $post_id, array( (int) $venue_term_id ), 'venue', false );
+		}
+
+		// Find-or-create the artist.
+		$artist_term_id = self::ensure_artist_term( $event );
+		if ( $artist_term_id ) {
+			wp_set_object_terms( $post_id, array( (int) $artist_term_id ), 'artist', false );
+		}
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Concert import: created event from external payload',
+			array(
+				'post_id'     => $post_id,
+				'source_slug' => $source_slug,
+				'external_id' => $event->source_id,
+				'title'       => $title,
+			)
+		);
+
+		return $post_id;
+	}
+
+	/**
+	 * Build a human-readable event title from the external payload.
+	 *
+	 * Format: "<Headliner> at <Venue> · <Pretty Date>". Falls back gracefully
+	 * if any field is missing. Mirrors how existing concert-stats UI labels
+	 * events.
+	 */
+	private static function format_title( ExternalEvent $event ): string {
+		$pretty_date = '';
+		if ( '' !== $event->date ) {
+			$ts          = strtotime( $event->date . ' 00:00:00 UTC' );
+			$pretty_date = $ts ? gmdate( 'F j, Y', $ts ) : $event->date;
+		}
+
+		$parts = array();
+		if ( '' !== $event->headliner ) {
+			$parts[] = $event->headliner;
+		}
+		if ( '' !== $event->venue_name ) {
+			$parts[] = ( $parts ? 'at ' : '' ) . $event->venue_name;
+		}
+
+		$prefix = implode( ' ', $parts );
+		if ( '' === $prefix ) {
+			$prefix = 'Concert';
+		}
+
+		return '' !== $pretty_date ? $prefix . ' · ' . $pretty_date : $prefix;
+	}
+
+	/**
+	 * Find or create the venue term for this event.
+	 *
+	 * Prefers data-machine-events' canonical helper (address-based dedupe +
+	 * smart name variations), and falls back to wp_insert_term when the
+	 * events plugin's class is not loaded.
+	 *
+	 * Sets `_venue_address` meta on the term when address-ish fields are
+	 * present in the payload so the background geocoding sweep can fill in
+	 * lat/lng without blocking the import.
+	 */
+	private static function ensure_venue_term( ExternalEvent $event ): ?int {
+		if ( '' === $event->venue_name ) {
+			return null;
+		}
+
+		$venue_data = array(
+			'city'    => $event->city,
+			'state'   => $event->state,
+			'country' => $event->country,
+			'address' => '',
+		);
+
+		if ( class_exists( '\\DataMachineEvents\\Core\\Venue_Taxonomy' ) ) {
+			$result = \DataMachineEvents\Core\Venue_Taxonomy::find_or_create_venue(
+				$event->venue_name,
+				$venue_data
+			);
+			$term_id = isset( $result['term_id'] ) ? (int) $result['term_id'] : 0;
+		} else {
+			$existing = get_term_by( 'name', $event->venue_name, 'venue' );
+			if ( $existing && ! is_wp_error( $existing ) ) {
+				$term_id = (int) $existing->term_id;
+			} else {
+				$inserted = wp_insert_term( $event->venue_name, 'venue' );
+				$term_id  = is_wp_error( $inserted ) ? 0 : (int) ( $inserted['term_id'] ?? 0 );
+			}
+		}
+
+		if ( ! $term_id ) {
+			return null;
+		}
+
+		// Mark for background geocoding via the existing `_venue_address`
+		// pattern when we have any address-ish fields. The sweep treats
+		// city/state/country as enough to seed a Nominatim query.
+		$address_line = trim( implode( ', ', array_filter( array( $event->city, $event->state, $event->country ) ) ) );
+		if ( '' !== $address_line ) {
+			$existing_address = (string) get_term_meta( $term_id, '_venue_address', true );
+			if ( '' === $existing_address ) {
+				update_term_meta( $term_id, '_venue_address', $address_line );
+			}
+		}
+
+		return $term_id;
+	}
+
+	/**
+	 * Find or create the artist term for this event.
+	 *
+	 * The artist taxonomy doesn't ship a public find-or-create helper, so we
+	 * implement the same smart-lookup pattern locally (exact name, then with /
+	 * without "The " prefix).
+	 */
+	private static function ensure_artist_term( ExternalEvent $event ): ?int {
+		if ( '' === $event->headliner ) {
+			return null;
+		}
+
+		$name = $event->headliner;
+
+		$existing = get_term_by( 'name', $name, 'artist' );
+
+		if ( ! $existing ) {
+			$alt = ( stripos( $name, 'The ' ) === 0 ) ? substr( $name, 4 ) : 'The ' . $name;
+			if ( $alt ) {
+				$existing = get_term_by( 'name', $alt, 'artist' );
+			}
+		}
+
+		if ( $existing && ! is_wp_error( $existing ) ) {
+			return (int) $existing->term_id;
+		}
+
+		$inserted = wp_insert_term( $name, 'artist' );
+		if ( is_wp_error( $inserted ) ) {
+			return null;
+		}
+
+		return isset( $inserted['term_id'] ) ? (int) $inserted['term_id'] : null;
+	}
+}

--- a/inc/concert-tracking/import/ImportOrchestrator.php
+++ b/inc/concert-tracking/import/ImportOrchestrator.php
@@ -196,41 +196,82 @@ final class ImportOrchestrator {
 		$total_pages  = isset( $result['total_pages'] ) ? max( 1, (int) $result['total_pages'] ) : $page;
 		$matcher      = new EventMatcher();
 		$events_blog  = $matcher->blog_id();
+		$source_slug  = (string) $run['source_slug'];
 
 		$seen      = 0;
 		$matched   = 0;
+		$created   = 0;
 		$unmatched = 0;
 		$skipped   = 0;
 
-		foreach ( $events as $external ) {
-			if ( ! $external instanceof ExternalEvent ) {
-				++$skipped;
-				continue;
-			}
-			++$seen;
+		// All event resolution + creation happens in the events-blog context.
+		// Switching once per page keeps the work atomic and avoids paying the
+		// switch_to_blog cost per-event. The EventMatcher will detect that we
+		// are already in the events blog and skip its own switch.
+		$switched     = false;
+		$current_blog = get_current_blog_id();
+		if ( $current_blog !== $events_blog ) {
+			switch_to_blog( $events_blog );
+			$switched = true;
+		}
 
-			if ( ! $external->is_matchable() ) {
-				++$skipped;
-				continue;
-			}
+		try {
+			foreach ( $events as $external ) {
+				if ( ! $external instanceof ExternalEvent ) {
+					++$skipped;
+					continue;
+				}
+				++$seen;
 
-			$matched_id = $matcher->match( $external );
-			if ( null === $matched_id ) {
-				++$unmatched;
-				continue;
-			}
+				if ( ! $external->is_matchable() ) {
+					++$skipped;
+					continue;
+				}
 
-			$newly_marked = ec_users_mark_event( (int) $run['user_id'], $matched_id, $events_blog );
-			if ( $newly_marked ) {
-				++$matched;
-			} else {
-				// Already marked — still counts toward "matched" totals so the
-				// user-facing summary reports an honest match count.
-				++$matched;
+				// 1. external_id idempotency check. The source's stable
+				//    identifier is more authoritative than name similarity, so
+				//    we look here BEFORE running the similarity matcher.
+				//    Re-imports for previously-created events become a no-op.
+				$resolved_id = EventCreator::find_by_external_id( $source_slug, $external->source_id );
+
+				// 2. Similarity match against existing events on the same date.
+				if ( null === $resolved_id ) {
+					$resolved_id = $matcher->match( $external );
+				}
+
+				$was_created = false;
+
+				// 3. Fall through to create. Skipping is data loss — every
+				//    other event-import path on the platform creates events,
+				//    and we already have the user's confirmation to bring this
+				//    history in.
+				if ( null === $resolved_id ) {
+					$resolved_id = EventCreator::create( $external, $source_slug );
+					if ( null === $resolved_id ) {
+						// Truly couldn't create (malformed payload, insert
+						// failure). Count as unmatched so it shows up in the
+						// run summary instead of being lost in skipped.
+						++$unmatched;
+						continue;
+					}
+					$was_created = true;
+				}
+
+				ec_users_mark_event( (int) $run['user_id'], $resolved_id, $events_blog );
+
+				if ( $was_created ) {
+					++$created;
+				} else {
+					++$matched;
+				}
+			}
+		} finally {
+			if ( $switched ) {
+				restore_current_blog();
 			}
 		}
 
-		self::increment_counters( $run_id, $seen, $matched, $unmatched, $skipped );
+		self::increment_counters( $run_id, $seen, $matched, $created, $unmatched, $skipped );
 		self::update_run(
 			$run_id,
 			array(
@@ -365,7 +406,7 @@ final class ImportOrchestrator {
 		$wpdb->update( $table, $changes, array( 'id' => $run_id ) );
 	}
 
-	private static function increment_counters( int $run_id, int $seen, int $matched, int $unmatched, int $skipped ): void {
+	private static function increment_counters( int $run_id, int $seen, int $matched, int $created, int $unmatched, int $skipped ): void {
 		global $wpdb;
 		$table = extrachill_users_concert_import_runs_table_name();
 		$now   = current_time( 'mysql', true );
@@ -375,12 +416,14 @@ final class ImportOrchestrator {
 				"UPDATE {$table}
 				SET total_events_seen      = total_events_seen      + %d,
 				    total_events_matched   = total_events_matched   + %d,
+				    total_events_created   = total_events_created   + %d,
 				    total_events_unmatched = total_events_unmatched + %d,
 				    total_events_skipped   = total_events_skipped   + %d,
 				    updated_at             = %s
 				WHERE id = %d",
 				$seen,
 				$matched,
+				$created,
 				$unmatched,
 				$skipped,
 				$now,

--- a/inc/concert-tracking/import/Sources/ConcertImportAuthProvider.php
+++ b/inc/concert-tracking/import/Sources/ConcertImportAuthProvider.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Base auth provider for concert-import sources.
+ *
+ * Each concert-import source (setlist.fm, phish.net, …) stores a single
+ * platform-wide API key. The key is held in Data Machine's encrypted auth
+ * envelope so credentials live at rest with the same AES-256-GCM protection
+ * used by every other Data Machine handler, and so they show up in the
+ * `wp datamachine auth ...` CLI surface.
+ *
+ * Each concrete subclass owns a unique provider slug (e.g.
+ * `ec_concert_import_setlist_fm`). One key per slug. No `account`/`username`
+ * fan-out — single-key sources don't need it.
+ *
+ * Storage layout (`get_site_option( 'datamachine_auth_data' )`):
+ *
+ *   [
+ *       'ec_concert_import_setlist_fm' => [
+ *           'config' => [ 'api_key' => 'dm:enc:v1:...:...:...' ],
+ *       ],
+ *       'ec_concert_import_phish_net' => [
+ *           'config' => [ 'api_key' => 'dm:enc:v1:...:...:...' ],
+ *       ],
+ *   ]
+ *
+ * `api_key` is added to the encrypted-fields list via the
+ * `datamachine_auth_encrypted_fields` filter (see register_encryption()).
+ *
+ * @package ExtraChill\Users\Concert_Import
+ * @since 0.14.0
+ */
+
+namespace ExtraChill\Users\Concert_Import\Sources;
+
+use DataMachine\Core\OAuth\BaseAuthProvider;
+
+defined( 'ABSPATH' ) || exit;
+
+abstract class ConcertImportAuthProvider extends BaseAuthProvider {
+
+	/**
+	 * Configurable field name used for credential entry + retrieval.
+	 *
+	 * Kept as `api_key` (not `password`) because the CLI / admin UI surfaces
+	 * the field label directly — `api_key` reads correctly for this kind of
+	 * platform-wide credential.
+	 */
+	public const CREDENTIAL_FIELD = 'api_key';
+
+	/**
+	 * Configuration fields surfaced via `wp datamachine auth config <slug> ...`.
+	 *
+	 * Single field. No account/username — these sources have one platform-wide
+	 * key, not per-account credentials.
+	 */
+	public function get_config_fields(): array {
+		return array(
+			self::CREDENTIAL_FIELD => array(
+				'label'       => __( 'API Key', 'extrachill-users' ),
+				'type'        => 'password',
+				'required'    => true,
+				'description' => __( 'Platform-wide API key for this concert import source.', 'extrachill-users' ),
+			),
+		);
+	}
+
+	/**
+	 * Whether a usable credential is stored.
+	 *
+	 * Stored at the site-level config slot so the credential is shared across
+	 * the multisite network. Concert tracking is network-scoped; the credential
+	 * is too.
+	 */
+	public function is_authenticated(): bool {
+		return '' !== $this->get_api_key();
+	}
+
+	/**
+	 * Return the decrypted API key, or empty string when none is configured.
+	 *
+	 * Reads the site-level config slot. Decryption happens inside
+	 * BaseAuthProvider::get_config().
+	 */
+	public function get_api_key(): string {
+		$config = $this->get_config();
+		$value  = isset( $config[ self::CREDENTIAL_FIELD ] ) ? (string) $config[ self::CREDENTIAL_FIELD ] : '';
+		return trim( $value );
+	}
+
+	/**
+	 * Register all concert-import auth providers with the Data Machine registry
+	 * and mark `api_key` as encrypted-at-rest for each one.
+	 *
+	 * Idempotent — safe to call multiple times.
+	 */
+	public static function register_with_datamachine(): void {
+		add_filter(
+			'datamachine_auth_providers',
+			static function ( $providers ) {
+				if ( ! is_array( $providers ) ) {
+					$providers = array();
+				}
+				$slug = SetlistFmAuthProvider::PROVIDER_SLUG;
+				$providers[ $slug ] = $providers[ $slug ] ?? new SetlistFmAuthProvider();
+
+				$slug = PhishNetAuthProvider::PROVIDER_SLUG;
+				$providers[ $slug ] = $providers[ $slug ] ?? new PhishNetAuthProvider();
+
+				return $providers;
+			}
+		);
+
+		add_filter(
+			'datamachine_auth_encrypted_fields',
+			static function ( array $fields, string $provider_slug ): array {
+				if ( in_array(
+					$provider_slug,
+					array( SetlistFmAuthProvider::PROVIDER_SLUG, PhishNetAuthProvider::PROVIDER_SLUG ),
+					true
+				) ) {
+					$fields[] = self::CREDENTIAL_FIELD;
+				}
+
+				return $fields;
+			},
+			10,
+			2
+		);
+	}
+}

--- a/inc/concert-tracking/import/Sources/PhishNetAuthProvider.php
+++ b/inc/concert-tracking/import/Sources/PhishNetAuthProvider.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * phish.net Data Machine auth provider.
+ *
+ * Holds the encrypted platform-wide phish.net API key. Discoverable via
+ * `wp datamachine auth status` and managed via
+ * `wp datamachine auth config ec_concert_import_phish_net --api_key=...`.
+ *
+ * @package ExtraChill\Users\Concert_Import
+ * @since 0.14.0
+ */
+
+namespace ExtraChill\Users\Concert_Import\Sources;
+
+defined( 'ABSPATH' ) || exit;
+
+final class PhishNetAuthProvider extends ConcertImportAuthProvider {
+
+	public const PROVIDER_SLUG = 'ec_concert_import_phish_net';
+
+	public function __construct() {
+		parent::__construct( self::PROVIDER_SLUG );
+	}
+}

--- a/inc/concert-tracking/import/Sources/PhishNetImportSource.php
+++ b/inc/concert-tracking/import/Sources/PhishNetImportSource.php
@@ -15,9 +15,13 @@
  * Because the response is not paginated, our orchestrator only makes one
  * request per run. The framework still drives this through page=1 / total_pages=1.
  *
- * Platform-wide API key from network option
- * `ec_concert_import_phishnet_api_key`. Constant
- * `EC_CONCERT_IMPORT_PHISHNET_API_KEY` overrides in non-prod.
+ * Platform-wide API key is held in Data Machine's encrypted auth envelope
+ * under the `ec_concert_import_phish_net` provider slug. Manage it via:
+ *
+ *   wp datamachine auth config ec_concert_import_phish_net --api_key=...
+ *
+ * Credentials are encrypted at rest (AES-256-GCM) and discoverable through
+ * `wp datamachine auth status`.
  *
  * @package ExtraChill\Users\Concert_Import
  * @since 0.13.0
@@ -32,10 +36,8 @@ defined( 'ABSPATH' ) || exit;
 
 final class PhishNetImportSource implements ImportSource {
 
-	public const SLUG             = 'phish-net';
-	public const API_BASE         = 'https://api.phish.net/v5';
-	public const OPTION_API_KEY   = 'ec_concert_import_phishnet_api_key';
-	public const CONSTANT_API_KEY = 'EC_CONCERT_IMPORT_PHISHNET_API_KEY';
+	public const SLUG     = 'phish-net';
+	public const API_BASE = 'https://api.phish.net/v5';
 
 	public function slug(): string {
 		return self::SLUG;
@@ -189,14 +191,12 @@ final class PhishNetImportSource implements ImportSource {
 		);
 	}
 
+	/**
+	 * Read the platform-wide phish.net API key from the Data Machine auth
+	 * provider. Returns empty string when no credential has been provisioned.
+	 */
 	private function get_api_key(): string {
-		if ( defined( self::CONSTANT_API_KEY ) ) {
-			$constant_value = constant( self::CONSTANT_API_KEY );
-			if ( is_string( $constant_value ) && '' !== $constant_value ) {
-				return $constant_value;
-			}
-		}
-		$value = get_site_option( self::OPTION_API_KEY, '' );
-		return is_string( $value ) ? trim( $value ) : '';
+		$provider = new PhishNetAuthProvider();
+		return $provider->get_api_key();
 	}
 }

--- a/inc/concert-tracking/import/Sources/SetlistFmAuthProvider.php
+++ b/inc/concert-tracking/import/Sources/SetlistFmAuthProvider.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * setlist.fm Data Machine auth provider.
+ *
+ * Holds the encrypted platform-wide setlist.fm API key. Discoverable via
+ * `wp datamachine auth status` and managed via
+ * `wp datamachine auth config ec_concert_import_setlist_fm --api_key=...`.
+ *
+ * @package ExtraChill\Users\Concert_Import
+ * @since 0.14.0
+ */
+
+namespace ExtraChill\Users\Concert_Import\Sources;
+
+defined( 'ABSPATH' ) || exit;
+
+final class SetlistFmAuthProvider extends ConcertImportAuthProvider {
+
+	public const PROVIDER_SLUG = 'ec_concert_import_setlist_fm';
+
+	public function __construct() {
+		parent::__construct( self::PROVIDER_SLUG );
+	}
+}

--- a/inc/concert-tracking/import/Sources/SetlistFmImportSource.php
+++ b/inc/concert-tracking/import/Sources/SetlistFmImportSource.php
@@ -9,10 +9,13 @@
  *  - Rate limits: 2 req/sec, 1440 req/day (free tier).
  *  - Accept: application/json.
  *
- * Platform-wide API key is read from the network option
- * `ec_concert_import_setlistfm_api_key` (admin UI to manage this is tracked
- * in a follow-up issue; the constant `EC_CONCERT_IMPORT_SETLISTFM_API_KEY`
- * is honored as an override for staging environments).
+ * Platform-wide API key is held in Data Machine's encrypted auth envelope
+ * under the `ec_concert_import_setlist_fm` provider slug. Manage it via:
+ *
+ *   wp datamachine auth config ec_concert_import_setlist_fm --api_key=...
+ *
+ * Credentials are encrypted at rest (AES-256-GCM) and discoverable through
+ * `wp datamachine auth status`.
  *
  * @package ExtraChill\Users\Concert_Import
  * @since 0.13.0
@@ -27,10 +30,8 @@ defined( 'ABSPATH' ) || exit;
 
 final class SetlistFmImportSource implements ImportSource {
 
-	public const SLUG               = 'setlist-fm';
-	public const API_BASE           = 'https://api.setlist.fm/rest/1.0';
-	public const OPTION_API_KEY     = 'ec_concert_import_setlistfm_api_key';
-	public const CONSTANT_API_KEY   = 'EC_CONCERT_IMPORT_SETLISTFM_API_KEY';
+	public const SLUG     = 'setlist-fm';
+	public const API_BASE = 'https://api.setlist.fm/rest/1.0';
 
 	public function slug(): string {
 		return self::SLUG;
@@ -203,14 +204,12 @@ final class SetlistFmImportSource implements ImportSource {
 		return '';
 	}
 
+	/**
+	 * Read the platform-wide setlist.fm API key from the Data Machine auth
+	 * provider. Returns empty string when no credential has been provisioned.
+	 */
 	private function get_api_key(): string {
-		if ( defined( self::CONSTANT_API_KEY ) ) {
-			$constant_value = constant( self::CONSTANT_API_KEY );
-			if ( is_string( $constant_value ) && '' !== $constant_value ) {
-				return $constant_value;
-			}
-		}
-		$value = get_site_option( self::OPTION_API_KEY, '' );
-		return is_string( $value ) ? trim( $value ) : '';
+		$provider = new SetlistFmAuthProvider();
+		return $provider->get_api_key();
 	}
 }

--- a/inc/concert-tracking/import/bootstrap.php
+++ b/inc/concert-tracking/import/bootstrap.php
@@ -17,11 +17,31 @@ require_once __DIR__ . '/ExternalEvent.php';
 require_once __DIR__ . '/ImportSource.php';
 require_once __DIR__ . '/EventMatcher.php';
 require_once __DIR__ . '/ImportOrchestrator.php';
+require_once __DIR__ . '/EventCreator.php';
+require_once __DIR__ . '/Sources/ConcertImportAuthProvider.php';
+require_once __DIR__ . '/Sources/SetlistFmAuthProvider.php';
+require_once __DIR__ . '/Sources/PhishNetAuthProvider.php';
 require_once __DIR__ . '/Sources/SetlistFmImportSource.php';
 require_once __DIR__ . '/Sources/PhishNetImportSource.php';
 
 // Register the Action Scheduler worker hook.
 \ExtraChill\Users\Concert_Import\ImportOrchestrator::register_hooks();
+
+// Register each source's API key with Data Machine's encrypted auth provider
+// registry. This makes the credentials discoverable via
+// `wp datamachine auth status` and encrypts them at rest via the standard
+// AES-256-GCM envelope. Wired on plugins_loaded so Data Machine has finished
+// declaring its base classes.
+add_action(
+	'plugins_loaded',
+	static function () {
+		if ( ! class_exists( '\\DataMachine\\Core\\OAuth\\BaseAuthProvider' ) ) {
+			return;
+		}
+		\ExtraChill\Users\Concert_Import\Sources\ConcertImportAuthProvider::register_with_datamachine();
+	},
+	30
+);
 
 // Register default sources.
 add_filter(

--- a/inc/core/abilities/concert-import.php
+++ b/inc/core/abilities/concert-import.php
@@ -33,7 +33,13 @@ function extrachill_users_register_concert_import_abilities() {
 			'category'            => 'extrachill-users',
 			'input_schema'        => array(
 				'type'       => 'object',
-				'properties' => new stdClass(),
+				'properties' => array(
+					'include_unconfigured' => array(
+						'type'        => 'boolean',
+						'description' => 'When true, include sources whose API key has not been provisioned. Admins only. Defaults to false so end users never see "API key not configured" plumbing.',
+						'default'     => false,
+					),
+				),
 			),
 			'output_schema'       => array(
 				'type'       => 'object',
@@ -208,6 +214,7 @@ function extrachill_users_shape_concert_import_run( array $run ): array {
 		'requests_today_date'    => $run['requests_today_date'] ?: null,
 		'total_events_seen'      => (int) ( $run['total_events_seen'] ?? 0 ),
 		'total_events_matched'   => (int) ( $run['total_events_matched'] ?? 0 ),
+		'total_events_created'   => (int) ( $run['total_events_created'] ?? 0 ),
 		'total_events_unmatched' => (int) ( $run['total_events_unmatched'] ?? 0 ),
 		'total_events_skipped'   => (int) ( $run['total_events_skipped'] ?? 0 ),
 		'started_at'             => $run['started_at'] ?: null,
@@ -227,9 +234,17 @@ function extrachill_users_ability_list_concert_import_sources( array $input ) {
 		return new WP_Error( 'not_logged_in', 'You must be logged in.', array( 'status' => 401 ) );
 	}
 
+	// Admins can ask to see unconfigured sources for setup / debugging. End
+	// users never see "not yet available" plumbing — they only see sources
+	// they can actually use.
+	$include_unconfigured = ! empty( $input['include_unconfigured'] ) && current_user_can( 'manage_options' );
+
 	$sources = ImportOrchestrator::sources();
 	$out     = array();
 	foreach ( $sources as $source ) {
+		if ( ! $include_unconfigured && ! $source->is_configured() ) {
+			continue;
+		}
 		$out[] = extrachill_users_shape_concert_import_source( $source, $user_id );
 	}
 

--- a/inc/core/activation.php
+++ b/inc/core/activation.php
@@ -239,19 +239,32 @@ function extrachill_users_maybe_create_concert_tracking_table() {
 add_action( 'admin_init', 'extrachill_users_maybe_create_concert_tracking_table' );
 
 /**
- * Ensure concert import runs table exists.
- * Fallback for existing installations where the table was added after activation.
+ * Ensure concert import runs table exists and is on the current schema version.
+ *
+ * Re-runs dbDelta whenever EXTRACHILL_USERS_CONCERT_IMPORT_RUNS_SCHEMA_VERSION
+ * (defined in import-db.php) is bumped. dbDelta is the canonical add-column
+ * upgrade path — adding `total_events_created` only needs the schema string
+ * updated and the version bumped.
  */
 function extrachill_users_maybe_create_concert_import_runs_table() {
-	if ( get_site_option( 'extrachill_users_concert_import_runs_table_created' ) ) {
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/import-db.php';
+
+	$current_version = defined( 'EXTRACHILL_USERS_CONCERT_IMPORT_RUNS_SCHEMA_VERSION' )
+		? (string) EXTRACHILL_USERS_CONCERT_IMPORT_RUNS_SCHEMA_VERSION
+		: '1';
+
+	$installed_version = (string) get_site_option( 'extrachill_users_concert_import_runs_schema_version', '' );
+
+	if ( $installed_version === $current_version ) {
 		return;
 	}
 
-	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/import-db.php';
 	if ( function_exists( 'extrachill_users_install_concert_import_runs_table' ) ) {
 		extrachill_users_install_concert_import_runs_table();
 	}
 
+	update_site_option( 'extrachill_users_concert_import_runs_schema_version', $current_version );
+	// Maintain the legacy flag so any external code that checks it keeps working.
 	update_site_option( 'extrachill_users_concert_import_runs_table_created', 1 );
 }
 add_action( 'admin_init', 'extrachill_users_maybe_create_concert_import_runs_table' );

--- a/tests/unit/ConcertImportAuthProviderTest.php
+++ b/tests/unit/ConcertImportAuthProviderTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Unit tests for the concert-import Data Machine auth provider integration.
+ *
+ * These tests exercise the provider/source contract that replaces the old
+ * hand-rolled `OPTION_API_KEY` / `CONSTANT_API_KEY` storage (fixed in #54).
+ *
+ * The tests work against the real BaseAuthProvider storage path so we
+ * actually verify encryption + decryption round-trip through the same
+ * envelope used in production. WP_UnitTestCase ensures wp_salt('auth') is
+ * available so the AES-256-GCM key derivation succeeds.
+ */
+
+use ExtraChill\Users\Concert_Import\Sources\ConcertImportAuthProvider;
+use ExtraChill\Users\Concert_Import\Sources\PhishNetAuthProvider;
+use ExtraChill\Users\Concert_Import\Sources\PhishNetImportSource;
+use ExtraChill\Users\Concert_Import\Sources\SetlistFmAuthProvider;
+use ExtraChill\Users\Concert_Import\Sources\SetlistFmImportSource;
+
+class Test_Concert_Import_Auth_Provider extends WP_UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		if ( ! class_exists( '\\DataMachine\\Core\\OAuth\\BaseAuthProvider' ) ) {
+			$this->markTestSkipped( 'Data Machine BaseAuthProvider is not available in this test run.' );
+		}
+		ConcertImportAuthProvider::register_with_datamachine();
+		// Reset the shared auth storage between tests.
+		delete_site_option( 'datamachine_auth_data' );
+	}
+
+	protected function tearDown(): void {
+		delete_site_option( 'datamachine_auth_data' );
+		parent::tearDown();
+	}
+
+	public function test_setlist_source_is_not_configured_when_no_api_key_is_stored(): void {
+		$source = new SetlistFmImportSource();
+		$this->assertFalse(
+			$source->is_configured(),
+			'SetlistFmImportSource::is_configured() must return false when no auth ref is configured.'
+		);
+	}
+
+	public function test_phishnet_source_is_not_configured_when_no_api_key_is_stored(): void {
+		$source = new PhishNetImportSource();
+		$this->assertFalse(
+			$source->is_configured(),
+			'PhishNetImportSource::is_configured() must return false when no auth ref is configured.'
+		);
+	}
+
+	public function test_setlist_source_reads_api_key_from_data_machine_auth_provider(): void {
+		$provider = new SetlistFmAuthProvider();
+		$provider->save_config( array( 'api_key' => 'secret-setlist-key' ) );
+
+		$source = new SetlistFmImportSource();
+		$this->assertTrue(
+			$source->is_configured(),
+			'SetlistFmImportSource::is_configured() must return true once a key is stored via the auth provider.'
+		);
+
+		// Round-trip the key through a second provider instance to prove decryption works.
+		$round_trip = ( new SetlistFmAuthProvider() )->get_api_key();
+		$this->assertSame( 'secret-setlist-key', $round_trip );
+	}
+
+	public function test_phishnet_source_reads_api_key_from_data_machine_auth_provider(): void {
+		$provider = new PhishNetAuthProvider();
+		$provider->save_config( array( 'api_key' => 'secret-phish-key' ) );
+
+		$source = new PhishNetImportSource();
+		$this->assertTrue( $source->is_configured() );
+
+		$round_trip = ( new PhishNetAuthProvider() )->get_api_key();
+		$this->assertSame( 'secret-phish-key', $round_trip );
+	}
+
+	public function test_api_key_is_stored_encrypted_at_rest(): void {
+		$provider = new SetlistFmAuthProvider();
+		$provider->save_config( array( 'api_key' => 'plaintext-key' ) );
+
+		$raw = get_site_option( 'datamachine_auth_data', array() );
+		$stored = $raw[ SetlistFmAuthProvider::PROVIDER_SLUG ]['config']['api_key'] ?? '';
+
+		$this->assertNotEmpty( $stored, 'API key must be persisted.' );
+		$this->assertStringStartsWith(
+			'dm:enc:v1:',
+			$stored,
+			'API key must be stored in the Data Machine encryption envelope, not as plaintext in wp_sitemeta.'
+		);
+		$this->assertStringNotContainsString(
+			'plaintext-key',
+			$stored,
+			'Plaintext API key value must never appear in the persisted record.'
+		);
+	}
+
+	public function test_get_config_fields_advertises_a_single_api_key_field(): void {
+		$provider = new SetlistFmAuthProvider();
+		$fields   = $provider->get_config_fields();
+
+		$this->assertArrayHasKey( 'api_key', $fields, 'Provider must expose `api_key` to the auth CLI.' );
+		$this->assertSame( 'password', $fields['api_key']['type'] ?? '' );
+		$this->assertTrue( ! empty( $fields['api_key']['required'] ) );
+
+		// No leftover account/username from HttpBasicAuthProvider — these
+		// sources have one platform-wide credential, not a per-account fan-out.
+		$this->assertArrayNotHasKey( 'account', $fields );
+		$this->assertArrayNotHasKey( 'username', $fields );
+	}
+
+	public function test_separate_sources_use_distinct_provider_slots(): void {
+		( new SetlistFmAuthProvider() )->save_config( array( 'api_key' => 'setlist-only' ) );
+		( new PhishNetAuthProvider() )->save_config( array( 'api_key' => 'phish-only' ) );
+
+		$this->assertSame( 'setlist-only', ( new SetlistFmAuthProvider() )->get_api_key() );
+		$this->assertSame( 'phish-only',   ( new PhishNetAuthProvider() )->get_api_key() );
+
+		// Storage layout: each provider gets its own top-level key.
+		$raw = get_site_option( 'datamachine_auth_data', array() );
+		$this->assertArrayHasKey( SetlistFmAuthProvider::PROVIDER_SLUG, $raw );
+		$this->assertArrayHasKey( PhishNetAuthProvider::PROVIDER_SLUG, $raw );
+	}
+}

--- a/tests/unit/EventCreatorTest.php
+++ b/tests/unit/EventCreatorTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Unit tests for EventCreator's idempotency lookup + (where feasible without
+ * a full events-blog fixture) basic event-creation behaviour.
+ *
+ * These tests target the new "create on miss" path added in #54. The full
+ * end-to-end create flow needs the events subsite with venue/artist
+ * taxonomies registered — exercising that here would require booting the
+ * data-machine-events plugin and switching to the events blog. Instead we:
+ *
+ *  1. Exercise `EventCreator::find_by_external_id()` against an event we
+ *     stamp directly with the audit/idempotency meta.
+ *  2. Exercise `EventCreator::create()` happy path in the current blog, then
+ *     verify the audit meta was written. The taxonomies-not-registered
+ *     branches degrade gracefully (no terms set) — that's intentional so the
+ *     orchestrator still records the import even when run outside the events
+ *     blog in test contexts.
+ */
+
+use ExtraChill\Users\Concert_Import\EventCreator;
+use ExtraChill\Users\Concert_Import\ExternalEvent;
+
+class Test_Event_Creator extends WP_UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		if ( ! post_type_exists( 'data_machine_events' ) ) {
+			register_post_type(
+				'data_machine_events',
+				array(
+					'public'  => false,
+					'show_ui' => false,
+				)
+			);
+		}
+	}
+
+	public function test_find_by_external_id_returns_null_when_no_match_exists(): void {
+		$this->assertNull(
+			EventCreator::find_by_external_id( 'setlist-fm', 'nonexistent-id' )
+		);
+	}
+
+	public function test_find_by_external_id_returns_null_for_empty_inputs(): void {
+		$this->assertNull( EventCreator::find_by_external_id( '', 'whatever' ) );
+		$this->assertNull( EventCreator::find_by_external_id( 'setlist-fm', '' ) );
+	}
+
+	public function test_find_by_external_id_locates_a_previously_imported_event(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'data_machine_events',
+				'post_status' => 'publish',
+				'post_title'  => 'Imported Show',
+			)
+		);
+		update_post_meta( $post_id, EventCreator::META_IMPORT_SOURCE, 'setlist-fm' );
+		update_post_meta( $post_id, EventCreator::META_IMPORT_EXTERNAL_ID, 'abc-123' );
+
+		$this->assertSame(
+			$post_id,
+			EventCreator::find_by_external_id( 'setlist-fm', 'abc-123' )
+		);
+	}
+
+	public function test_find_by_external_id_scopes_to_the_correct_source(): void {
+		// A phish.net show with the same external_id as a hypothetical
+		// setlist.fm show must not collide — sources have independent
+		// id namespaces.
+		$phish_post = self::factory()->post->create(
+			array(
+				'post_type'   => 'data_machine_events',
+				'post_status' => 'publish',
+			)
+		);
+		update_post_meta( $phish_post, EventCreator::META_IMPORT_SOURCE, 'phish-net' );
+		update_post_meta( $phish_post, EventCreator::META_IMPORT_EXTERNAL_ID, 'shared-id' );
+
+		$this->assertSame(
+			$phish_post,
+			EventCreator::find_by_external_id( 'phish-net', 'shared-id' )
+		);
+		$this->assertNull(
+			EventCreator::find_by_external_id( 'setlist-fm', 'shared-id' ),
+			'External ids are scoped per source and must not cross-match.'
+		);
+	}
+
+	public function test_create_returns_null_for_unmatchable_payload(): void {
+		// Missing venue_name → not matchable → no creation.
+		$event = new ExternalEvent(
+			array(
+				'date'      => '2024-06-01',
+				'headliner' => 'Some Band',
+				'source_id' => 'no-venue',
+			)
+		);
+		$this->assertNull( EventCreator::create( $event, 'setlist-fm' ) );
+	}
+
+	public function test_create_writes_audit_meta_and_returns_post_id(): void {
+		$event = new ExternalEvent(
+			array(
+				'date'       => '2024-06-15',
+				'venue_name' => 'Test Venue',
+				'city'       => 'Charleston',
+				'state'      => 'SC',
+				'country'    => 'United States',
+				'headliner'  => 'Test Band',
+				'source_id'  => 'created-by-test-123',
+			)
+		);
+
+		$post_id = EventCreator::create( $event, 'setlist-fm' );
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
+
+		$this->assertSame(
+			'setlist-fm',
+			get_post_meta( $post_id, EventCreator::META_IMPORT_SOURCE, true )
+		);
+		$this->assertSame(
+			'created-by-test-123',
+			get_post_meta( $post_id, EventCreator::META_IMPORT_EXTERNAL_ID, true )
+		);
+
+		// The newly-stamped event must now be discoverable via external_id —
+		// this is the idempotency contract that prevents re-imports from
+		// duplicating events.
+		$this->assertSame(
+			$post_id,
+			EventCreator::find_by_external_id( 'setlist-fm', 'created-by-test-123' )
+		);
+	}
+}

--- a/tests/unit/ListConcertImportSourcesAbilityTest.php
+++ b/tests/unit/ListConcertImportSourcesAbilityTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Unit tests for the `extrachill/list-concert-import-sources` ability's
+ * end-user filtering (#54, Fix 1).
+ *
+ * End users must never see unconfigured sources — "API key not configured"
+ * is platform plumbing, not actionable UX. Admins can explicitly request the
+ * unconfigured list for setup/debugging.
+ */
+
+use ExtraChill\Users\Concert_Import\ImportSource;
+use ExtraChill\Users\Concert_Import\ExternalEvent;
+
+/**
+ * Tiny in-memory ImportSource used to flip is_configured() per test.
+ *
+ * Lives inside this test file so we don't pollute the source tree with a
+ * test-only fixture class.
+ */
+final class FakeConfigurableImportSource implements ImportSource {
+
+	public function __construct(
+		private string $slug,
+		private string $label,
+		private bool $configured
+	) {
+	}
+
+	public function slug(): string {
+		return $this->slug;
+	}
+	public function label(): string {
+		return $this->label;
+	}
+	public function rate_limit(): array {
+		return array( 'requests_per_second' => 1.0, 'requests_per_day' => 1000 );
+	}
+	public function is_configured(): bool {
+		return $this->configured;
+	}
+	public function preview( string $username ) {
+		return array( 'total' => 0, 'username' => $username );
+	}
+	public function fetch_page( string $username, int $page ) {
+		return array( 'events' => array(), 'total_pages' => 1, 'total' => 0, 'page' => 1 );
+	}
+}
+
+class Test_List_Concert_Import_Sources_Ability extends WP_UnitTestCase {
+
+	/**
+	 * @var int
+	 */
+	private int $user_id;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $this->user_id );
+
+		// Replace registered sources with controlled fakes so the test owns
+		// the configured/unconfigured matrix.
+		add_filter( 'extrachill_concert_import_sources', array( $this, 'replace_sources' ), 999 );
+	}
+
+	protected function tearDown(): void {
+		remove_filter( 'extrachill_concert_import_sources', array( $this, 'replace_sources' ), 999 );
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	public function replace_sources( $sources ): array {
+		return array(
+			new FakeConfigurableImportSource( 'configured-source', 'Configured Source', true ),
+			new FakeConfigurableImportSource( 'unconfigured-source', 'Unconfigured Source', false ),
+		);
+	}
+
+	public function test_end_user_only_sees_configured_sources(): void {
+		$result = extrachill_users_ability_list_concert_import_sources( array() );
+
+		$this->assertArrayHasKey( 'sources', $result );
+		$slugs = array_map( static fn( $s ) => $s['slug'], $result['sources'] );
+
+		$this->assertContains( 'configured-source', $slugs );
+		$this->assertNotContains(
+			'unconfigured-source',
+			$slugs,
+			'End users must not see unconfigured import sources — "not configured" is admin plumbing.'
+		);
+	}
+
+	public function test_subscriber_cannot_override_filter_with_include_unconfigured(): void {
+		// Subscribers do not have `manage_options`. Passing the flag must be
+		// silently ignored so end users can't bypass the filter.
+		$result = extrachill_users_ability_list_concert_import_sources(
+			array( 'include_unconfigured' => true )
+		);
+		$slugs = array_map( static fn( $s ) => $s['slug'], $result['sources'] );
+
+		$this->assertNotContains(
+			'unconfigured-source',
+			$slugs,
+			'Non-admin callers must not be able to surface unconfigured sources by passing the flag.'
+		);
+	}
+
+	public function test_admin_with_flag_sees_all_sources(): void {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$result = extrachill_users_ability_list_concert_import_sources(
+			array( 'include_unconfigured' => true )
+		);
+		$slugs = array_map( static fn( $s ) => $s['slug'], $result['sources'] );
+
+		$this->assertContains( 'configured-source', $slugs );
+		$this->assertContains( 'unconfigured-source', $slugs );
+	}
+
+	public function test_admin_without_flag_still_sees_only_configured(): void {
+		// Admin power is opt-in: omitting the flag means the admin gets the
+		// same view an end user would. Avoids accidentally surfacing
+		// unconfigured sources in normal admin browsing.
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$result = extrachill_users_ability_list_concert_import_sources( array() );
+		$slugs  = array_map( static fn( $s ) => $s['slug'], $result['sources'] );
+
+		$this->assertContains( 'configured-source', $slugs );
+		$this->assertNotContains( 'unconfigured-source', $slugs );
+	}
+}


### PR DESCRIPTION
## Summary

Closes #54. Three cohesive fixes to the concert-import framework after v0.13.0 hit live production with no API keys provisioned.

### Fix 1 — UI no longer leaks platform plumbing to end users

`extrachill/list-concert-import-sources` filters out sources whose `is_configured()` returns false. End users only see actionable sources. Admins can opt in to the full list with `include_unconfigured=true` (gated by `manage_options`) for setup / debugging.

- Subscriber passing the flag → flag is silently ignored.
- Admin without the flag → still only sees configured sources (opt-in admin power).
- Admin with the flag → sees everything.

### Fix 2 — Unmatched events are CREATED, not skipped

Skipping a user's tracked-show data was silent data loss. The orchestrator now resolves each external event via three layered steps:

1. **`_dm_import_external_id` idempotency lookup** — re-imports for previously-created events are a no-op. The source's stable id is more authoritative than name similarity, so this fires *before* the matcher.
2. **`EventMatcher` similarity match** — unchanged 85% threshold against existing same-date events.
3. **`EventCreator::create()`** — publishes a `data_machine_events` post, inserts the `datamachine_event_dates` row, find-or-creates venue + artist terms (uses `Venue_Taxonomy::find_or_create_venue()` when data-machine-events is loaded; falls back to `wp_insert_term` otherwise), and stamps `_dm_import_source` + `_dm_import_external_id` meta for audit and re-import idempotency.

Venue geocoding is **intentionally not inline** — venue meta is marked via `_venue_address` and the existing background sweep handles it. Inline Nominatim would block the import on a slow/unavailable upstream for no good reason given the import already takes days.

New `total_events_created` counter added to `ec_concert_import_runs`. Schema is upgraded via `dbDelta` driven by a new `EXTRACHILL_USERS_CONCERT_IMPORT_RUNS_SCHEMA_VERSION` option so existing installs pick up the column on `admin_init`. The orchestrator switches to the events blog **once per page** (not per event) for both the lookup and the create paths — `EventMatcher` detects it's already in the events blog and skips its own switch.

Intro copy in the React UI updated from "Shows we can't find will be skipped" to "Shows we don't already have we'll add for you so your full history comes in." (Companion PR in `extrachill-events`.)

### Fix 3 — API keys migrate to Data Machine's `BaseAuthProvider` system

Drops the hand-rolled `OPTION_API_KEY` + `CONSTANT_API_KEY` pattern that stored credentials in **plaintext in `wp_sitemeta`**.

**Auth provider choice:** I built a new `ConcertImportAuthProvider` base class extending `BaseAuthProvider` directly rather than reusing `HttpBasicAuthProvider`. Rationale: `HttpBasicAuthProvider`'s `get_config_fields()` ships `account`/`username`/`password`/`proxy_url`. We have one platform-wide key per source — no per-account fan-out, no username, no proxy. Forcing the key into the `password` slot of a `username`-required schema would confuse the CLI/UI and add a useless required field. The new base is ~120 lines and matches the actual shape (single `api_key` field, `password`-typed). I did **not** file a new `ApiKeyAuthProvider` against `data-machine` — that would be premature with one consumer (us). If a second platform-wide-API-key handler shows up in `data-machine` proper, that's the time to upstream the abstraction.

Two concrete providers ship:
- `SetlistFmAuthProvider` (slug `ec_concert_import_setlist_fm`)
- `PhishNetAuthProvider` (slug `ec_concert_import_phish_net`)

Each registers a single required `api_key` field added to the `datamachine_auth_encrypted_fields` filter so it round-trips through the AES-256-GCM envelope at rest. Credentials are now discoverable through `wp datamachine auth status` and managed via `wp datamachine auth config <slug> --api_key=...`.

**Hard cutover** — no legacy `get_site_option()` fallback, no migration code (no keys exist in production yet).

## Verification matrix

```
# 1. Confirm providers are registered.
wp --allow-root --path=/var/www/extrachill.com datamachine auth status \
  | grep ec_concert_import

# Expected:
# ec_concert_import_setlist_fm  direct  no   no  —  —
# ec_concert_import_phish_net   direct  no   no  —  —

# 2. End user sees no Import tab when no keys are provisioned.
curl -s -b "wordpress_logged_in_*=…" \
  https://extrachill.com/wp-json/wp-abilities/v1/abilities/extrachill%2Flist-concert-import-sources/run \
  -X POST -H 'Content-Type: application/json' --data '{"input":{}}'
# Expected: { "sources": [] }

# 3. Provision a key and re-fetch.
wp --allow-root --path=/var/www/extrachill.com datamachine auth config \
  ec_concert_import_setlist_fm --api_key=TESTKEY123

# Re-run step 2 → setlist-fm now appears, configured=true.

# 4. Confirm encrypted at rest.
wp --allow-root --path=/var/www/extrachill.com network meta get 1 datamachine_auth_data \
  | grep -o 'dm:enc:v1:[^"]*' | head -1
# Expected: a dm:enc:v1:base64:base64:base64 envelope.

# 5. Admin override.
curl -s -b "wordpress_logged_in_*=admincookie…" \
  https://extrachill.com/wp-json/wp-abilities/v1/abilities/extrachill%2Flist-concert-import-sources/run \
  -X POST -H 'Content-Type: application/json' \
  --data '{"input":{"include_unconfigured":true}}'
# Expected: both setlist-fm and phish-net listed.

# 6. Layer-purity grep (must return 0).
grep -riE 'setlist|phish|concert-import' \
  /var/lib/datamachine/workspace/data-machine-events/inc/
```

## Files

- `inc/concert-tracking/import/Sources/ConcertImportAuthProvider.php` (new)
- `inc/concert-tracking/import/Sources/SetlistFmAuthProvider.php` (new)
- `inc/concert-tracking/import/Sources/PhishNetAuthProvider.php` (new)
- `inc/concert-tracking/import/Sources/SetlistFmImportSource.php` — reads from auth provider
- `inc/concert-tracking/import/Sources/PhishNetImportSource.php` — reads from auth provider
- `inc/concert-tracking/import/EventCreator.php` (new) — creates + idempotency lookup
- `inc/concert-tracking/import/ImportOrchestrator.php` — three-step resolve, page-scoped switch_to_blog
- `inc/concert-tracking/import/bootstrap.php` — registers providers + new files
- `inc/concert-tracking/import-db.php` — adds `total_events_created`, schema version
- `inc/core/abilities/concert-import.php` — filter unconfigured for end users, shape the new counter
- `inc/core/activation.php` — schema-version-driven re-run
- `tests/unit/ConcertImportAuthProviderTest.php` (new)
- `tests/unit/EventCreatorTest.php` (new)
- `tests/unit/ListConcertImportSourcesAbilityTest.php` (new)

## Companion PR

`extrachill-events` will get a follow-up PR for the React UI (gate Import tab on `hasImports`, drop disabled-source rendering paths, surface the new `total_events_created` counter, update the intro copy). I'll open it after this one merges so the ability behavior is live first.

mention @chubes when ready for review.