### PR TITLE
feat(concert-tracking): award rank points for shows attended

### DIFF
--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -145,6 +145,7 @@ function extrachill_users_init() {
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/footer/online-users-stats.php';
 
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/service.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/rank-points.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/buttons.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/import-db.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/import/bootstrap.php';

--- a/inc/concert-tracking/rank-points.php
+++ b/inc/concert-tracking/rank-points.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Concert tracking → community rank points.
+ *
+ * Registers concert-going (My Shows) as a pluggable point source for the
+ * cross-site community rank/points system. The community plugin exposes a
+ * generic, feature-agnostic extensibility seam — the `ec_rank_extra_points`
+ * filter (see extrachill-community/inc/social/rank-system/point-calculation.php)
+ * — and this file is the concert-specific consumer of it. Community never
+ * references concerts; concerts opt into rank via the filter from here. Layer
+ * purity preserved.
+ *
+ * Weight rationale: each tracked show is worth more than a forum reply
+ * (2 points) because attending a concert is a higher-intent, harder-to-fake
+ * signal of genuine scene participation than posting a reply. 3 points per
+ * show is the chosen weight; tune via the `ec_users_concert_rank_points_per_show`
+ * filter below.
+ *
+ * Performance: this runs inside extrachill_get_user_total_points(), whose TOTAL
+ * is transient-cached for one hour, so the show count query (a single COUNT(*)
+ * via ec_users_get_user_event_count) only executes on cache misses.
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Default rank points awarded per tracked show.
+ *
+ * Concerts are higher-intent than a forum reply (2 pts), hence a higher weight.
+ */
+const EC_USERS_CONCERT_RANK_POINTS_PER_SHOW = 3;
+
+/**
+ * Contribute concert-attendance points to a user's community rank total.
+ *
+ * Hooks the community plugin's generic `ec_rank_extra_points` seam and adds
+ * (shows attended × per-show weight) to the running extra-points value. Returns
+ * the value unchanged when the count helper is unavailable so the rank total
+ * never breaks if concert tracking is disabled.
+ *
+ * @param float $points  Running total of externally contributed points.
+ * @param int   $user_id WordPress user ID being scored.
+ * @return float Running total plus this source's contribution.
+ */
+function ec_users_concert_rank_extra_points( $points, $user_id ) {
+	if ( ! function_exists( 'ec_users_get_user_event_count' ) ) {
+		return (float) $points;
+	}
+
+	$shows = ec_users_get_user_event_count( (int) $user_id );
+
+	/**
+	 * Filter the rank points awarded per tracked show.
+	 *
+	 * @param int $points_per_show Default per-show weight.
+	 * @param int $user_id         WordPress user ID being scored.
+	 */
+	$per_show = (int) apply_filters(
+		'ec_users_concert_rank_points_per_show',
+		EC_USERS_CONCERT_RANK_POINTS_PER_SHOW,
+		(int) $user_id
+	);
+
+	return (float) $points + ( $shows * $per_show );
+}
+add_filter( 'ec_rank_extra_points', 'ec_users_concert_rank_extra_points', 10, 2 );


### PR DESCRIPTION
## Summary
- Registers concert-going (My Shows) as a point source for the cross-site community rank system, so attending shows raises a user's rank.
- Concert tracking currently earns **zero** rank points. This wires it in via the community plugin's generic `ec_rank_extra_points` filter — concerts opt INTO rank from here; the community plugin never references concerts (layer purity preserved).

## What changed
- New file `inc/concert-tracking/rank-points.php` hooks `ec_rank_extra_points` and returns `points + (shows × weight)`.
- Show count comes from the existing `ec_users_get_user_event_count( $user_id )` helper (single `COUNT(*)`).
- Required from `extrachill-users.php` via **one isolated line** next to the other concert-tracking requires.

## Weight
- **3 points per tracked show** (default). Concerts are higher-intent / harder-to-fake than a forum reply (2 pts), hence the higher weight.
- Tunable via `ec_users_concert_rank_points_per_show` filter.

## Performance
Runs inside `extrachill_get_user_total_points()`, whose TOTAL is transient-cached for 1 hour, so the count query only fires on cache misses. Gracefully no-ops (returns points unchanged) if the count helper is unavailable.

## Dependency + merge order
> **Depends on Extra-Chill/extrachill-community#88** (the `ec_rank_extra_points` seam). That filter must exist for this consumer to contribute points. **Merge the community PR (#88) first**, then this one. Until the seam is merged, this filter is a harmless no-op (nothing applies `ec_rank_extra_points`).

## Verification
- `php -l` clean on both changed files.
- `homeboy lint --changed-since HEAD` → `passed: true`, PHPStan 0 errors.