### PR TITLE
feat: capability gate + live-staging feature rollout primitives

### DIFF
--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -101,6 +101,7 @@ function extrachill_users_init() {
 	}
 	$initialized = true;
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/assets.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/gating.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/admin-access-control.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/moderation/bootstrap.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/abilities/register.php';

--- a/inc/artist-profiles.php
+++ b/inc/artist-profiles.php
@@ -87,6 +87,11 @@ function ec_get_artists_for_user( $user_id = null, $admin_override = false ) {
 /**
  * Check if user can create artist profiles
  *
+ * @deprecated-soon Slated for migration to ec_user_can( 'create_artist_profile' )
+ *                  and deletion per Extra-Chill/extrachill-users#60 (pending the
+ *                  refactor tooling in homeboy#3075). Kept as a thin compat
+ *                  function; ec_user_can() delegates here so logic has one home.
+ *
  * @param int|null $user_id User ID (defaults to current user)
  * @return bool             True if user has permission to create artist profiles
  */
@@ -169,6 +174,11 @@ function ec_get_latest_artist_for_user( $user_id = null ) {
  * - An administrator (manage_options capability)
  * - The post author of the artist profile
  * - Listed in the user's _artist_profile_ids meta (roster member)
+ *
+ * @deprecated-soon Slated for migration to ec_user_can( 'manage_artist', [ 'artist_id' => $id ] )
+ *                  and deletion per Extra-Chill/extrachill-users#60 (pending the
+ *                  refactor tooling in homeboy#3075). Kept as a thin compat
+ *                  function; ec_user_can() delegates here so logic has one home.
  *
  * @param int|null $user_id   User ID (defaults to current user)
  * @param int|null $artist_id Artist profile post ID

--- a/inc/core/gating.php
+++ b/inc/core/gating.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Capability gate + feature-rollout primitives.
+ *
+ * The single source of truth for "who can do what" (capability) and
+ * "is this feature live for this user's tier yet" (rollout). These two
+ * concerns are orthogonal and compose; they never collapse into one check:
+ *
+ *     if ( ec_feature_available( 'shop' ) && ec_user_can( 'manage_shop', [ 'artist_id' => $id ] ) ) { ... }
+ *
+ * Capability is answered by {@see ec_user_can()}. Rollout tier is answered by
+ * {@see ec_feature_available()} / {@see ec_feature_tier()}.
+ *
+ * See Extra-Chill/extrachill-users#60 for the locked design spec.
+ *
+ * @package ExtraChill\Users
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * The rollout ladder, lowest-to-highest audience.
+ *
+ * admin  → only super-admins / manage_options users.
+ * team   → admin OR extra_chill_team role (ec_is_team_member()).
+ * public → everyone who passes the feature's own base capability gate.
+ *
+ * Position in this array is the ladder order used for clamping.
+ *
+ * @return string[]
+ */
+function ec_feature_tier_ladder() {
+	return array( 'admin', 'team', 'public' );
+}
+
+/**
+ * Feature ceiling registry: feature => the MAX tier the code is ready to expose.
+ *
+ * The ceiling is a code-owned constant changed only via commit + deploy + review.
+ * The live tier (network option) can never exceed this — see ec_feature_tier().
+ *
+ * Filterable via `ec_feature_ceilings` so other plugins can register gated
+ * features without editing this file.
+ *
+ * @return array<string,string> feature slug => ceiling tier.
+ */
+function ec_feature_ceilings() {
+	$ceilings = array(
+		// Shop manager: admin-only until the system is ready for the team.
+		'shop' => 'admin',
+	);
+
+	/**
+	 * Filter the feature ceiling registry.
+	 *
+	 * Each entry maps a feature slug to the maximum rollout tier the code is
+	 * ready to expose (`admin` | `team` | `public`). The live tier stored in
+	 * the network option is always clamped to this ceiling.
+	 *
+	 * @param array<string,string> $ceilings feature slug => ceiling tier.
+	 */
+	$ceilings = apply_filters( 'ec_feature_ceilings', $ceilings );
+
+	return is_array( $ceilings ) ? $ceilings : array();
+}
+
+/**
+ * Get the code ceiling tier for a feature.
+ *
+ * Unknown features default to `admin` (the most restrictive rung) so a
+ * misconfigured or unregistered feature can never leak past admins.
+ *
+ * @param string $feature Feature slug.
+ * @return string One of `admin` | `team` | `public`.
+ */
+function ec_feature_ceiling( $feature ) {
+	$ceilings = ec_feature_ceilings();
+	$ceiling  = isset( $ceilings[ $feature ] ) ? $ceilings[ $feature ] : 'admin';
+
+	return ec_feature_tier_is_valid( $ceiling ) ? $ceiling : 'admin';
+}
+
+/**
+ * Whether a tier string is a valid rung on the ladder.
+ *
+ * @param string $tier Tier string.
+ * @return bool
+ */
+function ec_feature_tier_is_valid( $tier ) {
+	return in_array( $tier, ec_feature_tier_ladder(), true );
+}
+
+/**
+ * Compare two ladder positions.
+ *
+ * Returns the LOWER (more restrictive) of the two tiers — i.e. the clamp.
+ * Invalid inputs fall back to the most restrictive rung (`admin`).
+ *
+ * @param string $a First tier.
+ * @param string $b Second tier.
+ * @return string The more restrictive of the two.
+ */
+function ec_feature_tier_min( $a, $b ) {
+	$ladder = ec_feature_tier_ladder();
+
+	$pos_a = array_search( $a, $ladder, true );
+	$pos_b = array_search( $b, $ladder, true );
+
+	if ( false === $pos_a ) {
+		$pos_a = 0;
+	}
+	if ( false === $pos_b ) {
+		$pos_b = 0;
+	}
+
+	return $ladder[ min( $pos_a, $pos_b ) ];
+}
+
+/**
+ * Get the effective (clamped) rollout tier for a feature.
+ *
+ * Hybrid storage:
+ *   - Code ceiling   = ec_feature_ceiling( $feature )      (max the code is ready for)
+ *   - Network option = get_site_option( "ec_feature_tier_{$feature}" )  (current live tier)
+ *
+ * Effective tier = min( option_tier, ceiling ) on the ladder. The option can
+ * NEVER expose a feature past the code ceiling — this is the safety rail that
+ * makes flipping the live tier from wp-admin foot-gun-proof.
+ *
+ * @param string $feature Feature slug.
+ * @return string One of `admin` | `team` | `public`.
+ */
+function ec_feature_tier( $feature ) {
+	$ceiling = ec_feature_ceiling( $feature );
+
+	$option_tier = get_site_option( "ec_feature_tier_{$feature}", $ceiling );
+	if ( ! ec_feature_tier_is_valid( $option_tier ) ) {
+		$option_tier = $ceiling;
+	}
+
+	return ec_feature_tier_min( $option_tier, $ceiling );
+}
+
+/**
+ * Whether a feature is live for the given user's tier.
+ *
+ * This answers ONLY the rollout question ("has the feature been promoted to a
+ * tier this user is in?"). It is composed with — never a substitute for — the
+ * feature's own base capability gate (ec_user_can()).
+ *
+ *     admin  → user_can( $uid, 'manage_options' )
+ *     team   → admin OR ec_is_team_member( $uid )
+ *     public → true
+ *
+ * @param string   $feature Feature slug.
+ * @param int|null $user_id User ID (defaults to current user).
+ * @return bool
+ */
+function ec_feature_available( $feature, $user_id = null ) {
+	$user_id = null === $user_id ? get_current_user_id() : (int) $user_id;
+
+	$tier = ec_feature_tier( $feature );
+
+	switch ( $tier ) {
+		case 'public':
+			return true;
+
+		case 'team':
+			if ( $user_id <= 0 ) {
+				return false;
+			}
+			if ( user_can( $user_id, 'manage_options' ) ) {
+				return true;
+			}
+			return function_exists( 'ec_is_team_member' ) && ec_is_team_member( $user_id );
+
+		case 'admin':
+		default:
+			if ( $user_id <= 0 ) {
+				return false;
+			}
+			return user_can( $user_id, 'manage_options' );
+	}
+}
+
+/**
+ * The canonical capability gate.
+ *
+ * Answers "can this user do X?" for a named capability, dispatching per
+ * capability to the existing permission logic. This is the single signature
+ * every gate site should eventually call (existing ec_can_* functions are
+ * temporary thin wrappers slated for migration+deletion per #60).
+ *
+ * Supported capabilities:
+ *   - manage_artist          (context: artist_id) → ec_can_manage_artist()
+ *   - create_artist_profile                       → ec_can_create_artist_profiles()
+ *   - manage_shop                                 → ec_can_manage_shop()
+ *   - manage_options                              → user_can manage_options passthrough
+ *
+ * Unknown capabilities return false.
+ *
+ * @param string $capability Capability slug.
+ * @param array  $context    Optional context (e.g. [ 'artist_id' => 123, 'user_id' => 5 ]).
+ * @return bool
+ */
+function ec_user_can( $capability, array $context = array() ) {
+	$user_id = isset( $context['user_id'] ) ? (int) $context['user_id'] : get_current_user_id();
+
+	if ( $user_id <= 0 ) {
+		return false;
+	}
+
+	switch ( $capability ) {
+		case 'manage_artist':
+			$artist_id = isset( $context['artist_id'] ) ? (int) $context['artist_id'] : null;
+			return function_exists( 'ec_can_manage_artist' )
+				&& ec_can_manage_artist( $user_id, $artist_id );
+
+		case 'create_artist_profile':
+			return function_exists( 'ec_can_create_artist_profiles' )
+				&& ec_can_create_artist_profiles( $user_id );
+
+		case 'manage_shop':
+			return function_exists( 'ec_can_manage_shop' )
+				&& ec_can_manage_shop( $user_id );
+
+		case 'manage_options':
+			return user_can( $user_id, 'manage_options' );
+
+		default:
+			return false;
+	}
+}

--- a/inc/shop-permissions.php
+++ b/inc/shop-permissions.php
@@ -15,7 +15,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Returns whether the user can manage the shop.
  *
- * Admin-only until shop system is ready for public use.
+ * Shop manager is the first consumer of the feature-rollout primitive. The
+ * "admin-only until ready" logic is no longer a hardcoded manage_options check
+ * here — it now comes from the `shop` feature ceiling (currently `admin`, see
+ * ec_feature_ceilings()). Management additionally requires the user to own at
+ * least one artist profile.
+ *
+ *     can manage shop = ec_feature_available( 'shop' ) AND (owns >= 1 artist)
+ *
+ * With the shop ceiling at `admin` and no network-option override, this
+ * preserves the prior behavior exactly (admin + has artist). Promoting shop to
+ * the team becomes a one-flag flip of the network option; going public is a
+ * reviewed ceiling bump — no edits to this function.
  *
  * @param int|null $user_id User ID (defaults to current).
  * @return bool
@@ -27,10 +38,12 @@ function ec_can_manage_shop( $user_id = null ) {
 		return false;
 	}
 
-	if ( ! user_can( $user_id, 'manage_options' ) ) {
+	// Rollout gate: is the shop feature live for this user's tier yet?
+	if ( ! function_exists( 'ec_feature_available' ) || ! ec_feature_available( 'shop', $user_id ) ) {
 		return false;
 	}
 
+	// Base capability: the user must own at least one artist profile.
 	if ( function_exists( 'ec_get_artists_for_user' ) ) {
 		$artist_ids = ec_get_artists_for_user( $user_id );
 		if ( ! empty( $artist_ids ) ) {

--- a/inc/team-members.php
+++ b/inc/team-members.php
@@ -24,6 +24,10 @@ require_once __DIR__ . '/team-members/role.php';
  * a team member — full stop. The previous meta-based system was
  * retired by the one-time migration in inc/team-members/role.php.
  *
+ * This is the source of truth for the `team` rung of the feature-rollout
+ * ladder (ec_feature_available()). Slated for review during the gate-API
+ * migration per Extra-Chill/extrachill-users#60 (pending homeboy#3075).
+ *
  * @param int $user_id User ID (0 = current user).
  * @return bool
  */


### PR DESCRIPTION
Foundation slice for **Extra-Chill/extrachill-users#60** — the standardized capability/gating API plus the live-staging (progressive-rollout) primitive. Builds the primitives and wires the first consumer. **The full ~79-call-site migration is deferred** to the refactor tooling tracked in homeboy#3075 — `refs #60`, not `closes`.

## What was built

New file `inc/core/gating.php` (loaded early in `extrachill_users_init()`), exposing three composable primitives:

```php
ec_user_can( string $cap, array $context = [] ): bool   // capability gate
ec_feature_available( string $feature, $user_id = null ): bool   // rollout gate
ec_feature_tier( string $feature ): string   // effective, clamped tier
```

- **`ec_user_can()`** — capability gate. Dispatches per capability to the existing logic: `manage_artist` (context `artist_id`), `create_artist_profile`, `manage_shop`, and a generic `manage_options` passthrough. Unknown caps return `false`.
- **`ec_feature_available()`** — rollout gate. Answers "is this feature promoted to a tier this user is in?" — orthogonal to capability, composed never collapsed.
- **`ec_feature_tier()`** — the effective tier after the clamp.

## The rollout ladder (3 rungs, no beta/allowlist)

```
admin  →  team  →  public
```

- **admin** = `user_can( $uid, 'manage_options' )`
- **team** = admin OR `ec_is_team_member( $uid )` (the existing `extra_chill_team` / `access_studio` cap)
- **public** = `true`

## Hybrid flag storage with clamp (the safety rail)

- **Code ceiling** = `ec_feature_ceilings()` registry (filterable via `ec_feature_ceilings`), the max tier the code is ready to expose. Ships with `shop => 'admin'`. Unknown features default to `admin`.
- **Network option** = `get_site_option( "ec_feature_tier_{$feature}", $ceiling )`, the current live tier — flippable from wp-admin, no deploy.
- **Effective tier = `min( option_tier, ceiling )`** on the ladder. The option can **never** expose a feature past the code ceiling.

### Clamp proof (ran standalone)

| feature | ceiling | network option | effective tier |
|---------|---------|----------------|----------------|
| shop | admin | _(none)_ | **admin** |
| shop | admin | `public` | **admin** (clamped) |
| shop | admin | `team` | **admin** (clamped) |
| shop | admin | `nonsense` | **admin** (falls back to ceiling) |
| demo | team | `public` | **team** (clamped) |
| demo | team | `admin` | **admin** (option below ceiling honored) |

So flipping the network option to `public` from wp-admin **cannot** leak a feature the code ceiling says is only `admin`-ready. You can restrict tighter than the ceiling, never looser.

## Shop wired as first consumer — behavior UNCHANGED

`ec_can_manage_shop()` no longer hardcodes a `manage_options` check. It now reads:

```php
ec_can_manage_shop() = ec_feature_available( 'shop' ) && ( user owns >= 1 artist )
```

With the shop ceiling at `admin` and no option override, this is **exactly today's behavior**: admin + owns an artist → can manage; non-admin → cannot. Promoting shop to the team is a one-flag option flip; going public is a reviewed ceiling bump — no edits to `shop-permissions.php`.

## Backward compat — temporary wrappers, zero call-site churn

`ec_can_manage_artist()`, `ec_can_create_artist_profiles()`, `ec_can_manage_shop()`, and `ec_is_team_member()` keep their signatures and keep working. `ec_user_can()` delegates into them so logic has one home. Docblocks note they're slated for migration + deletion per #60 (pending homeboy#3075). **No call sites were migrated or deleted in this PR.**

## Scope / non-goals

- The ~79-call-site mechanical migration is **out of scope** here — it depends on the AST signature-reshape tooling in homeboy#3075 which doesn't exist yet.
- A network-admin UI to flip the live tier is noted as a follow-up; this PR lands the **option read path** (`get_site_option( "ec_feature_tier_{$feature}" )`) and documents the option key convention. The primitives land cleanly first.

## Verification

- ✅ All changed PHP files lint clean (`php -l`).
- ✅ Clamp proven (table above) — a `public` option still clamps to the `admin` ceiling for shop.
- ✅ Shop manager behavior unchanged (admin + artist = manage; non-admin = cannot).
- ✅ Existing `ec_can_*` functions return identical results (no call-site churn).
- ✅ CHANGELOG.md and version strings untouched.

`refs #60`