### PR TITLE
fix: scope team role to own posts only (drop edit_others_posts)

### DIFF
--- a/inc/team-members/role.php
+++ b/inc/team-members/role.php
@@ -54,19 +54,25 @@ const EC_USERS_TEAM_ROLE = 'extra_chill_team';
  *      tokens, Events admin, the wp-admin admin bar).
  *
  * Explicitly NOT granted: manage_options, delete_others_posts,
- * edit_users, plugin/theme management. The team role is for music
- * journalists, not site administrators.
+ * edit_others_posts, edit_users, plugin/theme management. The team role
+ * is for music journalists, not site administrators. Team members work
+ * on their OWN content only — they can draft and edit their own posts
+ * (published or not) but cannot edit other authors' posts. Editing
+ * others' work is an editor/administrator concern.
  *
  * @return array<string,bool> Capability map suitable for add_role().
  */
 function ec_users_get_team_role_caps() {
 	return array(
 		// --- Standard WP caps ---
+		// Scoped to the member's OWN posts: edit_posts (own drafts) and
+		// edit_published_posts (own published work). edit_others_posts is
+		// deliberately NOT granted so team members cannot edit other
+		// authors' content.
 		'read'                 => true,
 		'upload_files'         => true,
 		'edit_posts'           => true,
 		'edit_published_posts' => true,
-		'edit_others_posts'    => true,
 		'delete_posts'         => true,
 
 		// --- Custom EC team-only caps ---


### PR DESCRIPTION
## Summary

The `extra_chill_team` role granted `edit_others_posts`, which let **any team member edit any other author's posts** — including already-published live articles by other writers. That's broader than intended. Team members are music journalists who should work on their **own** content only.

This removes `edit_others_posts` from the team cap set. Members keep:
- `edit_posts` — draft and edit their own unpublished posts
- `edit_published_posts` — edit their own published work
- `upload_files`, `delete_posts` (own), and all the custom `access_*` team caps

They still **cannot publish** (`publish_posts` was never granted) and **cannot delete others' posts** (`delete_others_posts` never granted).

## Why this is safe (no cross-plugin breakage)

I traced the two consumers of `edit_others_posts` in the EC plugin tree:

1. **Events admin** — `extrachill-roadie/inc/permissions.php:179-182` bridges Data Machine Events' write gate to `access_events_admin`, **not** `edit_others_posts`. The team role still grants `access_events_admin`, so events admin access is unaffected.

2. **Community draft ability** — `extrachill-community/inc/content/editor/draft-abilities.php:145-162` only checks `edit_others_posts` when a caller acts on **another user's** draft (`requested_user_id !== current_user_id`). Editing one's own draft passes without the cap (lines 157-158). So removing the cap only blocks team members from editing *other* people's community drafts — which is exactly the own-work-only scope we want.

## Existing members updated automatically

The role self-heals on `init`: `ec_users_register_team_role()` diffs the live cap set against `ec_users_get_team_role_caps()` and re-registers the role when they differ (role.php:120-123). On deploy, every existing team member loses `edit_others_posts` on the next request — no migration script needed.

## Test plan

- [ ] After deploy, a team member can create + edit their own drafts and edit their own published posts.
- [ ] A team member can NOT edit another author's post (the post's editor is locked / 403 via REST).
- [ ] A team member still cannot publish their own posts (drafts → submit for review only).
- [ ] Events admin still works for team members (access_events_admin path).
- [ ] Community: a team member can edit their own draft; cannot edit another user's draft via the bbpress draft ability.

## Context

Surfaced while onboarding a new contributor (Tucker McManus) to the team role. The goal is "draft your own work, submit for review" — not "edit the whole site." This tightens the role to match.