### PR TITLE
feat: add Snowflake, Icicle, Iceberg rank tiers

### DIFF
--- a/inc/rank-system/rank-tiers.php
+++ b/inc/rank-system/rank-tiers.php
@@ -76,11 +76,25 @@ function ec_get_default_rank_tiers() {
 			'class_name' => 'rank-first-frost',
 		),
 		array(
+			'key'        => 'snowflake',
+			'label'      => 'Snowflake',
+			'min_points' => 130,
+			'icon'       => 'snowflake',
+			'class_name' => 'rank-snowflake',
+		),
+		array(
 			'key'        => 'overnight_freeze',
 			'label'      => 'Overnight Freeze',
 			'min_points' => 155,
 			'icon'       => 'snowflake',
 			'class_name' => 'rank-overnight-freeze',
+		),
+		array(
+			'key'        => 'icicle',
+			'label'      => 'Icicle',
+			'min_points' => 190,
+			'icon'       => 'snowflake',
+			'class_name' => 'rank-icicle',
 		),
 		array(
 			'key'        => 'ice_cube',
@@ -193,6 +207,13 @@ function ec_get_default_rank_tiers() {
 			'min_points' => 101974,
 			'icon'       => 'snowflake',
 			'class_name' => 'rank-glacier',
+		),
+		array(
+			'key'        => 'iceberg',
+			'label'      => 'Iceberg',
+			'min_points' => 125000,
+			'icon'       => 'snowflake',
+			'class_name' => 'rank-iceberg',
 		),
 		array(
 			'key'        => 'antarctica',

--- a/tests/unit/RankTiersTest.php
+++ b/tests/unit/RankTiersTest.php
@@ -34,7 +34,9 @@ class Test_Rank_Tiers extends WP_UnitTestCase {
 			array( 35, 'Puddle' ),
 			array( 69, 'Crisp Air' ),
 			array( 103, 'First Frost' ),
+			array( 130, 'Snowflake' ),
 			array( 155, 'Overnight Freeze' ),
+			array( 190, 'Icicle' ),
 			array( 232, 'Ice Cube' ),
 			array( 349, 'Full Ice Tray' ),
 			array( 523, 'Bag of Ice' ),
@@ -51,6 +53,7 @@ class Test_Rank_Tiers extends WP_UnitTestCase {
 			array( 45322, 'Ski Resort' ),
 			array( 67983, 'Blizzard' ),
 			array( 101974, 'Glacier' ),
+			array( 125000, 'Iceberg' ),
 			array( 152961, 'Antarctica' ),
 			array( 229442, 'Ice Age' ),
 			array( 344164, 'Upper Atmosphere' ),
@@ -177,7 +180,7 @@ class Test_Rank_Tiers extends WP_UnitTestCase {
 		$this->assertSame( 'First Frost', ec_get_rank_for_points( 120 ) );
 	}
 
-	public function test_default_ladder_has_26_tiers(): void {
-		$this->assertCount( 26, ec_get_default_rank_tiers() );
+	public function test_default_ladder_has_29_tiers(): void {
+		$this->assertCount( 29, ec_get_default_rank_tiers() );
 	}
 }


### PR DESCRIPTION
## Summary

Fills three clear thematic gaps in the frozen-themed rank ladder without bloating it or breaking the ~1.5x geometric curve. Each new tier is inserted at a sensible threshold strictly between its neighbors so the array stays ascending by `min_points`. **The existing 26 tiers and their thresholds are unchanged** — only 3 new records were inserted in sorted position.

Stacks on top of #64 (`refactor-rank-registry`), so the base is `refactor-rank-registry`, not `main`.

## New tiers

| Tier | `min_points` | Inserted between | Why it fills a gap |
|------|-------------:|------------------|--------------------|
| **Snowflake** | `130` | First Frost (103) → Overnight Freeze (155) | The brand's spirit animal, absent despite 3 snow-event tiers. Lands in the early/onboarding band. |
| **Icicle** | `190` | Overnight Freeze (155) → Ice Cube (232) | The iconic "ice forming" image, missing from Act 1. |
| **Iceberg** | `125000` | Glacier (101974) → Antarctica (152961) | The classic cold landmark, missing from the geographic/cosmic act. |

All three use `icon = snowflake` and `class_name = rank-{key}` per the brief. Thresholds sit cleanly between neighbors (strictly greater than the tier below, strictly less than the tier above).

## Unchanged

- All 26 existing tier labels, keys, icons, class names, and thresholds are untouched.
- No renumbering or shifting of existing thresholds.
- The ladder remains strictly ascending by `min_points`.

## Test update

`tests/unit/RankTiersTest.php`:
- Added the 3 new rows to `canonical_ladder()` in their sorted positions (130 Snowflake, 190 Icicle, 125000 Iceberg).
- Renamed `test_default_ladder_has_26_tiers()` → `test_default_ladder_has_29_tiers()` and bumped the count assertion `26` → `29`.
- The exhaustive threshold assertions and the just-below-boundary assertions automatically cover the new tiers.
- `test_filter_can_add_a_tier()` still passes: it asserts `120 -> First Frost` and `140 -> Snowflake`, both of which hold with Snowflake now in the defaults at 130.

## Verification

- `php -l` clean on both edited files.
- `phpcs --standard=WordPress` clean (exit 0, zero violations) on `inc/rank-system/rank-tiers.php`.
- No WP test framework on this host, so lookup logic was verified with a standalone PHP harness that stubs `apply_filters`/`add_filter`/`sanitize_key` and asserts every `(threshold -> label)` and `(threshold-1 -> lower label)` pair plus the count and strict-ascending invariant:

```
PASS: 29 tiers, strictly ascending, all 29 threshold + just-below boundaries correct.
```