### PR TITLE
fix: HTTP-safe refresh token generator (random_bytes)

### DIFF
--- a/inc/auth-tokens/service.php
+++ b/inc/auth-tokens/service.php
@@ -38,7 +38,7 @@ function extrachill_users_issue_refresh_token( int $user_id, string $device_id, 
 	$expires_ts = $now_ts + EXTRACHILL_USERS_REFRESH_TOKEN_TTL;
 	$expires_at = extrachill_users_mysql_gmt_from_ts( $expires_ts );
 
-	$refresh_token = wp_generate_password( 64, true, true );
+	$refresh_token = extrachill_users_generate_refresh_token();
 	$token_hash    = extrachill_users_hash_refresh_token( $refresh_token );
 
 	$existing_id = $wpdb->get_var(
@@ -180,7 +180,7 @@ function extrachill_users_refresh_tokens( string $refresh_token, string $device_
 		);
 	}
 
-	$new_refresh_token = wp_generate_password( 64, true, true );
+	$new_refresh_token = extrachill_users_generate_refresh_token();
 	$new_token_hash    = extrachill_users_hash_refresh_token( $new_refresh_token );
 	$new_expires_ts    = $now_ts + EXTRACHILL_USERS_REFRESH_TOKEN_TTL;
 	$new_expires_at    = extrachill_users_mysql_gmt_from_ts( $new_expires_ts );

--- a/inc/auth-tokens/tokens.php
+++ b/inc/auth-tokens/tokens.php
@@ -64,6 +64,32 @@ function extrachill_users_generate_access_token( int $user_id, string $device_id
 }
 
 /**
+ * Generate an opaque refresh token.
+ *
+ * 256 random bits, base64url-encoded (no padding) = 43 chars from the
+ * `[A-Za-z0-9_-]` alphabet (RFC 7235 bearer token alphabet). It survives
+ * HTTP headers, URL params, JSON bodies, command-line args, and shell
+ * escaping without any character class needing escaping.
+ *
+ * Deliberately NOT `wp_generate_password( 64, true, true )`: its
+ * "extra special chars" alphabet adds `<`, `>`, `&`, `"`, `'`, and a
+ * literal space — all hostile to HTTP transport. `sanitize_text_field()`
+ * HTML-encodes the first five (mangling the token in transit), and a
+ * literal space gets corrupted by `trim()` on the receiving side. This
+ * caused ~45% silent auth failures in extrachill.com production before
+ * the sibling wp-native-auth plugin switched to this generator. We match
+ * wp-native-auth/inc/tokens.php exactly to avoid a second divergence.
+ *
+ * Entropy: 32 bytes of CSPRNG (`random_bytes`) = 256 bits, well above
+ * the 128-bit threshold for opaque token unguessability.
+ *
+ * @return string Base64url-encoded random token (43 chars).
+ */
+function extrachill_users_generate_refresh_token(): string {
+	return rtrim( strtr( base64_encode( random_bytes( 32 ) ), '+/', '-_' ), '=' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions -- Required for HTTP-safe API auth tokens, not obfuscation.
+}
+
+/**
  * Hash refresh token for storage.
  */
 function extrachill_users_hash_refresh_token( string $refresh_token ): string {


### PR DESCRIPTION
## Summary (SECURITY)

Closes #72.

`extrachill-users` minted refresh tokens with `wp_generate_password( 64, true, true )` at **two** call sites — the EXACT generator the sibling `wp-native-auth` plugin was deliberately rewritten away from. Its "extra special chars" alphabet (`<`, `>`, `&`, `"`, `'`, literal space) is hostile to HTTP transport: `sanitize_text_field()` HTML-encodes five of them and `trim()` corrupts edge whitespace, which caused **~45% silent auth failures in extrachill.com production** before wp-native-auth switched generators. extrachill-users still shipped the known-buggy one.

## Fix

Both refresh-token mint sites now use the proven wp-native-auth generator:

```php
rtrim( strtr( base64_encode( random_bytes( 32 ) ), '+/', '-_' ), '=' )
```

- Extracted a single local helper `extrachill_users_generate_refresh_token()` in `inc/auth-tokens/tokens.php` so both sites share one generator (no second divergence). The helper's docblock mirrors wp-native-auth's documented reasoning.
- `inc/auth-tokens/service.php:41` (issue) and `:183` (rotate) both call the helper.
- Output is 43 chars from the base64url alphabet `[A-Za-z0-9_-]` (RFC 7235), 256 bits of CSPRNG entropy.

## Why nothing breaks

- Storage hashes the token via `hash_hmac( 'sha256', $token, ... )` → fixed 64-char hex, **length-agnostic** to the input. The shorter token format is transparent to the `refresh_token_hash` column.
- The out-of-scope `browser-handoff-token.php` uses `wp_generate_password( 64, false, false )` (alphanumeric-only, already HTTP-safe) — left untouched.

## Verification

- `grep` confirms no `wp_generate_password` remains in refresh-token mint paths.
- Generator line matches `wp-native-auth/inc/tokens.php:65` exactly.
- `php -l` clean on both files.