### PR TITLE
feat(notifications): render notification bell network-wide (refs #104)

### DIFF
--- a/assets/css/notification-bell.css
+++ b/assets/css/notification-bell.css
@@ -1,0 +1,39 @@
+/**
+ * Notification Bell Styles
+ *
+ * Minimal styling for the header notification bell rendered by
+ * inc/notifications/bell.php. Enqueued network-wide for logged-in users so the
+ * bell looks correct on every site (the theme owns .header-right-icon layout;
+ * these rules style the bell glyph and the unread-count badge).
+ *
+ * Moved here from extrachill-community per Extra-Chill/extrachill-users#104.
+ *
+ * @package ExtraChill\Users
+ */
+
+.notification-bell-svg {
+	color: var(--button-text-color);
+	font-size: var(--font-size-lg);
+}
+
+.notification-bell-icon a:hover .notification-bell-svg {
+	color: var(--link-color);
+}
+
+.notification-bell-icon {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.notification-count {
+	position: absolute;
+	top: -5px;
+	right: -5px;
+	background-color: var(--error-color);
+	color: var(--button-text-color);
+	border-radius: 50%;
+	padding: 0 5px;
+	font-size: var(--font-size-xs);
+}

--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -155,6 +155,8 @@ function extrachill_users_init() {
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/notifications/service.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/notifications/email.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/notifications/unsubscribe.php';
+	// Header notification bell — renders network-wide via the theme header hook.
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/notifications/bell.php';
 
 	// wp-native-auth bridge: layer EC policy (membership, blocking, Turnstile)
 	// onto the generic wp-native-auth filter surface when both plugins are active.

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -61,6 +61,20 @@ function extrachill_users_enqueue_avatar_menu_assets() {
 			'all'
 		);
 	}
+
+	// Notification bell styles — only needed when the bell renders, i.e. for
+	// logged-in users. The bell itself is hooked into the theme header by
+	// inc/notifications/bell.php and appears network-wide.
+	$notification_bell_css_path = EXTRACHILL_USERS_PLUGIN_DIR . 'assets/css/notification-bell.css';
+	if ( is_user_logged_in() && file_exists( $notification_bell_css_path ) ) {
+		wp_enqueue_style(
+			'extrachill-users-notification-bell',
+			EXTRACHILL_USERS_PLUGIN_URL . 'assets/css/notification-bell.css',
+			array( 'extrachill-root' ),
+			(string) filemtime( $notification_bell_css_path ),
+			'all'
+		);
+	}
 }
 add_action( 'wp_enqueue_scripts', 'extrachill_users_enqueue_avatar_menu_assets' );
 

--- a/inc/notifications/bell.php
+++ b/inc/notifications/bell.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Notification Bell Display Component
+ *
+ * Renders the notification bell icon with an unread-count badge in the theme
+ * header for logged-in users. Lives in extrachill-users (network-activated) so
+ * the bell appears on EVERY site in the network, not just community.
+ *
+ * Reads the unread count from the network notification substrate
+ * (extrachill/get-notification-unread-count). The substrate table is keyed by
+ * base_prefix, so it is the same physical table on every site — no
+ * switch_to_blog is required here. The bell always links to the community
+ * site's /notifications page, which renders the full notification list.
+ *
+ * Moved here from extrachill-community per Extra-Chill/extrachill-users#104.
+ *
+ * @package ExtraChill\Users
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Display the notification bell with unread count.
+ *
+ * Renders for logged-in users only. Reads the unread count from the network
+ * notification substrate and always links to the community notifications page.
+ */
+function extrachill_users_display_notification_bell() {
+	if ( ! is_user_logged_in() ) {
+		return;
+	}
+
+	$unread_count = extrachill_users_get_unread_notification_count();
+
+	// Resolve the community notifications URL. ec_get_site_url() is provided by
+	// extrachill-multisite (a hard dependency of this plugin), but guard anyway
+	// so a missing helper degrades gracefully instead of fataling.
+	$notifications_url = function_exists( 'ec_get_site_url' )
+		? ec_get_site_url( 'community' ) . '/notifications'
+		: home_url( '/notifications' );
+	?>
+	<div class="notification-bell-icon header-right-icon">
+		<a href="<?php echo esc_url( $notifications_url ); ?>" title="Notifications">
+			<?php
+			// ec_icon() is a theme helper (network-wide). Fall back to a simple
+			// span if it is unavailable so the bell never fatals.
+			if ( function_exists( 'ec_icon' ) ) {
+				echo ec_icon( 'bell', 'notification-bell-svg' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- ec_icon() returns trusted, self-contained SVG markup for a fixed internal icon id
+			} else {
+				echo '<span class="notification-bell-svg" aria-hidden="true">&#128276;</span>';
+			}
+			?>
+			<?php if ( $unread_count > 0 ) : ?>
+				<span class="notification-count"><?php echo (int) $unread_count; ?></span>
+			<?php endif; ?>
+		</a>
+	</div>
+	<?php
+}
+
+/**
+ * Get the current user's unread notification count from the substrate.
+ *
+ * Thin wrapper over the extrachill/get-notification-unread-count ability
+ * (registered by this plugin). Falls back to 0 if the ability is unavailable.
+ *
+ * @return int Unread notification count.
+ */
+function extrachill_users_get_unread_notification_count() {
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		return 0;
+	}
+
+	$ability = wp_get_ability( 'extrachill/get-notification-unread-count' );
+	if ( ! $ability ) {
+		return 0;
+	}
+
+	$result = $ability->execute( array( 'user_id' => get_current_user_id() ) );
+	if ( is_wp_error( $result ) || ! is_array( $result ) ) {
+		return 0;
+	}
+
+	return isset( $result['unread_count'] ) ? (int) $result['unread_count'] : 0;
+}
+
+// Hook notification bell into theme header (priority 20: after navigation, before avatar menu).
+add_action( 'extrachill_header_top_right', 'extrachill_users_display_notification_bell', 20 );


### PR DESCRIPTION
## Summary
Moves the header notification bell **render** out of `extrachill-community` (active community-only) and into `extrachill-users` (network-activated) so logged-in users see the bell on **every** site's header, not just community.extrachill.com.

The notification substrate (`{base_prefix}ec_notifications` table, `ec_users_notify()`, reads, and the 6 abilities incl. `extrachill/get-notification-unread-count`) already lives here and is network-wide — only the bell render needed to move.

## What changed
- **New `inc/notifications/bell.php`** — `extrachill_users_display_notification_bell()` (hooked `extrachill_header_top_right` @ priority 20, same as before) + `extrachill_users_get_unread_notification_count()`, a thin wrapper over the `extrachill/get-notification-unread-count` ability.
- **Behavior preserved exactly**: `is_user_logged_in()` guard, same markup (`div.notification-bell-icon.header-right-icon > a > ec_icon('bell',…) + span.notification-count` when count > 0), still links to `ec_get_site_url('community') . '/notifications'`.
- **Cross-plugin deps guarded** with `function_exists()`: `ec_icon()` (theme), `ec_get_site_url()` (multisite), `wp_get_ability()`. Graceful fallbacks if any are missing (bell glyph span / `home_url('/notifications')`).
- **Wired into the loader** in `extrachill-users.php` right after the existing notification substrate requires.

## CSS decision
The bell's visual rules previously lived in **community's `inc/assets/css/global.css`** (community-only); the theme owns `.header-right-icon` layout network-wide. I added a **minimal** `assets/css/notification-bell.css` here with only `.notification-bell-icon`, `.notification-count`, `.notification-bell-svg`, enqueued network-wide **for logged-in users only**, depending on `extrachill-root`. The unused `.notification-bell-avatar-wrapper` rules were dropped (zero usage). Community's heavy stylesheet is NOT enqueued network-wide.

## No switch_to_blog
Substrate table is `base_prefix`-keyed — same physical table on every site. None added.

## Verification
- `php -l` clean on all touched files; no conflict markers.
- Zero leftover references to the old community helper/render names.

## Paired PR — must land together
Removal of the community-side bell: **Extra-Chill/extrachill-community#108** (branch `fix-104-remove-bell`). Merge together to avoid a window with no bell (community first) or a double bell on community (this first).

Closes #104