### PR TITLE
refactor(notifications): queue digest sends + schedule via DM RecurringScheduler

### DIFF
--- a/inc/notifications/email.php
+++ b/inc/notifications/email.php
@@ -8,13 +8,17 @@
  * Extra Chill") to pull them back — a retention loop.
  *
  * Design:
- *   - A recurring cron (hourly) finds users whose OLDEST unread notification is
+ *   - A recurring sweep (hourly) finds users whose OLDEST unread notification is
  *     older than EC_NOTIFICATIONS_EMAIL_DELAY (so we never email instantly) and
  *     who have not been emailed within EC_NOTIFICATIONS_EMAIL_COOLDOWN (anti-spam:
- *     at most one digest per user per cooldown window).
- *   - For each such user, ONE branded HTML digest is sent via the platform mail
- *     path (ec_send_email() — it resolves the SMTP-configured site and handles
- *     switch_to_blog() internally; callers must NOT wrap it).
+ *     at most one digest per user per cooldown window). The sweep is scheduled
+ *     through Data Machine's RecurringScheduler (Action Scheduler-backed), with
+ *     a wp_schedule_event() fallback when Data Machine is unavailable.
+ *   - For each such user, ONE branded HTML digest is ENQUEUED via the platform
+ *     queued mail path (ec_send_email_queued() — one Action-Scheduler-backed job
+ *     per recipient; it resolves the SMTP-configured site and handles
+ *     switch_to_blog() internally; callers must NOT wrap it). Queuing keeps cron
+ *     non-blocking and isolates a single failed send from the rest of the batch.
  *   - Per-user opt-out via the ec_notification_emails_disabled user_meta flag
  *     (default OFF == opted-in). A settings-UI toggle is a follow-up.
  *
@@ -84,10 +88,25 @@ const EC_NOTIFICATIONS_EMAILS_DISABLED_META = 'ec_notification_emails_disabled';
  */
 const EC_NOTIFICATIONS_EMAIL_CRON_HOOK = 'ec_notifications_email_digest';
 
