### PR TITLE
feat(notifications): digest email opt-out toggle + one-click unsubscribe

### DIFF
--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -154,6 +154,7 @@ function extrachill_users_init() {
 	// Network notification substrate: entry point + read/CRUD + back-compat shim.
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/notifications/service.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/notifications/email.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/notifications/unsubscribe.php';
 
 	// wp-native-auth bridge: layer EC policy (membership, blocking, Turnstile)
 	// onto the generic wp-native-auth filter surface when both plugins are active.

--- a/inc/core/abilities/notifications.php
+++ b/inc/core/abilities/notifications.php
@@ -205,6 +205,78 @@ function extrachill_users_register_notification_abilities() {
 			),
 		)
 	);
+
+	// ─── Get Notification Preferences ─────────────────────────────────────────
+
+	wp_register_ability(
+		'extrachill/get-notification-preferences',
+		array(
+			'label'               => __( 'Get Notification Preferences', 'extrachill-users' ),
+			'description'         => __( 'Return a user\'s notification delivery preferences (e.g. whether unread-notification digest emails are enabled). Self-only.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id'        => array( 'type' => 'integer' ),
+					'emails_enabled' => array(
+						'type'        => 'boolean',
+						'description' => 'True when the user receives unread-notification digest emails.',
+					),
+				),
+			),
+			'execute_callback'    => 'extrachill_users_ability_get_notification_preferences',
+			// Self-only: returns the authenticated user's own preferences.
+			'permission_callback' => 'is_user_logged_in',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'   => true,
+					'idempotent' => true,
+				),
+			),
+		)
+	);
+
+	// ─── Update Notification Preferences ──────────────────────────────────────
+
+	wp_register_ability(
+		'extrachill/update-notification-preferences',
+		array(
+			'label'               => __( 'Update Notification Preferences', 'extrachill-users' ),
+			'description'         => __( 'Update a user\'s notification delivery preferences. Currently exposes the unread-notification digest-email opt-in toggle. Self-only.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'emails_enabled' => array(
+						'type'        => 'boolean',
+						'description' => 'Set true to receive unread-notification digest emails, false to opt out.',
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id'        => array( 'type' => 'integer' ),
+					'emails_enabled' => array( 'type' => 'boolean' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_users_ability_update_notification_preferences',
+			// Self-only: updates the authenticated user's own preferences.
+			'permission_callback' => 'is_user_logged_in',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'   => false,
+					'idempotent' => true,
+				),
+			),
+		)
+	);
 }
 
 // ─── Execute Callbacks ─────────────────────────────────────────────────────────
