### PR TITLE
fix(concert-tracking): empty search query returns empty results (closes #130, users side)

### DIFF
--- a/inc/concert-tracking/service.php
+++ b/inc/concert-tracking/service.php
@@ -807,7 +807,11 @@ function ec_users_get_event_attendees( int $event_id, int $blog_id = 0, int $lim
  *   - artist taxonomy term names
  *   - venue taxonomy term names
  *
- * Empty query returns the most recent past events as suggestions.
+ * Empty query returns no results. The frontend should render a prompt
+ * encouraging the user to type a query. See extrachill-events#130 — the
+ * previous default of "most recent past events" pretended to be relevant
+ * suggestions but was just the global event firehose with zero relation
+ * to the user.
  *
  * Each returned event includes `is_marked` for the given user so the UI can
  * render a "+ Mark Attended" / "✓ Tracked" state immediately.
@@ -815,7 +819,7 @@ function ec_users_get_event_attendees( int $event_id, int $blog_id = 0, int $lim
  * @param int   $user_id User ID (for is_marked computation).
  * @param array $args {
  *     Search arguments.
- *     @type string $query     Search query. Empty returns recent past events.
+ *     @type string $query     Search query. Empty returns no results.
  *     @type int    $page      1-indexed page number. Default 1.
  *     @type int    $per_page  Results per page. Default 20.
  *     @type int    $blog_id   Blog ID. Defaults to events blog.
@@ -834,8 +838,22 @@ function ec_users_search_events_for_marking( int $user_id, array $args = array()
 
 	$args = wp_parse_args( $args, $defaults );
 
-	$query    = trim( (string) $args['query'] );
-	$page     = max( 1, (int) $args['page'] );
+	$query = trim( (string) $args['query'] );
+	$page  = max( 1, (int) $args['page'] );
+
+	// When the query is empty, return no results. The 'most recent past events'
+	// the old default returned had zero relation to the user — it pretended to be
+	// 'suggestions' but was just the global event firehose. The frontend renders
+	// an InlineStatus prompt instead. See extrachill-events#130.
+	if ( '' === $query ) {
+		return array(
+			'events' => array(),
+			'total'  => 0,
+			'pages'  => 0,
+			'page'   => $page,
+		);
+	}
+
 	$per_page = max( 1, min( 100, (int) $args['per_page'] ) );
 	$blog_id  = $args['blog_id'] ? (int) $args['blog_id'] : ( function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : 7 );
 

--- a/inc/core/abilities/concert-tracking.php
+++ b/inc/core/abilities/concert-tracking.php
@@ -206,7 +206,7 @@ function extrachill_users_register_concert_tracking_abilities() {
 				'properties' => array(
 					'query'    => array(
 						'type'        => 'string',
-						'description' => 'Search query. Empty returns most recent past events as suggestions.',
+						'description' => 'Search query. Empty returns no results; the frontend renders a prompt instead.',
 						'default'     => '',
 					),
 					'page'     => array(


### PR DESCRIPTION
## Summary

`ec_users_search_events_for_marking()` now returns empty results
immediately when the query is empty (after trim), with no DB query.

## Why

The previous behavior returned the 20 most recent past events from
anywhere in the network when the query was empty, ordered by
`start_datetime DESC`. The UI presented these as 'suggestions' — but
they were the global event firehose with zero connection to the user.
Charleston, NYC, Austin, all mixed together. Misleading affordance.

The locked decision in #130 is: default to no results, render a prompt
in the UI instead. Smart suggestions based on the user's tracked-show
affinity is a follow-up — new users have no signal yet anyway.

## The fix

```php
$query = trim( (string) $args['query'] );
$page  = max( 1, (int) $args['page'] );

if ( '' === $query ) {
    return array(
        'events' => array(),
        'total'  => 0,
        'pages'  => 0,
        'page'   => $page,
    );
}
```

Inserted before the per-page / blog-id resolution and the DB work, so
the empty-input path now also avoids the table-prefix lookup.

Also:

- Updated the function docblock to document the new contract.
- Updated the `concert-tracking-search-events-for-marking` ability
  schema description to match.

## Acceptance

- Calling `ec_users_search_events_for_marking( $uid, [ 'query' => '' ] )`
  returns `{ events: [], total: 0, pages: 0, page: 1 }` with no DB query.
- Calling with a non-empty query still searches title / artist / venue
  as before.

Closes #130 — users side. Companion PRs in `extrachill` (theme) and
`extrachill-events` (frontend prompt + button styling).