### PR TITLE
fix: hash browser-handoff token storage key

### DIFF
--- a/inc/auth-tokens/browser-handoff-token.php
+++ b/inc/auth-tokens/browser-handoff-token.php
@@ -5,6 +5,9 @@
  * Generates and validates one-time tokens used to bootstrap a WordPress
  * cookie session in a real browser after app authentication.
  *
+ * The plaintext token is returned to the client, but the site transient is
+ * keyed by sha256(token) so a cache/Redis dump never exposes live tokens.
+ *
  * @package ExtraChill\Users
  */
 
@@ -19,7 +22,7 @@ defined( 'ABSPATH' ) || exit;
  */
 function extrachill_users_create_browser_handoff_token( int $user_id, string $redirect_url ): string {
 	$token = wp_generate_password( 64, false, false );
-	$key   = 'ec_browser_handoff_' . $token;
+	$key   = 'ec_browser_handoff_' . hash( 'sha256', $token );
 
 	set_site_transient(
 		$key,
@@ -46,7 +49,7 @@ function extrachill_users_consume_browser_handoff_token( string $token ) {
 		return new WP_Error( 'invalid_handoff_token', 'Invalid handoff token.', array( 'status' => 400 ) );
 	}
 
-	$key     = 'ec_browser_handoff_' . $token;
+	$key     = 'ec_browser_handoff_' . hash( 'sha256', $token );
 	$payload = get_site_transient( $key );
 	delete_site_transient( $key );
 


### PR DESCRIPTION
## Security fix — closes #73

### The leak
`inc/auth-tokens/browser-handoff-token.php` stored the browser-handoff token **verbatim** as the site-transient key:

```php
$key = 'ec_browser_handoff_' . $token;
```

Site transients are backed by the object cache (Redis on this network). A Redis/object-cache dump therefore exposed **live, unexpired handoff tokens** directly in the key namespace — anyone reading the cache could replay them to bootstrap a real browser cookie session before the 60s TTL elapsed.

### The fix
Key the transient by `sha256(token)` instead of the raw token, matching the already-hardened wp-native-auth fork (`wp-native-auth/inc/handoff-tokens.php`). The plaintext token is still what's handed to/from the client — only the internal storage key changed, so a cache dump now yields only irreversible hashes.

### Both sites updated (store + lookup hash identically)
- **Store** — `extrachill_users_create_browser_handoff_token()`: `set_site_transient( 'ec_browser_handoff_' . hash( 'sha256', $token ), ... )`
- **Lookup/consume** — `extrachill_users_consume_browser_handoff_token()`: `get_site_transient`/`delete_site_transient` use the same hashed key.

Because both sides hash the same way, the handoff still works end-to-end; the raw token returned to the client is unchanged.

### Verification
- `php -l` clean.
- Transient key is a sha256 hash, never the raw token.
- Store and lookup use identical hashing.
- Client-facing token unchanged (only the storage key is hashed).