@@ -308,5 +380,53 @@ function extrachill_users_ability_clear_notifications( array $input ) {
 	return array(
 		'user_id' => $user_id,
 		'removed' => ec_users_clear_notifications( $user_id, ! empty( $input['all'] ) ),
+	);
+}
+
+/**
+ * Get notification preferences ability callback.
+ *
+ * Self-only: always operates on the authenticated user, ignoring any
+ * client-supplied user_id (avoids IDOR over the Abilities /run endpoint).
+ *
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_get_notification_preferences() {
+	$user_id = extrachill_users_resolve_self_user_id();
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
+
+	return array(
+		'user_id'        => $user_id,
+		'emails_enabled' => ec_users_notification_emails_enabled( $user_id ),
+	);
+}
+
+/**
+ * Update notification preferences ability callback.
+ *
+ * Self-only. Persists the digest-email opt-in toggle through the canonical
+ * setter ec_users_set_notification_emails_disabled() — the SAME setter the
+ * one-click unsubscribe endpoint uses. The user-facing `emails_enabled` is
+ * inverted into the internal DISABLED flag here.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_update_notification_preferences( array $input ) {
+	$user_id = extrachill_users_resolve_self_user_id();
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
+
+	if ( array_key_exists( 'emails_enabled', $input ) ) {
+		$emails_enabled = filter_var( $input['emails_enabled'], FILTER_VALIDATE_BOOLEAN );
+		ec_users_set_notification_emails_disabled( $user_id, ! $emails_enabled );
+	}
+
+	return array(
+		'user_id'        => $user_id,
+		'emails_enabled' => ec_users_notification_emails_enabled( $user_id ),
 	);
 }

--- a/inc/notifications/email.php
+++ b/inc/notifications/email.php
@@ -20,7 +20,10 @@
  *     switch_to_blog() internally; callers must NOT wrap it). Queuing keeps cron
  *     non-blocking and isolates a single failed send from the rest of the batch.
  *   - Per-user opt-out via the ec_notification_emails_disabled user_meta flag
- *     (default OFF == opted-in). A settings-UI toggle is a follow-up.
+ *     (default OFF == opted-in). Written ONLY through the canonical setter
+ *     ec_users_set_notification_emails_disabled(), which both the settings-UI
+ *     toggle (update-notification-preferences ability) and the one-click
+ *     unsubscribe endpoint (inc/notifications/unsubscribe.php) call.
  *
  * Reads the substrate via ec_users_get_notifications() / a local distinct-user
  * query; never modifies db.php / service.php / abilities.
@@ -35,6 +38,7 @@
 defined( 'ABSPATH' ) || exit;
 
 require_once __DIR__ . '/service.php';
+require_once __DIR__ . '/unsubscribe.php';
 
 // ─── Tunables ────────────────────────────────────────────────────────────────
 
@@ -296,6 +300,50 @@ function ec_notifications_email_user_opted_out( $user_id ) {
 }
 
 /**
+ * Canonical setter for the digest-email opt-out flag.
+ *
+ * THE single source of truth for writing ec_notification_emails_disabled. Both
+ * the settings save path (the update-notification-preferences ability) and the
+ * one-click unsubscribe endpoint call through here so the persistence logic
+ * lives in exactly one place.
+ *
+ * Enabling removes the flag entirely (so the default "opted-in" state is the
+ * absence of the meta), keeping ec_notifications_email_user_opted_out() simple.
+ *
+ * @param int  $user_id  User ID.
+ * @param bool $disabled True to DISABLE digest emails, false to enable.
+ * @return bool True on success, false on an invalid user.
+ */
+function ec_users_set_notification_emails_disabled( $user_id, $disabled ) {
+	$user_id = (int) $user_id;
+	if ( $user_id <= 0 ) {
+		return false;
+	}
+
+	if ( $disabled ) {
+		update_user_meta( $user_id, EC_NOTIFICATIONS_EMAILS_DISABLED_META, 1 );
+		return true;
+	}
+
+	// Enabling = remove the flag so the opted-out check is false (default ON).
+	delete_user_meta( $user_id, EC_NOTIFICATIONS_EMAILS_DISABLED_META );
+	return true;
+}
+
+/**
+ * Whether unread-notification digest emails are ENABLED for a user.
+ *
+ * User-facing sense: true == the user receives digest emails. Derived from the
+ * inverted internal DISABLED flag. The settings UI binds its toggle to this.
+ *
+ * @param int $user_id User ID.
+ * @return bool
+ */
+function ec_users_notification_emails_enabled( $user_id ) {
+	return ! ec_notifications_email_user_opted_out( $user_id );
+}
+
+/**
  * Is the user inside the anti-spam cooldown window?
  *
  * @param int $user_id User ID.
@@ -370,6 +418,14 @@ function ec_notifications_email_send_digest( $user_id ) {
 
 	$digest = ec_notifications_email_build_digest( $user, $unread_count, $preview );
 
+	// Append a tokenized one-click unsubscribe footer line. Built here (not in
+	// the pure build_digest assembler) because it mints a per-user signed URL.
+	$body_html        = $digest['body_html'];
+	$unsubscribe_html = ec_notifications_email_unsubscribe_footer_html( $user_id );
+	if ( '' !== $unsubscribe_html ) {
+		$body_html .= $unsubscribe_html;
+	}
+
 	// Enqueue one async send per recipient. ec_send_email_queued() delegates to
 	// the datamachine/send-email-queued ability, which returns
 	// [ 'success' => bool, 'action_id' => int, ... ].
@@ -381,7 +437,7 @@ function ec_notifications_email_send_digest( $user_id ) {
 			'context'  => array(
 				'subject_html'   => esc_html( $digest['subject'] ),
 				'recipient_name' => $user->display_name,
-				'body_html'      => $digest['body_html'],
+				'body_html'      => $body_html,
 				'cta_url'        => $digest['cta_url'],
 				'cta_label'      => __( 'View Notifications', 'extrachill-users' ),
 				'preheader'      => $digest['preheader'],
@@ -473,6 +529,33 @@ function ec_notifications_email_build_digest( WP_User $user, $unread_count, arra
 		'body_html' => $body_html,
 		'cta_url'   => $notifications_url,
 	);
+}
+
+/**
+ * Build the one-click unsubscribe footer HTML for a digest email.
+ *
+ * Mints a per-user signed unsubscribe URL (inc/notifications/unsubscribe.php)
+ * and wraps it in a small footer paragraph. Returns '' if the URL can't be
+ * built (e.g. invalid user), so the caller simply omits the line.
+ *
+ * @param int $user_id Recipient user ID.
+ * @return string Footer HTML, or '' on failure.
+ */
+function ec_notifications_email_unsubscribe_footer_html( $user_id ) {
+	if ( ! function_exists( 'ec_notifications_unsubscribe_url' ) ) {
+		return '';
+	}
+
+	$url = ec_notifications_unsubscribe_url( (int) $user_id );
+	if ( '' === $url ) {
+		return '';
+	}
+
+	return '<p style="font-size:12px;color:#888;margin-top:24px;">'
+		. esc_html__( 'Don\'t want these emails?', 'extrachill-users' ) . ' '
+		. '<a href="' . esc_url( $url ) . '" style="color:#888;">'
+		. esc_html__( 'Unsubscribe from notification emails', 'extrachill-users' )
+		. '</a>.</p>';
 }
 
 /**

--- a/inc/notifications/unsubscribe.php
+++ b/inc/notifications/unsubscribe.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * One-click digest-email unsubscribe.
+ *
+ * CAN-SPAM / good-citizen requirement for the unread-notification digest
+ * (inc/notifications/email.php): every digest email carries a tokenized
+ * one-click unsubscribe link in its footer. Hitting the link sets the
+ * ec_notification_emails_disabled flag for that user WITHOUT requiring login,
+ * then renders a small confirmation page.
+ *
+ * Security:
+ *   - The link carries a uid + an HMAC signature, NOT a raw/guessable user_id.
+ *     The signature is keyed by wp_salt('auth') (a per-install secret) via
+ *     hash_hmac('sha256', ...), so a tampered uid is rejected. We reuse WP's
+ *     own signing material rather than rolling a new secret.
+ *   - Tokens are time-boxed: the signed payload includes an issue timestamp and
+ *     links expire after EC_NOTIFICATIONS_UNSUBSCRIBE_TTL.
+ *   - The flag is written ONLY through the canonical setter
+ *     ec_users_set_notification_emails_disabled() (defined in email.php) — the
+ *     same setter the settings-UI toggle uses.
+ *   - No AJAX (system-wide rule): the landing is a GET REST route that runs
+ *     before the template layer, renders confirmation HTML, and exits — the
+ *     same pattern as the browser-handoff handler.
+ *
+ * Issues: Extra-Chill/extrachill-users#97 (this), Extra-Chill/extrachill-users#96
+ *         (the settings toggle sharing the canonical setter).
+ * Parent epic: Extra-Chill/extrachill-community#82.
+ *
+ * @package ExtraChill\Users
+ * @since 0.15.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/email.php';
+
+/**
+ * How long a one-click unsubscribe link stays valid (seconds).
+ *
+ * Digests are infrequent, but a generous window keeps the link working if a
+ * user opens an older email. 30 days balances usability and replay surface.
+ */
+if ( ! defined( 'EC_NOTIFICATIONS_UNSUBSCRIBE_TTL' ) ) {
+	define( 'EC_NOTIFICATIONS_UNSUBSCRIBE_TTL', 30 * DAY_IN_SECONDS );
+}
+
+/**
+ * Action context string mixed into the HMAC so a signature minted for the
+ * unsubscribe flow can't be replayed against any other wp_hash-style use.
+ */
+const EC_NOTIFICATIONS_UNSUBSCRIBE_ACTION = 'ec_notifications_unsubscribe';
+
+/**
+ * Compute the HMAC signature for an unsubscribe link.
+ *
+ * Keyed by wp_salt('auth') (per-install secret). Binds the user id, the issue
+ * timestamp, and a fixed action context so the signature is non-transferable.
+ *
+ * @param int $user_id  User ID.
+ * @param int $issued_at Unix timestamp the link was issued.
+ * @return string Hex HMAC signature.
+ */
+function ec_notifications_unsubscribe_signature( $user_id, $issued_at ) {
+	$message = EC_NOTIFICATIONS_UNSUBSCRIBE_ACTION . '|' . (int) $user_id . '|' . (int) $issued_at;
+	return hash_hmac( 'sha256', $message, wp_salt( 'auth' ) );
+}
+
+/**
+ * Build a signed one-click unsubscribe URL for a user.
+ *
+ * Returns a GET URL into the extrachill/v1/notifications/unsubscribe REST route
+ * carrying uid, ts (issue time) and sig (HMAC). Returns '' for an invalid user.
+ *
+ * @param int $user_id User ID.
+ * @return string Absolute unsubscribe URL, or '' on invalid input.
+ */
+function ec_notifications_unsubscribe_url( $user_id ) {
+	$user_id = (int) $user_id;
+	if ( $user_id <= 0 ) {
+		return '';
+	}
+
+	$issued_at = time();
+	$sig       = ec_notifications_unsubscribe_signature( $user_id, $issued_at );
+
+	return add_query_arg(
+		array(
+			'uid' => $user_id,
+			'ts'  => $issued_at,
+			'sig' => $sig,
+		),
+		rest_url( 'extrachill/v1/notifications/unsubscribe' )
+	);
+}
+
+/**
+ * Verify an unsubscribe token triple.
+ *
+ * Constant-time signature comparison + TTL window check. Returns the verified
+ * user ID, or a WP_Error describing why the token is invalid.
+ *
+ * @param int    $user_id   Claimed user ID.
+ * @param int    $issued_at Claimed issue timestamp.
+ * @param string $sig       Provided HMAC signature.
+ * @return int|WP_Error Verified user ID, or WP_Error on failure.
+ */
+function ec_notifications_unsubscribe_verify( $user_id, $issued_at, $sig ) {
+	$user_id   = (int) $user_id;
+	$issued_at = (int) $issued_at;
+	$sig       = (string) $sig;
+
+	if ( $user_id <= 0 || $issued_at <= 0 || '' === $sig ) {
+		return new WP_Error( 'invalid_unsubscribe_token', 'Invalid unsubscribe link.', array( 'status' => 400 ) );
+	}
+
+	// Reject expired or future-dated links.
+	$now = time();
+	if ( $issued_at > $now + MINUTE_IN_SECONDS || ( $now - $issued_at ) > EC_NOTIFICATIONS_UNSUBSCRIBE_TTL ) {
+		return new WP_Error( 'expired_unsubscribe_token', 'This unsubscribe link has expired.', array( 'status' => 400 ) );
+	}
+
+	$expected = ec_notifications_unsubscribe_signature( $user_id, $issued_at );
+	if ( ! hash_equals( $expected, $sig ) ) {
+		return new WP_Error( 'invalid_unsubscribe_token', 'Invalid unsubscribe link.', array( 'status' => 400 ) );
+	}
+
+	if ( ! get_userdata( $user_id ) ) {
+		return new WP_Error( 'invalid_unsubscribe_token', 'Invalid unsubscribe link.', array( 'status' => 400 ) );
+	}
+
+	return $user_id;
+}
+
+add_action( 'rest_api_init', 'ec_notifications_register_unsubscribe_route' );
+
+/**
+ * Register the one-click unsubscribe REST route.
+ *
+ * GET + public (no login): the token itself authorizes the single, scoped
+ * action of disabling that user's digest emails.
+ */
+function ec_notifications_register_unsubscribe_route() {
+	register_rest_route(
+		'extrachill/v1',
+		'/notifications/unsubscribe',
+		array(
+			'methods'             => 'GET',
+			'callback'            => 'ec_notifications_handle_unsubscribe',
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'uid' => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'ts'  => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+				'sig' => array(
+					'required'          => true,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Handle the unsubscribe link: verify token, set opt-out flag, render page.
+ *
+ * Renders a minimal HTML confirmation page and exits (like the browser-handoff
+ * handler), so the user lands on a friendly page rather than a JSON body.
+ *
+ * @param WP_REST_Request $request Request.
+ * @return void Always renders HTML and exits.
+ */
+function ec_notifications_handle_unsubscribe( WP_REST_Request $request ) {
+	$verified = ec_notifications_unsubscribe_verify(
+		$request->get_param( 'uid' ),
+		$request->get_param( 'ts' ),
+		(string) $request->get_param( 'sig' )
+	);
+
+	if ( is_wp_error( $verified ) ) {
+		ec_notifications_render_unsubscribe_page(
+			__( 'Unsubscribe link invalid', 'extrachill-users' ),
+			__( 'This unsubscribe link is invalid or has expired. You can manage email preferences from your account settings.', 'extrachill-users' )
+		);
+		return; // ec_notifications_render_unsubscribe_page() exits.
+	}
+
+	// Canonical setter — same path the settings toggle writes through.
+	ec_users_set_notification_emails_disabled( $verified, true );
+
+	ec_notifications_render_unsubscribe_page(
+		__( 'You\'re unsubscribed', 'extrachill-users' ),
+		__( 'You will no longer receive unread-notification emails from Extra Chill. You can turn them back on any time from your account settings.', 'extrachill-users' )
+	);
+}
+
+/**
+ * Render a minimal standalone confirmation page and exit.
+ *
+ * Standalone (not themed) so it works even when hit before the template layer
+ * and regardless of which network site the link resolves through.
+ *
+ * @param string $title   Page heading.
+ * @param string $message Body message.
+ * @return void Exits.
+ */
+function ec_notifications_render_unsubscribe_page( $title, $message ) {
+	if ( ! headers_sent() ) {
+		status_header( 200 );
+		nocache_headers();
+		header( 'Content-Type: text/html; charset=utf-8' );
+	}
+
+	echo '<!DOCTYPE html><html><head><meta charset="utf-8">';
+	echo '<meta name="viewport" content="width=device-width, initial-scale=1">';
+	echo '<meta name="robots" content="noindex,nofollow">';
+	echo '<title>' . esc_html( $title ) . '</title>';
+	echo '<style>body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;background:#f6f6f6;color:#222;margin:0;padding:0}'
+		. '.wrap{max-width:520px;margin:10vh auto;padding:2rem;background:#fff;border-radius:8px;box-shadow:0 1px 4px rgba(0,0,0,.08);text-align:center}'
+		. 'h1{font-size:1.4rem;margin:0 0 1rem}p{line-height:1.5;margin:0 0 1.5rem}'
+		. 'a{display:inline-block;color:#fff;background:#222;text-decoration:none;padding:.65rem 1.25rem;border-radius:6px}</style>';
+	echo '</head><body><div class="wrap">';
+	echo '<h1>' . esc_html( $title ) . '</h1>';
+	echo '<p>' . esc_html( $message ) . '</p>';
+	echo '<a href="' . esc_url( home_url( '/' ) ) . '">' . esc_html__( 'Back to Extra Chill', 'extrachill-users' ) . '</a>';
+	echo '</div></body></html>';
+
+	exit;
+}


### PR DESCRIPTION
## Summary

Adds a user-facing opt-out for the unread-notification digest email in two ways: a settings toggle and a one-click unsubscribe link in the email footer. Both write through a single canonical setter.

Closes #96
Closes #97
Parent epic: Extra-Chill/extrachill-community#82

## What the prompt assumed vs. reality

The brief described an existing **digest frequency settings UI** (`digest-frequency-settings.php`, `Email::set_frequency`, `Service::rest_update_preferences`, `inc/account/*`) to extend. **None of that exists** on `main`. The shipped notification system is:

- `inc/notifications/service.php` — substrate (procedural functions, no `Service::` class)
- `inc/notifications/email.php` — the digest cron + the `ec_notification_emails_disabled` flag (read-only at send time, programmatic-only)
- `inc/core/abilities/notifications.php` — the **read/write surface is Abilities**, not a PHP form

Per the platform architecture (abilities own logic/writes; REST/CLI are thin wrappers; **NO AJAX**), the settings save path *is* the abilities layer. I extended that instead of building a parallel form handler.

## Issue A (#96) — settings-UI toggle for digest-email opt-out

- Added two abilities in `inc/core/abilities/notifications.php`, matching the existing notification-abilities pattern exactly:
  - `extrachill/get-notification-preferences` (self-only, readonly)
  - `extrachill/update-notification-preferences` (self-only) — accepts `emails_enabled` (boolean)
- The toggle is expressed in **user-facing sense** (`emails_enabled` = receiving emails); the ability inverts it into the internal `ec_notification_emails_disabled` DISABLED flag.
- Self-only via the existing `extrachill_users_resolve_self_user_id()` helper (no IDOR over the `/run` endpoint).
- These are auto-exposed over REST (`show_in_rest`) for the frontend settings UI (rendered in the community/account surface, which already consumes these abilities) — no new stack introduced.

## Issue B (#97) — one-click unsubscribe link in digest footer

- New `inc/notifications/unsubscribe.php`:
  - **Token scheme:** `uid` + issue `ts` + `sig`, where `sig = hash_hmac('sha256', "ec_notifications_unsubscribe|uid|ts", wp_salt('auth'))`. Reuses WP's own per-install signing material (`wp_salt`), no new secret, no guessable raw user_id. Action-context string prevents cross-use replay.
  - **Time-boxed:** links expire after `EC_NOTIFICATIONS_UNSUBSCRIBE_TTL` (30 days); future-dated tokens rejected; `hash_equals()` constant-time compare.
  - **Landing:** a public `GET extrachill/v1/notifications/unsubscribe` REST route (no login) — same "runs before the template layer, render + exit" pattern as the existing browser-handoff handler. **No AJAX.** Verifies the token, sets the flag, renders a minimal standalone `noindex` confirmation page. Tampered/expired tokens render an "invalid link" page.
- Footer link added to the digest body in `email.php` via `ec_notifications_email_unsubscribe_footer_html()` (built in the send function, not the pure `build_digest()` assembler, since it mints a per-user signed URL).

## Shared canonical setter (the A↔B dependency)

Both paths write the same flag through one function in `inc/notifications/email.php`:

- `ec_users_set_notification_emails_disabled( $user_id, bool $disabled )` — the only writer of `ec_notification_emails_disabled` (enabling deletes the meta so default = opted-in).
- `ec_users_notification_emails_enabled( $user_id )` — user-facing getter (inverts the flag).

The digest already respects the flag at send time (`ec_notifications_email_user_opted_out()`), so no change was needed there.

## Verification

- `php -l` clean on all changed files.
- `homeboy lint --changed-since origin/main` → **No lint findings.**
- Token round-trip via `wp eval`: valid token verifies to the user; canonical setter disables/re-enables; **tampered uid, tampered sig, and expired token all REJECTED**.
- Ability round-trip via `wp eval`: `emails_enabled=false` sets the disabled meta; `emails_enabled=true` clears it; getter reflects state. Both abilities registered.

## Security note

No prompt-injection text was encountered in any committed source file touched by this PR.