+/**
+ * Recurrence interval for the digest sweep (passed to RecurringScheduler).
+ */
+const EC_NOTIFICATIONS_EMAIL_INTERVAL = 'hourly';
+
 // ─── Schedule ──────────────────────────────────────────────────────────────
 
 /**
- * Ensure the recurring digest cron is scheduled (idempotent).
+ * Fully qualified Data Machine RecurringScheduler class name.
+ *
+ * The digest sweep is scheduled through Data Machine's shared recurring
+ * scheduling primitive (Action Scheduler-backed) rather than a hand-rolled
+ * wp_schedule_event(). Data Machine stays generic — extrachill-users consumes
+ * the primitive; no notification-specific code lives in Data Machine.
+ */
+const EC_NOTIFICATIONS_RECURRING_SCHEDULER = '\\DataMachine\\Engine\\Tasks\\RecurringScheduler';
+
+/**
+ * Ensure the recurring digest sweep is scheduled (idempotent).
  *
  * Self-heals on every site that loads this Network:true plugin, mirroring the
  * welcome-email fallback pattern in inc/core/activation.php. Because the
@@ -95,22 +114,67 @@ const EC_NOTIFICATIONS_EMAIL_CRON_HOOK = 'ec_notifications_email_digest';
  * site needs to run the digest — we pin it to the SMTP-configured mail site so
  * exactly one scheduler owns it and sends always originate from a
  * mail-capable context.
+ *
+ * Scheduling goes through Data Machine's RecurringScheduler::ensureSchedule()
+ * (Action Scheduler-backed, idempotent, persistence-verified). When Data
+ * Machine is unavailable, falls back to WP-Cron via wp_schedule_event() so the
+ * digest keeps working in isolation.
+ *
+ * On upgrade from the pre-queue WP-Cron implementation, any lingering
+ * wp_schedule_event() registration of the same hook is cleared first so the
+ * sweep cannot double-fire (once via WP-Cron and once via Action Scheduler).
  */
 function ec_notifications_email_maybe_schedule() {
+	$scheduler = EC_NOTIFICATIONS_RECURRING_SCHEDULER;
+
 	if ( ! ec_notifications_email_is_owner_site() ) {
-		// Not the owner site — make sure no stray schedule lingers here.
-		$existing = wp_next_scheduled( EC_NOTIFICATIONS_EMAIL_CRON_HOOK );
-		if ( $existing ) {
-			wp_unschedule_event( $existing, EC_NOTIFICATIONS_EMAIL_CRON_HOOK );
+		// Not the owner site — make sure no stray schedule lingers here, in
+		// either the legacy WP-Cron slot or the Action Scheduler slot.
+		ec_notifications_email_clear_legacy_wp_cron();
+
+		if ( class_exists( $scheduler ) ) {
+			$scheduler::unschedule( EC_NOTIFICATIONS_EMAIL_CRON_HOOK, array() );
 		}
 		return;
 	}
 
+	// Always clear any legacy wp_schedule_event() registration. When DM is
+	// available this prevents the old WP-Cron event from double-firing
+	// alongside the Action Scheduler recurrence (upgrade path).
+	if ( class_exists( $scheduler ) ) {
+		ec_notifications_email_clear_legacy_wp_cron();
+
+		$scheduler::ensureSchedule(
+			EC_NOTIFICATIONS_EMAIL_CRON_HOOK,
+			array(),
+			EC_NOTIFICATIONS_EMAIL_INTERVAL
+		);
+		return;
+	}
+
+	// Fallback: Data Machine not loaded — keep the WP-Cron schedule.
 	if ( ! wp_next_scheduled( EC_NOTIFICATIONS_EMAIL_CRON_HOOK ) ) {
 		wp_schedule_event( time() + HOUR_IN_SECONDS, 'hourly', EC_NOTIFICATIONS_EMAIL_CRON_HOOK );
 	}
 }
 add_action( 'init', 'ec_notifications_email_maybe_schedule' );
+
+/**
+ * Clear any legacy WP-Cron registration of the digest hook.
+ *
+ * The pre-queue implementation scheduled the sweep with wp_schedule_event().
+ * Once the sweep is owned by Data Machine's RecurringScheduler (Action
+ * Scheduler) we must remove the WP-Cron event so the digest does not fire
+ * twice. Safe to call unconditionally — a no-op when no WP-Cron event exists.
+ *
+ * @return void
+ */
+function ec_notifications_email_clear_legacy_wp_cron() {
+	$existing = wp_next_scheduled( EC_NOTIFICATIONS_EMAIL_CRON_HOOK );
+	if ( $existing ) {
+		wp_clear_scheduled_hook( EC_NOTIFICATIONS_EMAIL_CRON_HOOK );
+	}
+}
 
 /**
  * Is the current site the one that should run the digest cron?
@@ -141,7 +205,12 @@ function ec_notifications_email_is_owner_site() {
 // ─── Digest Run ──────────────────────────────────────────────────────────────
 
 /**
- * Cron callback: find eligible users and send each one digest email.
+ * Recurring callback: find eligible users and enqueue each one a digest email.
+ *
+ * Fired by the scheduled recurrence (Data Machine RecurringScheduler, or the
+ * WP-Cron fallback). Per recipient, ec_notifications_email_send_digest()
+ * enqueues an async send rather than calling wp_mail() inline, so the sweep
+ * itself stays cheap and non-blocking.
  */
 function ec_notifications_email_run() {
 	$user_ids = ec_notifications_email_find_eligible_users( EC_NOTIFICATIONS_EMAIL_BATCH_SIZE );
@@ -243,15 +312,24 @@ function ec_notifications_email_in_cooldown( $user_id, $now ) {
 }
 
 /**
- * Assemble + send one digest email to a user.
+ * Assemble + enqueue one digest email to a user.
  *
- * Re-checks unread state at send time (state can change between the candidate
- * scan and the send). On a successful send, records the last-emailed timestamp
- * so the cooldown applies. Mail goes through ec_send_email(), which resolves the
+ * Re-checks unread state at dispatch time (state can change between the
+ * candidate scan and dispatch), builds the branded digest, then ENQUEUES the
+ * send via ec_send_email_queued() — one Action-Scheduler-backed job per
+ * recipient. This avoids a blocking synchronous wp_mail() loop across the whole
+ * batch: cron no longer waits on SMTP per user, sends are spread across AS
+ * dispatch ticks, and a single failed send is isolated to its own job (the
+ * queued worker retries with backoff and never stalls the rest of the batch).
+ *
+ * The queued send is fire-and-forget from the digest's perspective, so the
+ * cooldown is stamped at ENQUEUE time (on a confirmed enqueue) rather than
+ * after delivery — eligibility and the unread count have already been verified
+ * here, and the worker re-builds nothing. ec_send_email_queued() resolves the
  * SMTP-configured site and handles switch_to_blog() internally — do NOT wrap.
  *
  * @param int $user_id Recipient user ID.
- * @return bool True when an email was dispatched.
+ * @return bool True when a digest send was enqueued.
  */
 function ec_notifications_email_send_digest( $user_id ) {
 	$user_id = (int) $user_id;
@@ -264,7 +342,7 @@ function ec_notifications_email_send_digest( $user_id ) {
 		return false;
 	}
 
-	// Re-check opt-out + cooldown at send time (defensive against races).
+	// Re-check opt-out + cooldown at dispatch time (defensive against races).
 	if ( ec_notifications_email_user_opted_out( $user_id ) ) {
 		return false;
 	}
@@ -292,7 +370,10 @@ function ec_notifications_email_send_digest( $user_id ) {
 
 	$digest = ec_notifications_email_build_digest( $user, $unread_count, $preview );
 
-	$envelope = ec_send_email(
+	// Enqueue one async send per recipient. ec_send_email_queued() delegates to
+	// the datamachine/send-email-queued ability, which returns
+	// [ 'success' => bool, 'action_id' => int, ... ].
+	$envelope = ec_send_email_queued(
 		array(
 			'to'       => $user->user_email,
 			'subject'  => $digest['subject'],
@@ -308,15 +389,17 @@ function ec_notifications_email_send_digest( $user_id ) {
 		)
 	);
 
-	$sent = ! empty( $envelope['success'] );
+	$queued = ! empty( $envelope['success'] );
 
-	if ( ! $sent ) {
+	if ( ! $queued ) {
 		$error = isset( $envelope['error'] ) ? (string) $envelope['error'] : 'unknown error';
-		error_log( sprintf( 'ec_notifications_email: digest send failed for user %d: %s', $user_id, $error ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- canonical operational logging surface.
+		error_log( sprintf( 'ec_notifications_email: digest enqueue failed for user %d: %s', $user_id, $error ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- canonical operational logging surface.
 		return false;
 	}
 
-	// Stamp the cooldown only after a confirmed send.
+	// Stamp the cooldown on a confirmed enqueue. The actual send happens
+	// asynchronously via Action Scheduler (with its own retry/backoff), so we
+	// cannot wait for delivery to record the cooldown.
 	update_user_meta( $user_id, EC_NOTIFICATIONS_LAST_EMAILED_META, time() );
 
 	return true;


### PR DESCRIPTION
## Summary

Hardens the unread-notification email digest channel (`inc/notifications/email.php`) on two axes. No behavioral change to digest **content** or **who receives it** — only the send path and the scheduling primitive change.

Closes #94
Closes #95
Epic: Extra-Chill/extrachill-community#82

> [!NOTE]
> The issues describe `inc/notifications/digest.php` + `inc/notifications/digest-cron.php`. Those files do not exist — the shipped digest is a single file, `inc/notifications/email.php` (the schedule wiring, the sweep, and the per-user send all live there). Both fixes were applied to that file.

## Issue A — queued sends instead of a synchronous loop (#94)

The cron sweep (`ec_notifications_email_run`) iterates eligible users and previously called `ec_notifications_email_send_digest()`, which built the branded digest and sent it **synchronously via `ec_send_email()`** (one blocking `wp_mail()` per user, in-process). On a large network this risks cron timeouts, SMTP bursts, and one failure stalling the batch.

**Change:** `ec_notifications_email_send_digest()` now ENQUEUES each recipient via **`ec_send_email_queued()`** instead of `ec_send_email()`.

- `ec_send_email_queued()` is the existing thin wrapper in `extrachill-multisite/inc/core/mail.php` that delegates to the Data Machine **`datamachine/send-email-queued`** ability.
- **Verified input shape** (identical to `ec_send_email()` — only the queue layer differs): `to`, `subject`, `template` (`extrachill/branded`), `context` (subject_html / recipient_name / body_html / cta_url / cta_label / preheader). `mail_site_id` is auto-resolved by the wrapper. The queued ability returns `[ 'success' => bool, 'action_id' => int, 'scheduled_for' => int, ... ]`; with no `send_at` it `as_enqueue_async_action()`s one job per recipient on the `data-machine-email` group, and the worker retries failed sends with a 5-min backoff (max 3 attempts).
- **Failure isolation:** each recipient is its own AS job, so one bad send can't stall the rest of the batch.
- **Cooldown:** stamped on a confirmed **enqueue** (the send is now async with its own retry/backoff, so we can't wait for delivery). Eligibility + unread count are already verified before enqueue, and the worker re-builds nothing.

## Issue B — schedule via DM RecurringScheduler, not `wp_schedule_event` (#95)

`ec_notifications_email_maybe_schedule()` previously registered the recurring sweep with a hand-rolled `wp_schedule_event()` on `init`.

**Change:** scheduling now goes through **`DataMachine\Engine\Tasks\RecurringScheduler::ensureSchedule( $hook, [], 'hourly' )`** (Action Scheduler-backed, idempotent, persistence-verified).

- **Verified API:** `RecurringScheduler` exposes static `ensureSchedule()` / `unschedule()` (not an instance `schedule()` method) — confirmed by reading the class. `ensureSchedule()` is idempotent (preserves a matching pending action, only reschedules on change) and uses AS group `data-machine`.
- **Upgrade-safe double-fire prevention:** on upgrade from the pre-queue WP-Cron implementation, `ec_notifications_email_clear_legacy_wp_cron()` calls `wp_clear_scheduled_hook()` on the old hook **before** registering the AS recurrence, so the sweep cannot fire twice (once via WP-Cron + once via Action Scheduler).
- **Graceful fallback:** guarded with `class_exists()` — when Data Machine is unavailable, it falls back to the original `wp_schedule_event()` so the digest keeps working in isolation. The non-owner-site branch also unschedules both the legacy WP-Cron slot and the AS slot.

## Layer purity

Data Machine stays generic — this PR only **consumes** its existing email-queue ability + recurring-scheduler primitive. No notification-specific code was added to Data Machine.

## Verification

- `php -l inc/notifications/email.php` → no syntax errors.
- `homeboy lint --changed-since origin/main` → **passed, zero findings** (PHPCS clean, PHPStan 0 errors).
- Re-read the file post-edit: no leftover synchronous `ec_send_email(` call and no leftover `wp_schedule_event()` loop (only the guarded DM-unavailable fallback remains).
- Cadence (`hourly`) and digest content unchanged.

## Security note

No prompt-injection text was found in any source file touched or read during this work.