### PR TITLE
feat(notifications): network notification substrate

### DIFF
--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -149,6 +149,9 @@ function extrachill_users_init() {
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/import-db.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/import/bootstrap.php';
 
+	// Network notification substrate: entry point + read/CRUD + back-compat shim.
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/notifications/service.php';
+
 	// wp-native-auth bridge: layer EC policy (membership, blocking, Turnstile)
 	// onto the generic wp-native-auth filter surface when both plugins are active.
 	if ( defined( 'WP_NATIVE_AUTH_VERSION' ) ) {

--- a/inc/core/abilities/notifications.php
+++ b/inc/core/abilities/notifications.php
@@ -1,0 +1,312 @@
+<?php
+/**
+ * Notification abilities.
+ *
+ * Read/write surface for the network notification substrate. Business logic
+ * lives in inc/notifications/service.php; these abilities are thin wrappers
+ * that resolve the acting user and delegate.
+ *
+ * Supersedes the community-only blob abilities
+ * (extrachill/community-get-notifications etc.) by reading/writing the
+ * network notification table instead of the per-user user_meta array.
+ *
+ * Parent epic: Extra-Chill/extrachill-community#82.
+ *
+ * @package ExtraChill\Users
+ * @since 0.15.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_users_register_notification_abilities' );
+
+/**
+ * Register notification abilities.
+ */
+function extrachill_users_register_notification_abilities() {
+
+	// ─── Get Notifications ────────────────────────────────────────────────────
+
+	wp_register_ability(
+		'extrachill/get-notifications',
+		array(
+			'label'               => __( 'Get Notifications', 'extrachill-users' ),
+			'description'         => __( 'List notifications for a user (newest first), with optional unread filter and pagination. Reads the network notification table.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id'  => array(
+						'type'        => 'integer',
+						'description' => 'User ID. Defaults to current user.',
+						'default'     => 0,
+					),
+					'unread'   => array(
+						'type'        => 'boolean',
+						'description' => 'Only return unread notifications.',
+						'default'     => false,
+					),
+					'page'     => array(
+						'type'        => 'integer',
+						'description' => '1-indexed page number.',
+						'default'     => 1,
+					),
+					'per_page' => array(
+						'type'        => 'integer',
+						'description' => 'Results per page (1-100).',
+						'default'     => 50,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id'       => array( 'type' => 'integer' ),
+					'total'         => array( 'type' => 'integer' ),
+					'unread_count'  => array( 'type' => 'integer' ),
+					'page'          => array( 'type' => 'integer' ),
+					'pages'         => array( 'type' => 'integer' ),
+					'notifications' => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_users_ability_get_notifications',
+			'permission_callback' => 'is_user_logged_in',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+
+	// ─── Get Unread Count ─────────────────────────────────────────────────────
+
+	wp_register_ability(
+		'extrachill/get-notification-unread-count',
+		array(
+			'label'               => __( 'Get Notification Unread Count', 'extrachill-users' ),
+			'description'         => __( 'Return the number of unread notifications for a user. Powers the bell badge.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id' => array(
+						'type'        => 'integer',
+						'description' => 'User ID. Defaults to current user.',
+						'default'     => 0,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id'      => array( 'type' => 'integer' ),
+					'unread_count' => array( 'type' => 'integer' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_users_ability_get_notification_unread_count',
+			'permission_callback' => 'is_user_logged_in',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+
+	// ─── Mark Notifications Read ──────────────────────────────────────────────
+
+	wp_register_ability(
+		'extrachill/mark-notifications-read',
+		array(
+			'label'               => __( 'Mark Notifications Read', 'extrachill-users' ),
+			'description'         => __( 'Mark a single notification (by id) or all unread notifications as read for a user.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id'         => array(
+						'type'        => 'integer',
+						'description' => 'User ID. Defaults to current user.',
+						'default'     => 0,
+					),
+					'notification_id' => array(
+						'type'        => 'integer',
+						'description' => 'Single notification ID to mark read. 0 marks ALL unread.',
+						'default'     => 0,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id' => array( 'type' => 'integer' ),
+					'marked'  => array( 'type' => 'integer' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_users_ability_mark_notifications_read',
+			'permission_callback' => 'is_user_logged_in',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+
+	// ─── Clear Notifications ──────────────────────────────────────────────────
+
+	wp_register_ability(
+		'extrachill/clear-notifications',
+		array(
+			'label'               => __( 'Clear Notifications', 'extrachill-users' ),
+			'description'         => __( 'Delete read notifications older than one week for a user, or all notifications.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id' => array(
+						'type'        => 'integer',
+						'description' => 'User ID. Defaults to current user.',
+						'default'     => 0,
+					),
+					'all'     => array(
+						'type'        => 'boolean',
+						'description' => 'Delete ALL notifications (not just old read ones).',
+						'default'     => false,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id' => array( 'type' => 'integer' ),
+					'removed' => array( 'type' => 'integer' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_users_ability_clear_notifications',
+			'permission_callback' => 'is_user_logged_in',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => true,
+					'destructive' => true,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute Callbacks ─────────────────────────────────────────────────────────
+
+/**
+ * Resolve the acting user ID from input, defaulting to the current user.
+ *
+ * Non-admins may only act on their own notifications; an explicit user_id that
+ * differs from the current user requires the list_users capability.
+ *
+ * @param array $input Ability input.
+ * @return int|WP_Error Resolved user ID, or WP_Error on permission failure.
+ */
+function extrachill_users_resolve_notification_user_id( array $input ) {
+	$current = get_current_user_id();
+	$user_id = ! empty( $input['user_id'] ) ? (int) $input['user_id'] : $current;
+
+	if ( $user_id <= 0 ) {
+		return new WP_Error( 'no_user', 'A valid user_id is required.', array( 'status' => 400 ) );
+	}
+
+	if ( $user_id !== $current && ! current_user_can( 'list_users' ) ) {
+		return new WP_Error( 'forbidden', 'You can only access your own notifications.', array( 'status' => 403 ) );
+	}
+
+	return $user_id;
+}
+
+/**
+ * Get notifications ability callback.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_get_notifications( array $input ) {
+	$user_id = extrachill_users_resolve_notification_user_id( $input );
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
+
+	return ec_users_get_notifications(
+		$user_id,
+		array(
+			'unread'   => ! empty( $input['unread'] ),
+			'page'     => isset( $input['page'] ) ? (int) $input['page'] : 1,
+			'per_page' => isset( $input['per_page'] ) ? (int) $input['per_page'] : 50,
+		)
+	);
+}
+
+/**
+ * Get notification unread count ability callback.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_get_notification_unread_count( array $input ) {
+	$user_id = extrachill_users_resolve_notification_user_id( $input );
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
+
+	return array(
+		'user_id'      => $user_id,
+		'unread_count' => ec_users_get_unread_count( $user_id ),
+	);
+}
+
+/**
+ * Mark notifications read ability callback.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_mark_notifications_read( array $input ) {
+	$user_id = extrachill_users_resolve_notification_user_id( $input );
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
+
+	$notification_id = isset( $input['notification_id'] ) ? (int) $input['notification_id'] : 0;
+
+	return array(
+		'user_id' => $user_id,
+		'marked'  => ec_users_mark_notifications_read( $user_id, $notification_id ),
+	);
+}
+
+/**
+ * Clear notifications ability callback.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_clear_notifications( array $input ) {
+	$user_id = extrachill_users_resolve_notification_user_id( $input );
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
+
+	return array(
+		'user_id' => $user_id,
+		'removed' => ec_users_clear_notifications( $user_id, ! empty( $input['all'] ) ),
+	);
+}

--- a/inc/core/abilities/register.php
+++ b/inc/core/abilities/register.php
@@ -37,6 +37,7 @@ require_once __DIR__ . '/user-profile.php';
 require_once __DIR__ . '/subscriptions.php';
 require_once __DIR__ . '/concert-tracking.php';
 require_once __DIR__ . '/concert-import.php';
+require_once __DIR__ . '/notifications.php';
 require_once __DIR__ . '/users-leaderboard.php';
 require_once __DIR__ . '/users-search.php';
 require_once __DIR__ . '/get-user-by-id.php';

--- a/inc/core/activation.php
+++ b/inc/core/activation.php
@@ -37,6 +37,16 @@ function extrachill_users_run_activation() {
 
 	update_site_option( 'extrachill_users_concert_import_runs_table_created', 1 );
 
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/notifications/db.php';
+	if ( function_exists( 'extrachill_users_install_notifications_table' ) ) {
+		extrachill_users_install_notifications_table();
+	}
+
+	update_site_option(
+		'extrachill_users_notifications_schema_version',
+		defined( 'EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION' ) ? (string) EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION : '1'
+	);
+
 	extrachill_users_create_login_pages_network();
 
 	// Register extra_chill_team role on every site in the network and

--- a/inc/notifications/db.php
+++ b/inc/notifications/db.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Network notification table + installers.
+ *
+ * The notification SUBSTRATE for the entire ExtraChill network. Stores one ROW
+ * per notification (not a per-user array blob) in a network-wide table keyed by
+ * {$wpdb->base_prefix} so ANY site (community, events, artist, shop) writes to
+ * and reads from the same table. This supersedes the legacy single-blob
+ * `extrachill_notifications` user_meta on the community site.
+ *
+ * Mirrors the concert-tracking table pattern in this same plugin
+ * (inc/concert-tracking/db.php): base_prefix table + idempotent dbDelta.
+ *
+ * Parent epic: Extra-Chill/extrachill-community#82.
+ *
+ * @package ExtraChill\Users
+ * @since 0.15.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Notification table schema version.
+ *
+ * Bump this whenever the CREATE TABLE string changes so the maybe-install
+ * guard re-runs dbDelta network-wide (dbDelta is the canonical add-column
+ * upgrade path).
+ */
+if ( ! defined( 'EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION' ) ) {
+	define( 'EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION', '1' );
+}
+
+/**
+ * Get the network notification table name.
+ *
+ * Uses base_prefix so it is the SAME table from every site in the network.
+ *
+ * @return string Full table name with base prefix.
+ */
+function extrachill_users_notifications_table_name() {
+	global $wpdb;
+
+	return $wpdb->base_prefix . 'ec_notifications';
+}
+
+/**
+ * Install/upgrade the network notification table.
+ *
+ * Uses dbDelta for idempotent creation. One row per notification.
+ *
+ * Columns:
+ *   - id         PK auto-increment
+ *   - user_id    recipient
+ *   - actor_id   who triggered the notification
+ *   - type       notification type identifier (e.g. reply, mention)
+ *   - title      human-readable title/subject
+ *   - link       URL to the notification target
+ *   - item_id    optional related object ID (post/topic/reply/event)
+ *   - is_read    0 unread, 1 read
+ *   - created_at when the notification was generated (UTC)
+ *
+ * Indexes:
+ *   - idx_user_unread  (user_id, is_read, created_at) — bell badge + unread list
+ *   - idx_user_created (user_id, created_at)          — full paginated list
+ */
+function extrachill_users_install_notifications_table() {
+	global $wpdb;
+
+	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+	$table_name      = extrachill_users_notifications_table_name();
+	$charset_collate = $wpdb->get_charset_collate();
+
+	$sql = "CREATE TABLE {$table_name} (
+		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+		user_id bigint(20) unsigned NOT NULL,
+		actor_id bigint(20) unsigned NOT NULL DEFAULT 0,
+		type varchar(64) NOT NULL DEFAULT '',
+		title text NOT NULL,
+		link text NOT NULL,
+		item_id bigint(20) unsigned DEFAULT NULL,
+		is_read tinyint(1) NOT NULL DEFAULT 0,
+		created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY  (id),
+		KEY idx_user_unread (user_id, is_read, created_at),
+		KEY idx_user_created (user_id, created_at)
+	) {$charset_collate};";
+
+	dbDelta( $sql );
+}

--- a/inc/notifications/service.php
+++ b/inc/notifications/service.php
@@ -1,0 +1,417 @@
+<?php
+/**
+ * Network notification service.
+ *
+ * The network-callable SUBSTRATE for notifications. Because extrachill-users is
+ * a Network:true plugin, ec_users_notify() is loaded on every site and ANY site
+ * (community, events, artist, shop) can call it to enqueue a notification. The
+ * back-compat shim keeps the legacy do_action( 'extrachill_notify' ) producers
+ * working and now routes them into the table from every site.
+ *
+ * All reads/writes target the base_prefix table from inc/notifications/db.php,
+ * so no switch_to_blog is needed — it is the same physical table everywhere.
+ *
+ * Parent epic: Extra-Chill/extrachill-community#82.
+ *
+ * @package ExtraChill\Users
+ * @since 0.15.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/db.php';
+
+// ─── Self-Healing Install ───────────────────────────────────────────────────────
+
+/**
+ * Ensure the network notification table exists and is on the current schema.
+ *
+ * The substrate lives in {base_prefix}ec_notifications (one table for the whole
+ * network). This guard runs on init so the table self-heals on EVERY site — any
+ * site that loads this Network:true plugin creates or upgrades the table the
+ * first time it is missing/outdated, without waiting for a (re)activation.
+ * Re-runs dbDelta whenever EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION is
+ * bumped. The site-option flag is also set by activation, so this is a no-op
+ * after the first install.
+ */
+function ec_users_maybe_install_notifications_table() {
+	$current_version = defined( 'EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION' )
+		? (string) EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION
+		: '1';
+
+	$installed_version = (string) get_site_option( 'extrachill_users_notifications_schema_version', '' );
+
+	if ( $installed_version === $current_version ) {
+		return;
+	}
+
+	extrachill_users_install_notifications_table();
+
+	update_site_option( 'extrachill_users_notifications_schema_version', $current_version );
+}
+add_action( 'init', 'ec_users_maybe_install_notifications_table' );
+
+// ─── Entry Point ───────────────────────────────────────────────────────────────
+
+/**
+ * Create one or more notifications.
+ *
+ * The single network-wide entry point. Callable from any site. Validates and
+ * enriches the payload, then inserts one row per recipient into the base_prefix
+ * notification table.
+ *
+ * @param int|int[] $user_ids Single recipient ID or array of recipient IDs.
+ * @param array     $data {
+ *     Notification payload.
+ *
+ *     @type int    $actor_id Required. User ID who triggered the notification.
+ *     @type string $type     Required. Type identifier (e.g. 'reply', 'mention').
+ *     @type string $link     Required. URL to the notification target.
+ *     @type string $title    Required. Human-readable title/subject.
+ *     @type int    $item_id  Optional. Related object ID (post/topic/reply/event).
+ * }
+ * @return int Number of notification rows inserted.
+ */
+function ec_users_notify( $user_ids, array $data ): int {
+	global $wpdb;
+
+	if ( ! is_array( $user_ids ) ) {
+		$user_ids = array( $user_ids );
+	}
+
+	// Validate required fields.
+	$actor_id = isset( $data['actor_id'] ) ? (int) $data['actor_id'] : 0;
+	$type     = isset( $data['type'] ) ? sanitize_key( $data['type'] ) : '';
+	$link     = isset( $data['link'] ) ? esc_url_raw( (string) $data['link'] ) : '';
+	$title    = isset( $data['title'] ) ? (string) $data['title'] : '';
+
+	// Back-compat: the legacy payload used 'topic_title' for the title field.
+	if ( '' === $title && ! empty( $data['topic_title'] ) ) {
+		$title = (string) $data['topic_title'];
+	}
+
+	$title = sanitize_text_field( $title );
+
+	if ( ! $actor_id || '' === $type || '' === $link || '' === $title ) {
+		return 0;
+	}
+
+	if ( ! get_userdata( $actor_id ) ) {
+		return 0;
+	}
+
+	$item_id = isset( $data['item_id'] ) ? (int) $data['item_id'] : 0;
+	if ( $item_id <= 0 && ! empty( $data['post_id'] ) ) {
+		// Back-compat: legacy callers passed the related object as 'post_id'.
+		$item_id = (int) $data['post_id'];
+	}
+
+	$table      = extrachill_users_notifications_table_name();
+	$created_at = current_time( 'mysql', true );
+	$inserted   = 0;
+
+	foreach ( $user_ids as $user_id ) {
+		$user_id = (int) $user_id;
+
+		if ( $user_id <= 0 || ! get_userdata( $user_id ) ) {
+			continue;
+		}
+
+		$result = $wpdb->insert(
+			$table,
+			array(
+				'user_id'    => $user_id,
+				'actor_id'   => $actor_id,
+				'type'       => $type,
+				'title'      => $title,
+				'link'       => $link,
+				'item_id'    => $item_id > 0 ? $item_id : null,
+				'is_read'    => 0,
+				'created_at' => $created_at,
+			),
+			array( '%d', '%d', '%s', '%s', '%s', $item_id > 0 ? '%d' : null, '%d', '%s' )
+		);
+
+		if ( $result ) {
+			++$inserted;
+		}
+	}
+
+	return $inserted;
+}
+
+// ─── Read / CRUD ─────────────────────────────────────────────────────────────
+
+/**
+ * Enrich a raw notification row with actor display data for rendering.
+ *
+ * @param array $row Raw DB row (associative).
+ * @return array Enriched notification.
+ */
+function ec_users_enrich_notification( array $row ): array {
+	$actor_id           = isset( $row['actor_id'] ) ? (int) $row['actor_id'] : 0;
+	$actor_display_name = '';
+	$actor_profile_link = '';
+
+	if ( $actor_id > 0 ) {
+		$actor = get_userdata( $actor_id );
+		if ( $actor ) {
+			$actor_display_name = $actor->display_name;
+			if ( function_exists( 'extrachill_get_user_community_profile_url' ) ) {
+				$actor_profile_link = (string) extrachill_get_user_community_profile_url( $actor_id );
+			}
+		}
+	}
+
+	return array(
+		'id'                 => isset( $row['id'] ) ? (int) $row['id'] : 0,
+		'user_id'            => isset( $row['user_id'] ) ? (int) $row['user_id'] : 0,
+		'actor_id'           => $actor_id,
+		'actor_display_name' => $actor_display_name,
+		'actor_profile_link' => $actor_profile_link,
+		'type'               => isset( $row['type'] ) ? (string) $row['type'] : '',
+		'title'              => isset( $row['title'] ) ? (string) $row['title'] : '',
+		'link'               => isset( $row['link'] ) ? (string) $row['link'] : '',
+		'item_id'            => empty( $row['item_id'] ) ? null : (int) $row['item_id'],
+		'read'               => ! empty( $row['is_read'] ),
+		'is_read'            => (int) ( ! empty( $row['is_read'] ) ),
+		'time'               => isset( $row['created_at'] ) ? (string) $row['created_at'] : '',
+		'created_at'         => isset( $row['created_at'] ) ? (string) $row['created_at'] : '',
+	);
+}
+
+/**
+ * Get notifications for a user (newest first, paginated).
+ *
+ * @param int   $user_id Recipient user ID.
+ * @param array $args {
+ *     Optional query arguments.
+ *
+ *     @type bool $unread   Only return unread notifications. Default false.
+ *     @type int  $page     1-indexed page number. Default 1.
+ *     @type int  $per_page Results per page (1-100). Default 50.
+ * }
+ * @return array{ user_id:int, total:int, unread_count:int, page:int, pages:int, notifications:array }
+ */
+function ec_users_get_notifications( int $user_id, array $args = array() ): array {
+	global $wpdb;
+
+	$defaults = array(
+		'unread'   => false,
+		'page'     => 1,
+		'per_page' => 50,
+	);
+	$args     = wp_parse_args( $args, $defaults );
+
+	$unread_only = ! empty( $args['unread'] );
+	$per_page    = max( 1, min( 100, (int) $args['per_page'] ) );
+	$page        = max( 1, (int) $args['page'] );
+
+	$table = extrachill_users_notifications_table_name();
+
+	if ( $user_id <= 0 ) {
+		return array(
+			'user_id'       => $user_id,
+			'total'         => 0,
+			'unread_count'  => 0,
+			'page'          => $page,
+			'pages'         => 0,
+			'notifications' => array(),
+		);
+	}
+
+	$unread_count = (int) $wpdb->get_var(
+		$wpdb->prepare(
+			"SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND is_read = 0", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+			$user_id
+		)
+	);
+
+	if ( $unread_only ) {
+		$total = $unread_count;
+	} else {
+		$total = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$table} WHERE user_id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+				$user_id
+			)
+		);
+	}
+
+	$pages  = (int) ceil( $total / $per_page );
+	$page   = $pages > 0 ? min( $page, $pages ) : 1;
+	$offset = ( $page - 1 ) * $per_page;
+
+	if ( 0 === $total ) {
+		return array(
+			'user_id'       => $user_id,
+			'total'         => 0,
+			'unread_count'  => $unread_count,
+			'page'          => $page,
+			'pages'         => 0,
+			'notifications' => array(),
+		);
+	}
+
+	if ( $unread_only ) {
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM {$table} WHERE user_id = %d AND is_read = 0 ORDER BY created_at DESC, id DESC LIMIT %d OFFSET %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+				$user_id,
+				$per_page,
+				$offset
+			),
+			ARRAY_A
+		);
+	} else {
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM {$table} WHERE user_id = %d ORDER BY created_at DESC, id DESC LIMIT %d OFFSET %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+				$user_id,
+				$per_page,
+				$offset
+			),
+			ARRAY_A
+		);
+	}
+
+	$notifications = array();
+	foreach ( (array) $rows as $row ) {
+		$notifications[] = ec_users_enrich_notification( $row );
+	}
+
+	return array(
+		'user_id'       => $user_id,
+		'total'         => $total,
+		'unread_count'  => $unread_count,
+		'page'          => $page,
+		'pages'         => $pages,
+		'notifications' => $notifications,
+	);
+}
+
+/**
+ * Count unread notifications for a user.
+ *
+ * @param int $user_id Recipient user ID.
+ * @return int
+ */
+function ec_users_get_unread_count( int $user_id ): int {
+	global $wpdb;
+
+	if ( $user_id <= 0 ) {
+		return 0;
+	}
+
+	$table = extrachill_users_notifications_table_name();
+
+	return (int) $wpdb->get_var(
+		$wpdb->prepare(
+			"SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND is_read = 0", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+			$user_id
+		)
+	);
+}
+
+/**
+ * Mark notifications as read for a user.
+ *
+ * Marks a single notification (when $notification_id given) or all unread
+ * notifications for the user.
+ *
+ * @param int $user_id         Recipient user ID.
+ * @param int $notification_id Optional. Single notification ID to mark read.
+ *                             0 marks ALL unread for the user. Default 0.
+ * @return int Number of rows updated.
+ */
+function ec_users_mark_notifications_read( int $user_id, int $notification_id = 0 ): int {
+	global $wpdb;
+
+	if ( $user_id <= 0 ) {
+		return 0;
+	}
+
+	$table = extrachill_users_notifications_table_name();
+
+	if ( $notification_id > 0 ) {
+		$updated = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table} SET is_read = 1 WHERE id = %d AND user_id = %d AND is_read = 0", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+				$notification_id,
+				$user_id
+			)
+		);
+	} else {
+		$updated = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table} SET is_read = 1 WHERE user_id = %d AND is_read = 0", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+				$user_id
+			)
+		);
+	}
+
+	return false === $updated ? 0 : (int) $updated;
+}
+
+/**
+ * Clear notifications for a user.
+ *
+ * Deletes ALL notifications when $all is true; otherwise deletes read
+ * notifications older than one week (matching the legacy cleanup semantics).
+ *
+ * @param int  $user_id Recipient user ID.
+ * @param bool $all     Delete ALL notifications, not just old read ones.
+ * @return int Number of rows removed.
+ */
+function ec_users_clear_notifications( int $user_id, bool $all = false ): int {
+	global $wpdb;
+
+	if ( $user_id <= 0 ) {
+		return 0;
+	}
+
+	$table = extrachill_users_notifications_table_name();
+
+	if ( $all ) {
+		$removed = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$table} WHERE user_id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+				$user_id
+			)
+		);
+	} else {
+		$one_week_ago = gmdate( 'Y-m-d H:i:s', time() - WEEK_IN_SECONDS );
+		$removed      = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$table} WHERE user_id = %d AND is_read = 1 AND created_at < %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+				$user_id,
+				$one_week_ago
+			)
+		);
+	}
+
+	return false === $removed ? 0 : (int) $removed;
+}
+
+// ─── Back-Compat Shim ──────────────────────────────────────────────────────────
+
+/**
+ * Forward the legacy extrachill_notify action into the new substrate.
+ *
+ * Registered network-wide so the existing community producers (forum replies +
+ * mentions) keep working AND now write into the table from every site. The
+ * community plugin still registers its own do_action handler on the community
+ * site; a follow-up should remove that handler to avoid double-writes (the
+ * substrate handler here is the canonical one). DO NOT remove it from this PR.
+ *
+ * @param int|int[] $user_ids Recipient ID(s).
+ * @param mixed     $data     Notification payload (legacy shape supported).
+ */
+function ec_users_handle_notify_action( $user_ids, $data ) {
+	if ( ! is_array( $data ) ) {
+		return;
+	}
+
+	ec_users_notify( $user_ids, $data );
+}
+add_action( 'extrachill_notify', 'ec_users_handle_notify_action', 10, 2 );


### PR DESCRIPTION
## Summary

Builds the **network notification SUBSTRATE** in `extrachill-users` (a `Network: true` plugin), the keystone of the network notification infrastructure epic **Extra-Chill/extrachill-community#82**.

Today the notification system is trapped: `extrachill_notify` is a `do_action` whose handler is registered **only** when the community plugin loads, so `do_action('extrachill_notify')` from any other site (events, artist, shop) fires into the void. Storage is a single growing `extrachill_notifications` user_meta **array blob** on the community site (race-prone read-append-write, lossy `array_slice` cap, no pagination). This blocks every cross-site engagement feature (concert reminders, artist-follow notifications, community pull-back emails).

This PR moves the substrate to the one plugin that is loaded on every site and is already the single source of truth for per-user network state (rank-system, badges, concert-tracking). Community keeps its **producers** (replies/mentions) and the bell UI as future **consumers** of this substrate — none of that is touched here.

## What's in scope (substrate only)

### 1. Network-scoped table — `inc/notifications/db.php`
`{$wpdb->base_prefix}ec_notifications`, **one row per notification** (not a per-user blob), installed via idempotent `dbDelta`. Mirrors the existing `inc/concert-tracking/db.php` `base_prefix` pattern, so every site reads/writes the **same physical table** — no `switch_to_blog` needed.

| column | type | notes |
|---|---|---|
| `id` | bigint PK auto_increment | |
| `user_id` | bigint | recipient |
| `actor_id` | bigint | who triggered it |
| `type` | varchar(64) | type identifier (`reply`, `mention`, …) |
| `title` | text | human-readable subject |
| `link` | text | URL to the target |
| `item_id` | bigint nullable | related object (post/topic/reply/event) |
| `is_read` | tinyint default 0 | |
| `created_at` | datetime | UTC |

Indexes: `idx_user_unread (user_id, is_read, created_at)` (bell badge + unread list), `idx_user_created (user_id, created_at)` (full paginated list). Schema-versioned (`EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION`) so a bump re-runs `dbDelta`.

### 2. Network-callable entry point — `ec_users_notify( int|array $user_ids, array $data )`
In `inc/notifications/service.php`. Callable from any site. Validates required fields (`actor_id`, `type`, `link`, `title`; optional `item_id`), enriches via existing network helpers, and inserts one prepared row per recipient. Accepts the legacy payload shape (`topic_title` → `title`, `post_id` → `item_id`).

### 3. Read / CRUD service + abilities
Ports the community read surface to the **new table** instead of user_meta. New abilities under the `extrachill/` namespace, `extrachill-users` category, following this plugin's registration pattern (`wp_register_ability`, `show_in_rest`, own-user permission with `list_users` override):

- `extrachill/get-notifications` — paginated list, newest-first, `unread` filter, returns `unread_count`
- `extrachill/get-notification-unread-count` — bell badge
- `extrachill/mark-notifications-read` — single (`notification_id`) or all
- `extrachill/clear-notifications` — read-older-than-1-week, or `all`

### 4. Back-compat shim
`add_action( 'extrachill_notify', 'ec_users_handle_notify_action', 10, 2 )` registered **network-wide**, forwarding to `ec_users_notify()`. The 2 existing community callers (forum replies + mentions) keep working **and now fire into the new table from every site**.

### Install wiring
- `register_activation_hook` → installs the table + sets the schema-version site option.
- A self-healing `init` guard (`ec_users_maybe_install_notifications_table`) re-runs `dbDelta` network-wide whenever the table is missing/outdated, so it self-heals without a reactivation.

## Verification
- `php -l` clean on all new/modified files.
- `homeboy lint --changed-since HEAD` → **passed, 0 findings** (PHPStan + lint).
- Manual end-to-end via `wp eval-file` against the live main site: table installs (`c8c_ec_notifications`), `ec_users_notify()` inserts, the legacy `do_action('extrachill_notify')` shim maps `topic_title`/`post_id` correctly, newest-first ordering, unread count, single + all mark-read, clear-all, and actor display-name enrichment all confirmed working. Test table dropped + schema flag cleared afterward — production left clean (real install happens on deploy/activation).

## Explicit follow-ups (out of scope here)
1. **Data migration** — backfill the existing `extrachill_notifications` user_meta blobs into the new table (a fresh table is fine for now).
2. **Remove the community-only handler** — `extrachill-community/inc/social/notifications/notification-handler.php` still registers its own `extrachill_notify` handler on the community site; once this ships, that handler should be removed to avoid **double-writes**. (Not edited in this PR.)
3. **Repoint the bell UI** + community read abilities to consume this substrate instead of the user_meta blob.
4. **Delivery channels** — email delivery + scheduled/future notifications.
5. **Data Machine integration** — concert reminders, artist-follow notifications, community pull-back prompts.

Parent epic: Extra-Chill/extrachill-community#82