### PR TITLE
feat(concert-tracking): enrich shows payload with cross-site term urls

### DIFF
--- a/inc/concert-tracking/service.php
+++ b/inc/concert-tracking/service.php
@@ -413,6 +413,7 @@ function ec_users_get_user_events( int $user_id, array $args = array() ): array 
  */
 function ec_users_build_show_data( WP_Post $post, array $row ): array {
 	$event_id = $post->ID;
+	$blog_id  = get_current_blog_id();
 
 	// Venue (first term).
 	$venue       = null;
@@ -421,6 +422,7 @@ function ec_users_build_show_data( WP_Post $post, array $row ): array {
 		$venue = array(
 			'name' => $venue_terms[0]->name,
 			'slug' => $venue_terms[0]->slug,
+			'url'  => ec_users_events_term_archive_url( $venue_terms[0]->slug, 'venue', $blog_id ),
 		);
 	}
 
@@ -449,11 +451,15 @@ function ec_users_build_show_data( WP_Post $post, array $row ): array {
 			$city = array(
 				'name' => $deepest->name,
 				'slug' => $deepest->slug,
+				'url'  => ec_users_events_term_archive_url( $deepest->slug, 'location', $blog_id ),
 			);
 		}
 	}
 
-	// Artists.
+	// Artists. Enrich each with a cross-site `url` (canonical artist profile
+	// on the artist site, falling back to the events artist archive) via the
+	// same linker primitive that powers the leaderboard, so a show card
+	// becomes multiple on-ramps into the network rather than a single link.
 	$artists      = array();
 	$artist_terms = wp_get_post_terms( $event_id, 'artist' );
 	if ( ! is_wp_error( $artist_terms ) ) {
@@ -463,6 +469,7 @@ function ec_users_build_show_data( WP_Post $post, array $row ): array {
 				'slug' => $term->slug,
 			);
 		}
+		$artists = ec_users_link_top_terms( $artists, 'artist', $blog_id );
 	}
 
 	return array(


### PR DESCRIPTION
## Summary

Enriches the **My Shows** payload (`ec_users_build_show_data`) so each show's artist, venue, and city carries a cross-site `url` — turning the concert-stats show cards into multiple on-ramps into the network instead of a single event link. This is the server-side half of the show-card interconnection work (UI in extrachill-events#concert-stats-card-interconnect).

## What changed

`inc/concert-tracking/service.php` — `ec_users_build_show_data()` now attaches a `url` to each term, reusing the **same linker primitives that already power the stats leaderboard** (no new URL-building infra):

- **artists** → `ec_users_link_top_terms( $artists, 'artist', $blog_id )` — canonical artist profile on the artist site via `extrachill_get_artist_profile_by_slug`, falling back to the events artist archive.
- **venue** → `ec_users_events_term_archive_url( slug, 'venue', $blog_id )` — events-site venue archive.
- **city** → `ec_users_events_term_archive_url( slug, 'location', $blog_id )` — events-site location archive.

`ec_users_build_show_data` already runs inside the events-blog `switch_to_blog` context, and `$blog_id = get_current_blog_id()` captures it; the linker primitives manage their own blog switching internally and resolve `''` when a term has no target (UI then renders plain text).

## Consumer

The concert-stats block (extrachill-events, branch `concert-stats-card-interconnect`) reads `show.artists[].url`, `show.venue.url`, `show.city.url` to render individual term links inside each show card.

## Verify

- `php -l inc/concert-tracking/service.php` — no syntax errors.
- `homeboy lint --changed-since` — the 4 findings reported are all pre-existing in `ec_users_get_user_events` (lines ~974/1002/1005/1029), confirmed present on `origin/main`; none are in the changed `ec_users_build_show_data` lines.

## Notes

- No `CHANGELOG.md` edits, no version bumps (homeboy owns both).