### PR TITLE
build: pin ajv ^8 to fix wp-scripts webpack build on Node 25

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@extrachill/components": "^0.5.2"
   },
   "devDependencies": {
-    "@wordpress/scripts": "^31.1.0"
+    "@wordpress/scripts": "^31.1.0",
+    "ajv": "^8.20.0"
   }
 }


### PR DESCRIPTION
## Summary

On the live extrachill.com VPS (Node 25), `@wordpress/scripts` webpack builds for this plugin silently fail because npm hoists **ajv v6.15.0** to the top-level `node_modules/ajv`, but `ajv-keywords@5.x` (pulled in via `schema-utils` → `copy-webpack-plugin`) requires **ajv v8** (`ajv/dist/compile/codegen`).

The build then errors, but the universal build script downgrades it to a non-fatal **warning** and ships a **PHP-only artifact with no JS/CSS** — silently stripping the plugin's blocks.

## Reproduced error

```
[webpack-cli] Error: Cannot find module 'ajv/dist/compile/codegen'
  requireStack: [
    '.../node_modules/ajv-keywords/dist/definitions/typeof.js',
    '.../node_modules/ajv-keywords/dist/keywords/typeof.js',
    '.../node_modules/schema-utils/dist/validate.js',
    '.../node_modules/copy-webpack-plugin/dist/index.js',
    '.../node_modules/@wordpress/scripts/config/webpack.config.js',
    ...
  ]
```

Confirmed top-level `node_modules/ajv` was **v6.15.0** before the fix; `npm run build` exited 2.

## Fix

Pin `"ajv": "^8.20.0"` as a devDependency so v8 is hoisted to the top level. After the fix:

- Top-level `node_modules/ajv` is **8.20.0**
- `npm run build` exits 0 — all 5 `wp-scripts build` invocations print `webpack ... compiled successfully`
- `node -e "require.resolve('ajv/dist/compile/codegen')"` resolves
- JS/CSS artifacts are emitted for all blocks (login-register, onboarding, password-reset, concert-attendance)

## Files changed

- `package.json` — added `"ajv": "^8.20.0"` to `devDependencies` (`package-lock.json` is not tracked in this repo, so it is not committed)

Part of Extra-Chill/extrachill-community#126