### PR TITLE
feat(interconnection): cross-site stat links + attendee 'who's going' surface

### DIFF
--- a/assets/css/concert-tracking.css
+++ b/assets/css/concert-tracking.css
@@ -28,3 +28,43 @@
 	color: var(--muted-text, #6b7280);
 	white-space: nowrap;
 }
+
+/* ─── Attendee strip ("who's going / who was there") ───────────────────── */
+
+.ec-attendance-list {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	margin-top: 0.5rem;
+	flex-wrap: wrap;
+}
+
+.ec-attendance-list__label {
+	font-size: var(--font-size-sm, 0.8125rem);
+	color: var(--muted-text, #6b7280);
+}
+
+.ec-attendance-list__avatars {
+	display: flex;
+	align-items: center;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.ec-attendance-list__item {
+	margin: 0 0 0 -0.5rem;
+}
+
+.ec-attendance-list__item:first-child {
+	margin-left: 0;
+}
+
+.ec-attendance-list__avatar {
+	display: block;
+	width: 32px;
+	height: 32px;
+	border-radius: 50%;
+	border: 2px solid var(--card-background, #fff);
+	object-fit: cover;
+}

--- a/inc/concert-tracking/buttons.php
+++ b/inc/concert-tracking/buttons.php
@@ -82,6 +82,64 @@ function ec_users_render_attendance_button( int $event_id ) {
 		<?php endif; ?>
 	</div>
 	<?php
+	ec_users_render_event_attendees( $event_id, $blog_id );
+}
+
+/**
+ * Render the "who's going / who was there" attendee strip for an event.
+ *
+ * Server-rendered (SEO-friendly, no JS dependency) avatar row linking each
+ * attendee to their community profile — turning the events page into a feeder
+ * for the community "living room" and surfacing the attendee social graph that
+ * the get-event-attendance ability already computes. Skips silently when there
+ * are no attendees.
+ *
+ * @param int $event_id Event post ID.
+ * @param int $blog_id  Blog ID.
+ */
+function ec_users_render_event_attendees( int $event_id, int $blog_id ) {
+	if ( ! function_exists( 'ec_users_get_event_attendees' ) ) {
+		return;
+	}
+
+	$attendees = ec_users_get_event_attendees( $event_id, $blog_id, 12 );
+	if ( empty( $attendees ) ) {
+		return;
+	}
+
+	?>
+	<div class="ec-attendance-list">
+		<span class="ec-attendance-list__label">
+			<?php echo esc_html( _n( 'Going', 'Going', count( $attendees ), 'extrachill-users' ) ); ?>
+		</span>
+		<ul class="ec-attendance-list__avatars">
+			<?php foreach ( $attendees as $attendee ) : ?>
+				<?php
+				$name   = isset( $attendee['display_name'] ) ? (string) $attendee['display_name'] : '';
+				$avatar = isset( $attendee['avatar_url'] ) ? (string) $attendee['avatar_url'] : '';
+				$url    = isset( $attendee['profile_url'] ) ? (string) $attendee['profile_url'] : '';
+				if ( '' === $avatar ) {
+					continue;
+				}
+				$img = sprintf(
+					'<img class="ec-attendance-list__avatar" src="%s" alt="%s" width="32" height="32" loading="lazy" />',
+					esc_url( $avatar ),
+					esc_attr( $name )
+				);
+				?>
+				<li class="ec-attendance-list__item">
+					<?php if ( '' !== $url ) : ?>
+						<a href="<?php echo esc_url( $url ); ?>" title="<?php echo esc_attr( $name ); ?>">
+							<?php echo $img; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- built from esc_url/esc_attr above. ?>
+						</a>
+					<?php else : ?>
+						<?php echo $img; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- built from esc_url/esc_attr above. ?>
+					<?php endif; ?>
+				</li>
+			<?php endforeach; ?>
+		</ul>
+	</div>
+	<?php
 }
 
 /**

--- a/inc/concert-tracking/service.php
+++ b/inc/concert-tracking/service.php
@@ -745,11 +745,96 @@ function ec_users_get_user_concert_stats( int $user_id, array $args = array() ):
 		'unique_cities'  => $unique_cities,
 		'first_show'     => $first_show,
 		'latest_show'    => $latest_show,
-		'top_artists'    => $cast_counts( $top_artists ),
-		'top_venues'     => $cast_counts( $top_venues ),
-		'top_cities'     => $cast_counts( $top_cities ),
+		'top_artists'    => ec_users_link_top_terms( $cast_counts( $top_artists ), 'artist', $blog_id ),
+		'top_venues'     => ec_users_link_top_terms( $cast_counts( $top_venues ), 'venue', $blog_id ),
+		'top_cities'     => ec_users_link_top_terms( $cast_counts( $top_cities ), 'location', $blog_id ),
 		'shows_by_year'  => $shows_by_year,
 	);
+}
+
+/**
+ * Enrich top-term stat items with a `url` for cross-site navigation.
+ *
+ * Turns the My Shows leaderboards (top artists / venues / cities) from a
+ * dead-end list into a launchpad into the network — the platform's
+ * network-density / interconnectedness goal. Each item gains a `url`:
+ *
+ * - artist → the artist's profile on the artist site (canonical entity link
+ *   via extrachill_get_artist_profile_by_slug), falling back to the events
+ *   artist archive.
+ * - venue  → the events-site venue archive.
+ * - location (city) → the events-site location archive.
+ *
+ * Uses the network's canonical linker primitives (extrachill-multisite) rather
+ * than hand-building URLs, so caching + content-awareness are inherited. Items
+ * with no resolvable target keep `url => ''` (the UI renders plain text).
+ *
+ * @param array  $items    Top-term items, each { name, slug, count }.
+ * @param string $taxonomy 'artist' | 'venue' | 'location'.
+ * @param int    $blog_id  Events blog ID (for venue/location archive URLs).
+ * @return array Items with an added `url` key.
+ */
+function ec_users_link_top_terms( array $items, string $taxonomy, int $blog_id ): array {
+	if ( empty( $items ) ) {
+		return $items;
+	}
+
+	foreach ( $items as &$item ) {
+		$slug        = isset( $item['slug'] ) ? (string) $item['slug'] : '';
+		$item['url'] = '';
+
+		if ( '' === $slug ) {
+			continue;
+		}
+
+		if ( 'artist' === $taxonomy && function_exists( 'extrachill_get_artist_profile_by_slug' ) ) {
+			$profile = extrachill_get_artist_profile_by_slug( $slug );
+			if ( is_array( $profile ) && ! empty( $profile['permalink'] ) ) {
+				$item['url'] = (string) $profile['permalink'];
+				continue;
+			}
+		}
+
+		// Venue / location (and artist fallback): the events-site term archive.
+		$item['url'] = ec_users_events_term_archive_url( $slug, $taxonomy, $blog_id );
+	}
+	unset( $item );
+
+	return $items;
+}
+
+/**
+ * Build the events-site archive URL for a taxonomy term slug.
+ *
+ * @param string $slug     Term slug.
+ * @param string $taxonomy Taxonomy slug.
+ * @param int    $blog_id  Events blog ID.
+ * @return string Archive URL, or '' when unresolvable.
+ */
+function ec_users_events_term_archive_url( string $slug, string $taxonomy, int $blog_id ): string {
+	if ( '' === $slug || ! $blog_id ) {
+		return '';
+	}
+
+	$switched     = false;
+	$current_blog = get_current_blog_id();
+	if ( $current_blog !== $blog_id ) {
+		switch_to_blog( $blog_id );
+		$switched = true;
+	}
+
+	try {
+		$term = get_term_by( 'slug', $slug, $taxonomy );
+		if ( ! $term instanceof WP_Term ) {
+			return '';
+		}
+		$link = get_term_link( $term, $taxonomy );
+		return is_wp_error( $link ) ? '' : (string) $link;
+	} finally {
+		if ( $switched ) {
+			restore_current_blog();
+		}
+	}
 }
 
 // ─── Event Attendees ─────────────────────────────────────────────────────────

--- a/inc/concert-tracking/service.php
+++ b/inc/concert-tracking/service.php
@@ -872,10 +872,15 @@ function ec_users_get_event_attendees( int $event_id, int $blog_id = 0, int $lim
 			continue;
 		}
 
+		$profile_url = function_exists( 'extrachill_get_user_community_profile_url' )
+			? (string) extrachill_get_user_community_profile_url( (int) $user->ID )
+			: '';
+
 		$attendees[] = array(
 			'user_id'      => (int) $user->ID,
 			'display_name' => $user->display_name,
 			'avatar_url'   => get_avatar_url( $user->ID, array( 'size' => 48 ) ),
+			'profile_url'  => $profile_url,
 		);
 	}
 


### PR DESCRIPTION
## Summary

Two interconnection features that turn My Shows from a silo on the events island into connective tissue across the network — directly serving the platform's network-density / cross-site-journey north star.

### 1. Cross-site URLs on top-term stats
The stats ability now enriches each top artist/venue/city with a `url` (via the canonical extrachill-multisite cross-site linker):
- artist → artist profile on the artist site (`extrachill_get_artist_profile_by_slug`), falling back to the events artist archive.
- venue / city → events-site term archive.

Uses the network's cached, content-aware linker primitives — no hand-built URLs. The UI renders these as links (see extrachill-events PR). Non-breaking: the stats output schema declares top lists as generic arrays.

### 2. Attendee "who's going / who was there" strip
The `get-event-attendance` ability already computed an attendee list with avatars, but **nothing ever rendered it** — the social graph was one query from the surface. Now a server-rendered avatar strip below the attendance button links each attendee to their **community profile**, turning the events page into a feeder for the community "living room" (epic ec-community#53 Phase 3).
- Enriches `ec_users_get_event_attendees` with each attendee's community profile URL (`extrachill_get_user_community_profile_url`).
- Server-rendered (SEO-friendly, no JS dependency).

## Validation
- `php -l` clean; `homeboy lint` 0 errors (2 pre-existing alignment warnings outside the changes).
- Linker primitives verified live: artist→archive, venue→archive, city→archive resolve; user 38 community profile → `community.extrachill.com/u/qrisg`.

## Companion PRs
- Extra-Chill/extrachill-events (leaderboard renders the stat links)
- Extra-Chill/extrachill-community (concert-history card renders the stat links)

Conventional commits; no version/changelog hand-edits.