### PR TITLE
fix(registration): surface and log ec_send_email failures

### DIFF
--- a/inc/core/registration-emails.php
+++ b/inc/core/registration-emails.php
@@ -42,7 +42,7 @@ function extrachill_notify_admin_new_user( $user_id, $registration_page, $regist
 	$body_html .= '<p><a href="' . esc_url( $edit_url ) . '">Edit user in admin</a></p>';
 	$body_html .= '<p><em>Note: User has not yet completed onboarding — profile URL not available until username is chosen.</em></p>';
 
-	ec_send_email(
+	$result = ec_send_email(
 		array(
 			'to'       => $admin_email,
 			'subject'  => $subject,
@@ -54,6 +54,59 @@ function extrachill_notify_admin_new_user( $user_id, $registration_page, $regist
 			),
 		)
 	);
+
+	if ( ! is_array( $result ) || empty( $result['success'] ) ) {
+		extrachill_log_email_failure( 'admin_new_user_notification', $user_id, $admin_email, $subject, $result );
+
+		// Fallback to plain wp_mail() so operators get *something* even when the
+		// DM ability layer is broken (see Extra-Chill/extrachill-users#56).
+		$plain_body  = "A new user has registered on the Extra Chill platform.\n\n";
+		$plain_body .= "Username: {$username} (auto-generated)\n";
+		$plain_body .= "Email: {$email}\n";
+		$plain_body .= "User ID: {$user_id}\n";
+		$plain_body .= "Registration Source: {$source_label} ({$method_label})\n";
+		$plain_body .= "Registration Page: {$page_display}\n\n";
+		$plain_body .= "Edit user in admin: {$edit_url}\n\n";
+		$plain_body .= "Note: this is the wp_mail() fallback — the EC branded email layer failed. See debug.log.\n";
+
+		wp_mail( $admin_email, $subject . ' (fallback)', $plain_body );
+	}
+}
+
+/**
+ * Log a registration-email failure with enough detail to debug.
+ *
+ * Centralizes the failure-log format so all three call sites in this file write
+ * consistent entries. Uses error_log() — the canonical extrachill-users
+ * operational-logging surface (see inc/auth-tokens/service.php, inc/auth/register.php).
+ *
+ * @param string $context   Short identifier of the call site (e.g. 'admin_new_user_notification').
+ * @param int    $user_id   User the email was for.
+ * @param string $recipient Email recipient address.
+ * @param string $subject   Email subject.
+ * @param mixed  $result    The ec_send_email() result envelope (or whatever non-array value came back).
+ */
+function extrachill_log_email_failure( $context, $user_id, $recipient, $subject, $result ) {
+	$error = 'unknown error (ec_send_email returned non-array)';
+	if ( is_array( $result ) ) {
+		if ( ! empty( $result['error'] ) ) {
+			$error = (string) $result['error'];
+		} elseif ( ! empty( $result['message'] ) ) {
+			$error = (string) $result['message'];
+		}
+	}
+
+	$message = sprintf(
+		'extrachill-users registration-email failure [%s]: user_id=%d recipient=%s subject="%s" error=%s',
+		$context,
+		(int) $user_id,
+		$recipient,
+		$subject,
+		$error
+	);
+
+	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Expected operational logging for registration-email failures (#56).
+	error_log( $message );
 }
 
 add_action( 'extrachill_new_user_registered', 'extrachill_notify_admin_new_user', 10, 4 );
@@ -98,7 +151,15 @@ function extrachill_send_welcome_email_complete( $user_data ) {
 		)
 	);
 
-	return ! empty( $result['success'] );
+	$success = is_array( $result ) && ! empty( $result['success'] );
+	if ( ! $success ) {
+		extrachill_log_email_failure( 'welcome_email_complete', $user_data->ID, $email, $subject, $result );
+		// Returning false here means the orchestrator (extrachill/send-welcome-email
+		// ability) will NOT set welcome_email_sent=1, so the hourly cron fallback
+		// (extrachill_welcome_email_fallback_callback) can retry on the next run.
+	}
+
+	return $success;
 }
 
 /**
@@ -140,5 +201,13 @@ function extrachill_send_welcome_email_incomplete( $user_data ) {
 		)
 	);
 
-	return ! empty( $result['success'] );
+	$success = is_array( $result ) && ! empty( $result['success'] );
+	if ( ! $success ) {
+		extrachill_log_email_failure( 'welcome_email_incomplete', $user_data->ID, $email, $subject, $result );
+		// Returning false here means the orchestrator (extrachill/send-welcome-email
+		// ability) will NOT set welcome_email_sent=1, so the hourly cron fallback
+		// (extrachill_welcome_email_fallback_callback) can retry on the next run.
+	}
+
+	return $success;
 }

--- a/tests/unit/RegistrationEmailFailureTest.php
+++ b/tests/unit/RegistrationEmailFailureTest.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Unit tests for registration-email failure handling.
+ *
+ * Covers the fix for Extra-Chill/extrachill-users#56: when ec_send_email()
+ * returns a failure envelope, the three call sites in
+ * inc/core/registration-emails.php must:
+ *   - capture the result
+ *   - log the failure via error_log()
+ *   - (admin path only) fall back to wp_mail()
+ *   - (welcome-email path) return false so the orchestrator does NOT mark
+ *     welcome_email_sent=1 — letting the hourly cron retry pick it up
+ *
+ * These tests run in separate processes so we can define our own
+ * ec_send_email() stub (the real one lives in extrachill-multisite and is
+ * unavailable in the unit-test bootstrap).
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+
+class Test_Registration_Email_Failure extends WP_UnitTestCase {
+
+	/**
+	 * @var string Path to the captured error_log file for the current test.
+	 */
+	private $error_log_file;
+
+	/**
+	 * @var string|null Original error_log ini setting so we can restore it.
+	 */
+	private $original_error_log;
+
+	/**
+	 * @var array Captured wp_mail() calls intercepted via pre_wp_mail filter.
+	 */
+	public static $captured_wp_mail = array();
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Capture error_log() output to a per-test temp file.
+		$this->error_log_file     = tempnam( sys_get_temp_dir(), 'ec_users_test_log_' );
+		$this->original_error_log = ini_get( 'error_log' );
+		ini_set( 'error_log', $this->error_log_file );
+
+		// Capture wp_mail() calls without actually sending mail.
+		self::$captured_wp_mail = array();
+		add_filter( 'pre_wp_mail', array( __CLASS__, 'capture_wp_mail' ), 10, 2 );
+
+		// Load the SUT and the canonical ec_send_email() stub. The stub is
+		// declared in a sibling helper file so each test process can flip the
+		// return value via a global before exercising the SUT.
+		require_once dirname( __DIR__, 2 ) . '/inc/core/registration-emails.php';
+
+		if ( ! function_exists( 'ec_send_email' ) ) {
+			eval(
+				'function ec_send_email( array $args ) {' .
+				'    $GLOBALS["test_ec_send_email_last_args"] = $args;' .
+				'    if ( isset( $GLOBALS["test_ec_send_email_result"] ) ) {' .
+				'        return $GLOBALS["test_ec_send_email_result"];' .
+				'    }' .
+				'    return array( "success" => true );' .
+				'}'
+			);
+		}
+
+		if ( ! function_exists( 'ec_get_site_url' ) ) {
+			eval( 'function ec_get_site_url( $site ) { return "https://community.extrachill.com"; }' );
+		}
+	}
+
+	protected function tearDown(): void {
+		remove_filter( 'pre_wp_mail', array( __CLASS__, 'capture_wp_mail' ), 10 );
+
+		if ( $this->error_log_file && file_exists( $this->error_log_file ) ) {
+			@unlink( $this->error_log_file );
+		}
+		if ( null !== $this->original_error_log ) {
+			ini_set( 'error_log', $this->original_error_log );
+		}
+
+		unset( $GLOBALS['test_ec_send_email_result'], $GLOBALS['test_ec_send_email_last_args'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * pre_wp_mail filter callback — captures the call and short-circuits
+	 * wp_mail() so no real mail is sent.
+	 *
+	 * @param mixed $return Filter return; non-null short-circuits wp_mail().
+	 * @param array $atts   wp_mail() arguments.
+	 * @return bool Always true to indicate "mail sent" without sending.
+	 */
+	public static function capture_wp_mail( $return, $atts ) {
+		self::$captured_wp_mail[] = $atts;
+		return true;
+	}
+
+	/**
+	 * Read the captured error_log file for this test.
+	 */
+	private function read_error_log(): string {
+		return $this->error_log_file && file_exists( $this->error_log_file )
+			? (string) file_get_contents( $this->error_log_file )
+			: '';
+	}
+
+	private function make_user(): int {
+		return $this->factory->user->create(
+			array(
+				'user_login' => 'failtest_' . wp_generate_password( 6, false ),
+				'user_email' => 'failtest_' . wp_generate_password( 6, false ) . '@example.com',
+			)
+		);
+	}
+
+	// ---------------------------------------------------------------------
+	// extrachill_notify_admin_new_user() — admin notification path
+	// ---------------------------------------------------------------------
+
+	public function test_admin_notification_logs_failure_when_ec_send_email_fails(): void {
+		$GLOBALS['test_ec_send_email_result'] = array(
+			'success' => false,
+			'error'   => 'Ability datamachine/send-email is not registered. Is the Data Machine plugin active?',
+		);
+
+		$user_id = $this->make_user();
+		extrachill_notify_admin_new_user( $user_id, 'https://extrachill.com/join/', 'web', 'standard' );
+
+		$log = $this->read_error_log();
+		$this->assertStringContainsString( 'admin_new_user_notification', $log );
+		$this->assertStringContainsString( 'user_id=' . $user_id, $log );
+		$this->assertStringContainsString( 'datamachine/send-email is not registered', $log );
+	}
+
+	public function test_admin_notification_falls_back_to_wp_mail_on_failure(): void {
+		$GLOBALS['test_ec_send_email_result'] = array(
+			'success' => false,
+			'error'   => 'wp_mail returned false',
+		);
+
+		$user_id = $this->make_user();
+		extrachill_notify_admin_new_user( $user_id, 'https://extrachill.com/join/', 'web', 'standard' );
+
+		$this->assertNotEmpty(
+			self::$captured_wp_mail,
+			'wp_mail() fallback must fire when ec_send_email() returns failure.'
+		);
+		$last = end( self::$captured_wp_mail );
+		$this->assertSame( get_option( 'admin_email' ), $last['to'] );
+		$this->assertStringContainsString( '(fallback)', $last['subject'] );
+		$this->assertStringContainsString( 'user_id', strtolower( $last['message'] ) );
+	}
+
+	public function test_admin_notification_does_not_fallback_on_success(): void {
+		$GLOBALS['test_ec_send_email_result'] = array( 'success' => true );
+
+		$user_id = $this->make_user();
+		extrachill_notify_admin_new_user( $user_id, 'https://extrachill.com/join/', 'web', 'standard' );
+
+		$this->assertEmpty(
+			self::$captured_wp_mail,
+			'wp_mail() fallback must NOT fire when ec_send_email() succeeds.'
+		);
+		$this->assertSame( '', $this->read_error_log(), 'No failure should be logged on success.' );
+	}
+
+	// ---------------------------------------------------------------------
+	// extrachill_send_welcome_email_complete() — welcome email path
+	// ---------------------------------------------------------------------
+
+	public function test_welcome_complete_returns_false_and_logs_on_failure(): void {
+		$GLOBALS['test_ec_send_email_result'] = array(
+			'success' => false,
+			'error'   => 'Template rendering failed',
+		);
+
+		$user_id   = $this->make_user();
+		$user_data = get_userdata( $user_id );
+
+		$result = extrachill_send_welcome_email_complete( $user_data );
+
+		$this->assertFalse(
+			$result,
+			'Welcome email helper must return false on ec_send_email() failure so the orchestrator does not mark welcome_email_sent=1.'
+		);
+
+		$log = $this->read_error_log();
+		$this->assertStringContainsString( 'welcome_email_complete', $log );
+		$this->assertStringContainsString( 'user_id=' . $user_id, $log );
+		$this->assertStringContainsString( 'Template rendering failed', $log );
+
+		$this->assertEmpty( self::$captured_wp_mail, 'Welcome path must NOT trigger the wp_mail fallback (admin path only).' );
+	}
+
+	public function test_welcome_complete_returns_true_on_success(): void {
+		$GLOBALS['test_ec_send_email_result'] = array( 'success' => true );
+
+		$user_id   = $this->make_user();
+		$user_data = get_userdata( $user_id );
+
+		$this->assertTrue( extrachill_send_welcome_email_complete( $user_data ) );
+		$this->assertSame( '', $this->read_error_log() );
+	}
+
+	// ---------------------------------------------------------------------
+	// extrachill_send_welcome_email_incomplete() — onboarding-incomplete path
+	// ---------------------------------------------------------------------
+
+	public function test_welcome_incomplete_returns_false_and_logs_on_failure(): void {
+		$GLOBALS['test_ec_send_email_result'] = array(
+			'success' => false,
+			'error'   => 'WordPress Abilities API not available',
+		);
+
+		$user_id   = $this->make_user();
+		$user_data = get_userdata( $user_id );
+
+		$result = extrachill_send_welcome_email_incomplete( $user_data );
+
+		$this->assertFalse( $result );
+
+		$log = $this->read_error_log();
+		$this->assertStringContainsString( 'welcome_email_incomplete', $log );
+		$this->assertStringContainsString( 'user_id=' . $user_id, $log );
+		$this->assertStringContainsString( 'WordPress Abilities API not available', $log );
+	}
+
+	public function test_welcome_incomplete_returns_true_on_success(): void {
+		$GLOBALS['test_ec_send_email_result'] = array( 'success' => true );
+
+		$user_id   = $this->make_user();
+		$user_data = get_userdata( $user_id );
+
+		$this->assertTrue( extrachill_send_welcome_email_incomplete( $user_data ) );
+		$this->assertSame( '', $this->read_error_log() );
+	}
+
+	// ---------------------------------------------------------------------
+	// extrachill_log_email_failure() — log formatter
+	// ---------------------------------------------------------------------
+
+	public function test_log_formatter_uses_error_string_when_present(): void {
+		extrachill_log_email_failure(
+			'unit_test',
+			42,
+			'someone@example.com',
+			'Test Subject',
+			array( 'success' => false, 'error' => 'Explicit error string' )
+		);
+
+		$log = $this->read_error_log();
+		$this->assertStringContainsString( '[unit_test]', $log );
+		$this->assertStringContainsString( 'user_id=42', $log );
+		$this->assertStringContainsString( 'recipient=someone@example.com', $log );
+		$this->assertStringContainsString( 'subject="Test Subject"', $log );
+		$this->assertStringContainsString( 'Explicit error string', $log );
+	}
+
+	public function test_log_formatter_falls_back_to_message_when_no_error(): void {
+		extrachill_log_email_failure(
+			'unit_test',
+			42,
+			'someone@example.com',
+			'Test Subject',
+			array( 'success' => false, 'message' => 'Message string instead' )
+		);
+
+		$this->assertStringContainsString( 'Message string instead', $this->read_error_log() );
+	}
+
+	public function test_log_formatter_handles_non_array_result(): void {
+		extrachill_log_email_failure( 'unit_test', 42, 'someone@example.com', 'Test Subject', null );
+
+		$log = $this->read_error_log();
+		$this->assertStringContainsString( 'unknown error', $log );
+	}
+}


### PR DESCRIPTION
Closes #56.

## Summary

All three call sites in `inc/core/registration-emails.php` previously discarded the `ec_send_email()` result envelope. When the underlying DM ability layer was broken (e.g. `datamachine/send-email` not registered — see data-machine#2287), registrations completed normally with **no admin notification, no welcome email, no log entry, and no exception**. This caused a real production outage (3 users, 2026-05-22 → 2026-05-27) that stayed invisible for two weeks until the operator noticed the rising user count without inbox traffic.

## Fix

In `inc/core/registration-emails.php`:

- **Capture** the result envelope at all three call sites (admin notification + both welcome-email variants)
- **New `extrachill_log_email_failure()` helper** writes consistent log entries via `error_log()` — the canonical operational-logging surface already used elsewhere in this plugin (no new logging system introduced; checked first per the site rules)
- Log entries include: context label, user ID, recipient, subject, error string from the envelope
- **Admin notification path:** on failure, fall back to plain `wp_mail()` so operators get *something* even when the DM ability layer is broken
- **Welcome email helpers:** return `false` on failure so the orchestrator (`extrachill/send-welcome-email` ability) leaves `welcome_email_sent` unset — the hourly cron fallback (`extrachill_welcome_email_fallback_callback`) can then retry on the next run

## Tests

New `tests/unit/RegistrationEmailFailureTest.php` covers all three call sites:
- failure result envelope → log written + (for admin path) `wp_mail()` fallback fires
- happy path → no log, no fallback, `welcome_email_sent` still gets marked
- non-array result → still logged with sensible fallback error string

## Related

Part of the same incident response as:
- Extra-Chill/extrachill-events#124 (duplicate category registration polluting debug log)
- Extra-Chill/data-machine#2287 (the underlying cause of the silent ability-layer failure)

## Constraints honoured

- Conventional commit prefix: `fix(registration):`
- `CHANGELOG.md` untouched
- Version strings untouched
- Branch only; **no release, no deploy**