### PR TITLE
refactor: rename Snowflake rank tier to Powder

### DIFF
--- a/inc/rank-system/rank-tiers.php
+++ b/inc/rank-system/rank-tiers.php
@@ -76,11 +76,11 @@ function ec_get_default_rank_tiers() {
 			'class_name' => 'rank-first-frost',
 		),
 		array(
-			'key'        => 'snowflake',
-			'label'      => 'Snowflake',
+			'key'        => 'powder',
+			'label'      => 'Powder',
 			'min_points' => 130,
 			'icon'       => 'snowflake',
-			'class_name' => 'rank-snowflake',
+			'class_name' => 'rank-powder',
 		),
 		array(
 			'key'        => 'overnight_freeze',

--- a/tests/unit/RankTiersTest.php
+++ b/tests/unit/RankTiersTest.php
@@ -34,7 +34,7 @@ class Test_Rank_Tiers extends WP_UnitTestCase {
 			array( 35, 'Puddle' ),
 			array( 69, 'Crisp Air' ),
 			array( 103, 'First Frost' ),
-			array( 130, 'Snowflake' ),
+			array( 130, 'Powder' ),
 			array( 155, 'Overnight Freeze' ),
 			array( 190, 'Icicle' ),
 			array( 232, 'Ice Cube' ),
@@ -155,15 +155,17 @@ class Test_Rank_Tiers extends WP_UnitTestCase {
 	}
 
 	public function test_filter_can_add_a_tier(): void {
+		// Insert a clearly-fictional tier at a threshold that does not collide
+		// with any real tier (between Full Ice Tray 349 and Bag of Ice 523).
 		add_filter(
 			'ec_rank_tiers',
 			static function ( $tiers ) {
 				$tiers[] = array(
-					'key'        => 'snowflake',
-					'label'      => 'Snowflake',
-					'min_points' => 130,
+					'key'        => 'test_tier',
+					'label'      => 'Test Tier',
+					'min_points' => 400,
 					'icon'       => 'snowflake',
-					'class_name' => 'rank-snowflake',
+					'class_name' => 'rank-test-tier',
 				);
 				return $tiers;
 			}
@@ -173,11 +175,11 @@ class Test_Rank_Tiers extends WP_UnitTestCase {
 		ec_flush_rank_tiers_cache();
 
 		$labels = wp_list_pluck( ec_get_rank_tiers(), 'label' );
-		$this->assertContains( 'Snowflake', $labels );
+		$this->assertContains( 'Test Tier', $labels );
 
 		// Inserted tier must slot in by min_points and resolve correctly.
-		$this->assertSame( 'Snowflake', ec_get_rank_for_points( 140 ) );
-		$this->assertSame( 'First Frost', ec_get_rank_for_points( 120 ) );
+		$this->assertSame( 'Test Tier', ec_get_rank_for_points( 450 ) );
+		$this->assertSame( 'Full Ice Tray', ec_get_rank_for_points( 360 ) );
 	}
 
 	public function test_default_ladder_has_29_tiers(): void {


### PR DESCRIPTION
## Summary

Renames the 130-point rank tier from **Snowflake** to **Powder**. "Snowflake" has picked up a pejorative societal connotation that's unwanted on a public-facing rank label users see on their profile. "Powder" (fresh snow) keeps the early-ice imagery, stays on-brand for a music/chill platform, and carries no loaded meaning.

## Changes

- Tier `key`: `snowflake` → `powder`
- Tier `label`: `Snowflake` → `Powder`
- Tier `class_name`: `rank-snowflake` → `rank-powder`
- **Unchanged:** the `min_points` threshold (130) and the `icon` hint (`snowflake` — a generic frosty glyph, not user-facing text)
- Test: updated the canonical-ladder assertion (`130 => 'Powder'`) and retargeted `test_filter_can_add_a_tier()` to insert a clearly-fictional `Test Tier` at a non-colliding threshold (400, between Full Ice Tray and Bag of Ice) so the filter test no longer piggybacks on the real 130-pt tier's label.

## Verification

- `php -l` clean on both files.
- Standalone logic harness: 29 tiers, `130/140/154 → Powder`, `155 → Overnight Freeze`, `125 → First Frost`; confirmed **no tier carries a "snowflake" label** anywhere.
- The `icon => 'snowflake'` entries across tiers are intentionally kept — that's a UI icon name, not a label.

## Context

Follows extrachill-users #68 which introduced the tier. Pure label refactor; no behavioral/threshold change. Conventional commit; homeboy owns versioning/changelog.