### PR TITLE
chore: bump @extrachill/components to ^0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "wp-scripts start blocks/login-register/src/index.js --output-path=build/login-register"
   },
   "dependencies": {
-    "@extrachill/components": "^0.4.50"
+    "@extrachill/components": "^0.5.2"
   },
   "devDependencies": {
     "@wordpress/scripts": "^31.1.0"


### PR DESCRIPTION
## Summary

Bumps the `@extrachill/components` dependency from `^0.4.50` to `^0.5.2` and rebuilds the plugin's block assets against the new version.

## What changed

- **Dependency**: `@extrachill/components` range `^0.4.x` (`^0.4.50`) → `^0.5.2`
- Resolved install confirmed: `@extrachill/components@0.5.2`
- Rebuilt JS/CSS assets via `npm run build` (login-register, password-reset, onboarding blocks). Note: `build/` and `package-lock.json` are gitignored in this repo, so only `package.json` appears in the diff — the rebuilt assets are produced at build/deploy time.

## Behavior changes riding along (smoke-test these)

`@extrachill/components@0.5.2` includes three behavior changes the reviewer should smoke-test on user-facing block surfaces (login/register, password reset, onboarding):

1. **BlockShellInner** narrow/wide centering fix (`margin-inline:auto`)
2. **SearchBox** canonical button classes
3. **InlineStatus/Badge** dark-mode token parity

## Build

- `npm run build` completed successfully with **no errors** across all blocks.

## Lint

- `homeboy lint extrachill-users` reports pre-existing PHPStan/JS debt (103 findings) unrelated to this change. **No new findings** are introduced by this dependency bump — the only changed file is `package.json`.