### PR TITLE
fix: expose user-facing abilities over Abilities REST /run with per-ability auth (#91)

### DIFF
--- a/inc/core/abilities/artist-access.php
+++ b/inc/core/abilities/artist-access.php
@@ -79,19 +79,19 @@ function extrachill_users_register_artist_access_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'user_id' => array( 'type' => 'integer' ),
-					'type'    => array(
+					'type' => array(
 						'type' => 'string',
 						'enum' => array( 'artist', 'professional' ),
 					),
 				),
-				'required'   => array( 'user_id', 'type' ),
+				'required'   => array( 'type' ),
 			),
 			'output_schema'       => array( 'type' => 'object' ),
 			'execute_callback'    => 'extrachill_users_ability_request_artist_access',
-			'permission_callback' => '__return_true',
+			// Self-only: the authenticated user requests access for themselves.
+			'permission_callback' => 'is_user_logged_in',
 			'meta'                => array(
-				'show_in_rest' => false,
+				'show_in_rest' => true,
 				'annotations'  => array(
 					'readonly' => false,
 				),
@@ -266,12 +266,13 @@ function extrachill_users_ability_reject_artist_access( $input ) {
  * @return array|WP_Error Result or error.
  */
 function extrachill_users_ability_request_artist_access( $input ) {
-	$user_id = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : 0;
-	$type    = isset( $input['type'] ) ? sanitize_text_field( $input['type'] ) : '';
-
-	if ( ! $user_id ) {
-		return new WP_Error( 'missing_user_id', 'user_id is required.' );
+	// Self-only: always operate on the authenticated user, ignoring any client-supplied user_id.
+	$user_id = extrachill_users_resolve_self_user_id();
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
 	}
+
+	$type = isset( $input['type'] ) ? sanitize_text_field( $input['type'] ) : '';
 
 	if ( ! in_array( $type, array( 'artist', 'professional' ), true ) ) {
 		return new WP_Error( 'invalid_type', 'type must be "artist" or "professional".' );

--- a/inc/core/abilities/register.php
+++ b/inc/core/abilities/register.php
@@ -14,6 +14,32 @@ defined( 'ABSPATH' ) || exit;
 add_action( 'wp_abilities_api_categories_init', 'extrachill_users_register_category' );
 
 /**
+ * Resolve the authenticated user for self-only abilities.
+ *
+ * Self-only abilities (profile/settings/subscriptions writes, etc.) operate on the
+ * current user only. When invoked over the Abilities REST `/run` endpoint a client
+ * could otherwise supply an arbitrary `user_id` (IDOR). This helper returns the
+ * authenticated user id so execute callbacks can force `$input['user_id']` to it,
+ * ignoring any client-supplied value. PHP-path callers (extrachill-api routes) pass
+ * `get_current_user_id()` already, so they are unaffected.
+ *
+ * @return int|WP_Error Current user id, or WP_Error if not logged in.
+ */
+function extrachill_users_resolve_self_user_id() {
+	$user_id = get_current_user_id();
+
+	if ( ! $user_id ) {
+		return new WP_Error(
+			'not_authenticated',
+			__( 'You must be logged in.', 'extrachill-users' ),
+			array( 'status' => 401 )
+		);
+	}
+
+	return $user_id;
+}
+
+/**
  * Register users ability category.
  */
 function extrachill_users_register_category() {

--- a/inc/core/abilities/subscriptions.php
+++ b/inc/core/abilities/subscriptions.php
@@ -27,16 +27,14 @@ function extrachill_users_register_subscription_abilities() {
 			'category'            => 'extrachill-users',
 			'input_schema'        => array(
 				'type'       => 'object',
-				'properties' => array(
-					'user_id' => array( 'type' => 'integer' ),
-				),
-				'required'   => array( 'user_id' ),
+				'properties' => array(),
 			),
 			'output_schema'       => array( 'type' => 'object' ),
 			'execute_callback'    => 'extrachill_users_ability_get_subscriptions',
-			'permission_callback' => '__return_true',
+			// Self-only: returns the authenticated user's followed artists / consent.
+			'permission_callback' => 'is_user_logged_in',
 			'meta'                => array(
-				'show_in_rest' => false,
+				'show_in_rest' => true,
 				'annotations'  => array(
 					'readonly'   => true,
 					'idempotent' => true,
@@ -55,19 +53,19 @@ function extrachill_users_register_subscription_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'user_id'           => array( 'type' => 'integer' ),
 					'consented_artists' => array(
 						'type'  => 'array',
 						'items' => array( 'type' => 'integer' ),
 					),
 				),
-				'required'   => array( 'user_id', 'consented_artists' ),
+				'required'   => array( 'consented_artists' ),
 			),
 			'output_schema'       => array( 'type' => 'object' ),
 			'execute_callback'    => 'extrachill_users_ability_update_subscriptions',
-			'permission_callback' => '__return_true',
+			// Self-only: updates the authenticated user's consent preferences.
+			'permission_callback' => 'is_user_logged_in',
 			'meta'                => array(
-				'show_in_rest' => false,
+				'show_in_rest' => true,
 				'annotations'  => array(
 					'readonly'   => false,
 					'idempotent' => true,
@@ -80,14 +78,15 @@ function extrachill_users_register_subscription_abilities() {
 /**
  * Get followed artists and email consent status.
  *
- * @param array $input Input with 'user_id'.
+ * Self-only: resolves the authenticated user; takes no input.
+ *
  * @return array|WP_Error Subscriptions data or error.
  */
-function extrachill_users_ability_get_subscriptions( $input ) {
-	$user_id = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : 0;
-
-	if ( ! $user_id ) {
-		return new WP_Error( 'missing_user_id', 'user_id is required.' );
+function extrachill_users_ability_get_subscriptions() {
+	// Self-only: always operate on the authenticated user, ignoring any client-supplied user_id.
+	$user_id = extrachill_users_resolve_self_user_id();
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
 	}
 
 	$user = get_user_by( 'ID', $user_id );
@@ -161,12 +160,13 @@ function extrachill_users_ability_get_subscriptions( $input ) {
  * @return array|WP_Error Result or error.
  */
 function extrachill_users_ability_update_subscriptions( $input ) {
-	$user_id           = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : 0;
-	$consented_artists = isset( $input['consented_artists'] ) ? array_map( 'intval', (array) $input['consented_artists'] ) : array();
-
-	if ( ! $user_id ) {
-		return new WP_Error( 'missing_user_id', 'user_id is required.' );
+	// Self-only: always operate on the authenticated user, ignoring any client-supplied user_id.
+	$user_id = extrachill_users_resolve_self_user_id();
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
 	}
+
+	$consented_artists = isset( $input['consented_artists'] ) ? array_map( 'intval', (array) $input['consented_artists'] ) : array();
 
 	$user = get_user_by( 'ID', $user_id );
 	if ( ! $user ) {

--- a/inc/core/abilities/user-profile.php
+++ b/inc/core/abilities/user-profile.php
@@ -35,9 +35,11 @@ function extrachill_users_register_profile_abilities() {
 			),
 			'output_schema'       => array( 'type' => 'object' ),
 			'execute_callback'    => 'extrachill_users_ability_get_profile',
+			// Public read: returns only public profile fields (no email). Used to view
+			// other users' profiles, so a client-supplied user_id is intentional.
 			'permission_callback' => '__return_true',
 			'meta'                => array(
-				'show_in_rest' => false,
+				'show_in_rest' => true,
 				'annotations'  => array(
 					'readonly'   => true,
 					'idempotent' => true,
@@ -56,18 +58,17 @@ function extrachill_users_register_profile_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'user_id'      => array( 'type' => 'integer' ),
 					'custom_title' => array( 'type' => 'string' ),
 					'bio'          => array( 'type' => 'string' ),
 					'local_city'   => array( 'type' => 'string' ),
 				),
-				'required'   => array( 'user_id' ),
 			),
 			'output_schema'       => array( 'type' => 'object' ),
 			'execute_callback'    => 'extrachill_users_ability_update_profile',
-			'permission_callback' => '__return_true',
+			// Self-only: operates on the authenticated user; user_id is server-resolved.
+			'permission_callback' => 'is_user_logged_in',
 			'meta'                => array(
-				'show_in_rest' => false,
+				'show_in_rest' => true,
 				'annotations'  => array(
 					'readonly'   => false,
 					'idempotent' => true,
@@ -86,8 +87,7 @@ function extrachill_users_register_profile_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'user_id' => array( 'type' => 'integer' ),
-					'links'   => array(
+					'links' => array(
 						'type'  => 'array',
 						'items' => array(
 							'type'       => 'object',
@@ -100,13 +100,14 @@ function extrachill_users_register_profile_abilities() {
 						),
 					),
 				),
-				'required'   => array( 'user_id', 'links' ),
+				'required'   => array( 'links' ),
 			),
 			'output_schema'       => array( 'type' => 'object' ),
 			'execute_callback'    => 'extrachill_users_ability_update_links',
-			'permission_callback' => '__return_true',
+			// Self-only: operates on the authenticated user; user_id is server-resolved.
+			'permission_callback' => 'is_user_logged_in',
 			'meta'                => array(
-				'show_in_rest' => false,
+				'show_in_rest' => true,
 				'annotations'  => array(
 					'readonly'   => false,
 					'idempotent' => true,
@@ -222,10 +223,10 @@ function extrachill_users_ability_get_profile( $input ) {
  * @return array|WP_Error Updated profile or error.
  */
 function extrachill_users_ability_update_profile( $input ) {
-	$user_id = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : 0;
-
-	if ( ! $user_id ) {
-		return new WP_Error( 'missing_user_id', 'user_id is required.' );
+	// Self-only: always operate on the authenticated user, ignoring any client-supplied user_id.
+	$user_id = extrachill_users_resolve_self_user_id();
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
 	}
 
 	$user = get_user_by( 'ID', $user_id );
@@ -283,12 +284,13 @@ function extrachill_users_ability_update_profile( $input ) {
  * @return array|WP_Error Updated links or error.
  */
 function extrachill_users_ability_update_links( $input ) {
-	$user_id = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : 0;
-	$links   = isset( $input['links'] ) ? $input['links'] : array();
-
-	if ( ! $user_id ) {
-		return new WP_Error( 'missing_user_id', 'user_id is required.' );
+	// Self-only: always operate on the authenticated user, ignoring any client-supplied user_id.
+	$user_id = extrachill_users_resolve_self_user_id();
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
 	}
+
+	$links = isset( $input['links'] ) ? $input['links'] : array();
 
 	$user = get_user_by( 'ID', $user_id );
 	if ( ! $user ) {

--- a/inc/core/abilities/user-settings.php
+++ b/inc/core/abilities/user-settings.php
@@ -28,16 +28,14 @@ function extrachill_users_register_settings_abilities() {
 			'category'            => 'extrachill-users',
 			'input_schema'        => array(
 				'type'       => 'object',
-				'properties' => array(
-					'user_id' => array( 'type' => 'integer' ),
-				),
-				'required'   => array( 'user_id' ),
+				'properties' => array(),
 			),
 			'output_schema'       => array( 'type' => 'object' ),
 			'execute_callback'    => 'extrachill_users_ability_get_settings',
-			'permission_callback' => '__return_true',
+			// Self-only: returns the authenticated user's account settings (incl. email).
+			'permission_callback' => 'is_user_logged_in',
 			'meta'                => array(
-				'show_in_rest' => false,
+				'show_in_rest' => true,
 				'annotations'  => array(
 					'readonly'   => true,
 					'idempotent' => true,
@@ -56,18 +54,17 @@ function extrachill_users_register_settings_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'user_id'      => array( 'type' => 'integer' ),
 					'first_name'   => array( 'type' => 'string' ),
 					'last_name'    => array( 'type' => 'string' ),
 					'display_name' => array( 'type' => 'string' ),
 				),
-				'required'   => array( 'user_id' ),
 			),
 			'output_schema'       => array( 'type' => 'object' ),
 			'execute_callback'    => 'extrachill_users_ability_update_settings',
-			'permission_callback' => '__return_true',
+			// Self-only: updates the authenticated user's account details.
+			'permission_callback' => 'is_user_logged_in',
 			'meta'                => array(
-				'show_in_rest' => false,
+				'show_in_rest' => true,
 				'annotations'  => array(
 					'readonly'   => false,
 					'idempotent' => true,
@@ -86,16 +83,16 @@ function extrachill_users_register_settings_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'user_id'   => array( 'type' => 'integer' ),
 					'new_email' => array( 'type' => 'string' ),
 				),
-				'required'   => array( 'user_id', 'new_email' ),
+				'required'   => array( 'new_email' ),
 			),
 			'output_schema'       => array( 'type' => 'object' ),
 			'execute_callback'    => 'extrachill_users_ability_change_email',
-			'permission_callback' => '__return_true',
+			// Self-only: changes the authenticated user's email.
+			'permission_callback' => 'is_user_logged_in',
 			'meta'                => array(
-				'show_in_rest' => false,
+				'show_in_rest' => true,
 				'annotations'  => array(
 					'readonly' => false,
 				),
@@ -113,18 +110,18 @@ function extrachill_users_register_settings_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'user_id'          => array( 'type' => 'integer' ),
 					'current_password' => array( 'type' => 'string' ),
 					'new_password'     => array( 'type' => 'string' ),
 					'confirm_password' => array( 'type' => 'string' ),
 				),
-				'required'   => array( 'user_id', 'current_password', 'new_password', 'confirm_password' ),
+				'required'   => array( 'current_password', 'new_password', 'confirm_password' ),
 			),
 			'output_schema'       => array( 'type' => 'object' ),
 			'execute_callback'    => 'extrachill_users_ability_change_password',
-			'permission_callback' => '__return_true',
+			// Self-only: changes the authenticated user's password (requires current password).
+			'permission_callback' => 'is_user_logged_in',
 			'meta'                => array(
-				'show_in_rest' => false,
+				'show_in_rest' => true,
 				'annotations'  => array(
 					'readonly' => false,
 				),
@@ -136,14 +133,15 @@ function extrachill_users_register_settings_abilities() {
 /**
  * Get user settings (account details).
  *
- * @param array $input Input with 'user_id'.
+ * Self-only: resolves the authenticated user; takes no input.
+ *
  * @return array|WP_Error Settings data or error.
  */
-function extrachill_users_ability_get_settings( $input ) {
-	$user_id = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : 0;
-
-	if ( ! $user_id ) {
-		return new WP_Error( 'missing_user_id', 'user_id is required.' );
+function extrachill_users_ability_get_settings() {
+	// Self-only: always operate on the authenticated user, ignoring any client-supplied user_id.
+	$user_id = extrachill_users_resolve_self_user_id();
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
 	}
 
 	$user = get_user_by( 'ID', $user_id );
@@ -195,10 +193,10 @@ function extrachill_users_ability_get_settings( $input ) {
  * @return array|WP_Error Updated settings or error.
  */
 function extrachill_users_ability_update_settings( $input ) {
-	$user_id = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : 0;
-
-	if ( ! $user_id ) {
-		return new WP_Error( 'missing_user_id', 'user_id is required.' );
+	// Self-only: always operate on the authenticated user, ignoring any client-supplied user_id.
+	$user_id = extrachill_users_resolve_self_user_id();
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
 	}
 
 	$user = get_user_by( 'ID', $user_id );
@@ -247,8 +245,8 @@ function extrachill_users_ability_update_settings( $input ) {
 		return $result;
 	}
 
-	// Return fresh settings data.
-	return extrachill_users_ability_get_settings( array( 'user_id' => $user_id ) );
+	// Return fresh settings data (resolves the same authenticated user).
+	return extrachill_users_ability_get_settings();
 }
 
 /**
@@ -261,12 +259,13 @@ function extrachill_users_ability_update_settings( $input ) {
  * @return array|WP_Error Result or error.
  */
 function extrachill_users_ability_change_email( $input ) {
-	$user_id   = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : 0;
-	$new_email = isset( $input['new_email'] ) ? sanitize_email( $input['new_email'] ) : '';
-
-	if ( ! $user_id ) {
-		return new WP_Error( 'missing_user_id', 'user_id is required.' );
+	// Self-only: always operate on the authenticated user, ignoring any client-supplied user_id.
+	$user_id = extrachill_users_resolve_self_user_id();
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
 	}
+
+	$new_email = isset( $input['new_email'] ) ? sanitize_email( $input['new_email'] ) : '';
 
 	if ( empty( $new_email ) || ! is_email( $new_email ) ) {
 		return new WP_Error( 'invalid_email', 'Please provide a valid email address.' );
@@ -359,14 +358,15 @@ function extrachill_users_ability_change_email( $input ) {
  * @return array|WP_Error Result or error.
  */
 function extrachill_users_ability_change_password( $input ) {
-	$user_id          = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : 0;
+	// Self-only: always operate on the authenticated user, ignoring any client-supplied user_id.
+	$user_id = extrachill_users_resolve_self_user_id();
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
+
 	$current_password = isset( $input['current_password'] ) ? $input['current_password'] : '';
 	$new_password     = isset( $input['new_password'] ) ? $input['new_password'] : '';
 	$confirm_password = isset( $input['confirm_password'] ) ? $input['confirm_password'] : '';
-
-	if ( ! $user_id ) {
-		return new WP_Error( 'missing_user_id', 'user_id is required.' );
-	}
 
 	$user = get_user_by( 'ID', $user_id );
 	if ( ! $user ) {


### PR DESCRIPTION
## Summary

The 11 user-facing `extrachill-users` abilities were registered `show_in_rest => false`. The WordPress Abilities API `/run` REST controller returns **HTTP 404** for any ability where `show_in_rest` is falsey, so `wp-native-client` (which POSTs to `/wp-json/wp-abilities/v1/abilities/<name>/run`) could not reach them. This blocked the JS API-client unification.

This PR flips `show_in_rest => true` on the 11 user-facing abilities **and** adds proper per-ability auth so direct REST exposure is safe (no IDOR).

Fixes #91. Unblocks Extra-Chill/extrachill-studio#84 and Extra-Chill/extrachill-community#23.

## The bug (verified live + in code)

`abilities-api/.../class-wp-rest-abilities-v1-run-controller.php` `check_ability_permissions()`:
```php
if ( ! $ability || ! $ability->get_meta_item( 'show_in_rest' ) ) {
    return new WP_Error( 'rest_ability_not_found', __( 'Ability not found.' ), array( 'status' => 404 ) );
}
```
Live proof:
```
POST https://community.extrachill.com/wp-json/wp-abilities/v1/abilities/extrachill/get-user-profile/run
→ HTTP 404 {"code":"rest_ability_not_found","message":"Ability not found.","data":{"status":404}}
```

## Why naive `show_in_rest => true` would be unsafe

Today these abilities use `permission_callback => '__return_true'` and take a **required** `user_id` input. They were only safe because the `extrachill-api` REST wrapper routes gate on `is_user_logged_in()` and always inject `user_id => get_current_user_id()` (the client never chooses it). Exposing `/run` directly would let any caller pass an arbitrary `user_id` and read/modify **another user's** profile/settings/subscriptions/email/password — a critical IDOR. So auth had to move into the ability layer.

## Design — per-ability auth

A small shared helper was added in `inc/core/abilities/register.php`:
```php
function extrachill_users_resolve_self_user_id() {
    $user_id = get_current_user_id();
    if ( ! $user_id ) {
        return new WP_Error( 'not_authenticated', __( 'You must be logged in.', 'extrachill-users' ), array( 'status' => 401 ) );
    }
    return $user_id;
}
```
Self-only execute callbacks call it and **ignore any client-supplied `user_id`**, forcing the authenticated user. `user_id` was dropped from those input schemas (server-resolved).

| Ability | show_in_rest | permission_callback | user_id resolution |
|---|---|---|---|
| `get-user-profile` | `true` | `__return_true` | **client-supplied** (public read; views other users' public profiles) |
| `update-user-profile` | `true` | `is_user_logged_in` | self-forced (`get_current_user_id()`) |
| `update-user-links` | `true` | `is_user_logged_in` | self-forced |
| `get-user-settings` | `true` | `is_user_logged_in` | self-forced |
| `update-user-settings` | `true` | `is_user_logged_in` | self-forced |
| `change-user-email` | `true` | `is_user_logged_in` | self-forced |
| `change-user-password` | `true` | `is_user_logged_in` | self-forced |
| `get-subscriptions` | `true` | `is_user_logged_in` | self-forced |
| `update-subscriptions` | `true` | `is_user_logged_in` | self-forced |
| `request-artist-access` | `true` | `is_user_logged_in` | self-forced |
| `users-leaderboard` | `true` (already) | `__return_true` (already) | n/a (no user_id; public ranked list) |

The admin artist-access abilities (`list-artist-access-requests`, `approve-artist-access`, `reject-artist-access`) intentionally **stay `show_in_rest => false`** — out of scope and not user-facing.

## Sensitive-field audit (public abilities)

- **`get-user-profile`** output audited — returns `user_id, display_name, username, avatar_url, custom_title, bio, local_city, links, link_types, artist_access`. **No email or other sensitive fields.** `username`/`display_name`/`avatar` are already public (author URLs, leaderboard). Safe to expose publicly.
- **`users-leaderboard`** output audited — returns display names, usernames, slugs, avatars, profile URLs, points, ranks, badges. All public. No sensitive fields.

## extrachill-api PHP-path routes unaffected

The `inc/routes/users/*.php` handlers in `extrachill-api` already call `$ability->execute( array( 'user_id' => get_current_user_id() ) )`. The self-forced value equals what they pass, so PHP-path callers behave identically. No changes to `extrachill-api` in this PR.

## Tests / lint

- `php -l` clean on all 5 changed files.
- `homeboy lint` (wordpress extension): **zero findings on the changed files**. (Remaining repo findings are pre-existing baseline noise unrelated to this change.)
- No existing tests reference these abilities.

## Notes

Unblocks Extra-Chill/extrachill-community#23 and Extra-Chill/extrachill-studio#84. Also relevant to the latent analytics bug noted in #91 (separate ability, separate repo).