### PR TITLE
fix: send registration emails in authenticated context (#110)

### DIFF
--- a/inc/core/registration-emails.php
+++ b/inc/core/registration-emails.php
@@ -10,6 +10,58 @@
  */
 
 /**
+ * Send a transactional EC email from a system-initiated registration context.
+ *
+ * Registration, onboarding, and the hourly welcome-email cron fallback all need
+ * to send branded transactional email, but they run in an *unprivileged* request
+ * context: an anonymous visitor (registration POST) or a brand-new subscriber
+ * (onboarding) who has none of the `datamachine_manage_*` capabilities. The
+ * underlying `datamachine/send-email` ability gates on
+ * {@see \DataMachine\Abilities\PermissionHelper::can_manage()}, so calling
+ * `ec_send_email()` directly from these contexts makes `WP_Ability::execute()`
+ * short-circuit and return a `WP_Error` (code `ability_invalid_permissions`) —
+ * NOT the documented `[ 'success' => ... ]` array envelope. That is the root
+ * cause of the "ec_send_email returned non-array" failures (#110).
+ *
+ * The authorization decision for these sends is made at THIS layer: the EC
+ * registration flow has already decided the email should go out. We therefore
+ * execute the inner ability inside
+ * {@see \DataMachine\Abilities\PermissionHelper::run_as_authenticated()}, the
+ * canonical seam for callers that have authorized an operation at their own
+ * layer and want to run an ability through the standard path.
+ *
+ * Falls back to a direct `ec_send_email()` call when the Data Machine
+ * PermissionHelper is unavailable (e.g. Data Machine deactivated) so behavior
+ * degrades gracefully rather than fataling — `ec_send_email()` already returns
+ * a well-formed error envelope in that case.
+ *
+ * @param array $args Arguments forwarded to {@see ec_send_email()}.
+ * @return mixed The `ec_send_email()` result envelope (array), or a WP_Error
+ *               if the abilities layer is genuinely unreachable.
+ */
+function extrachill_send_registration_email( array $args ) {
+	if ( ! function_exists( 'ec_send_email' ) ) {
+		return array(
+			'success' => false,
+			'error'   => 'ec_send_email() is unavailable — extrachill-multisite mail layer not loaded.',
+		);
+	}
+
+	$helper = '\DataMachine\Abilities\PermissionHelper';
+	if ( class_exists( $helper ) && method_exists( $helper, 'run_as_authenticated' ) ) {
+		return $helper::run_as_authenticated(
+			static function () use ( $args ) {
+				return ec_send_email( $args );
+			}
+		);
+	}
+
+	// Data Machine PermissionHelper unavailable — call directly. ec_send_email()
+	// still returns a structured envelope (bootstrap-failure error array).
+	return ec_send_email( $args );
+}
+
+/**
  * Send admin notification on new user registration.
  *
  * @param int    $user_id              User ID
@@ -42,7 +94,7 @@ function extrachill_notify_admin_new_user( $user_id, $registration_page, $regist
 	$body_html .= '<p><a href="' . esc_url( $edit_url ) . '">Edit user in admin</a></p>';
 	$body_html .= '<p><em>Note: User has not yet completed onboarding — profile URL not available until username is chosen.</em></p>';
 
-	$result = ec_send_email(
+	$result = extrachill_send_registration_email(
 		array(
 			'to'       => $admin_email,
 			'subject'  => $subject,
@@ -94,6 +146,15 @@ function extrachill_log_email_failure( $context, $user_id, $recipient, $subject,
 		} elseif ( ! empty( $result['message'] ) ) {
 			$error = (string) $result['message'];
 		}
+	} elseif ( is_wp_error( $result ) ) {
+		// The send-email ability returns a WP_Error (not the array envelope) when
+		// the inner permission/validation check fails. Surface the REAL code +
+		// message instead of the misleading "non-array" default (#110).
+		$error = sprintf( '%s: %s', $result->get_error_code(), $result->get_error_message() );
+	} elseif ( null === $result ) {
+		$error = 'ec_send_email returned null';
+	} else {
+		$error = sprintf( 'ec_send_email returned unexpected %s', gettype( $result ) );
 	}
 
 	$message = sprintf(
@@ -135,7 +196,7 @@ function extrachill_send_welcome_email_complete( $user_data ) {
 	$body_html .= '<p>See you around!</p>';
 	$body_html .= '<p>Much love,<br>Extra Chill</p>';
 
-	$result = ec_send_email(
+	$result = extrachill_send_registration_email(
 		array(
 			'to'       => $email,
 			'subject'  => $subject,
@@ -186,7 +247,7 @@ function extrachill_send_welcome_email_incomplete( $user_data ) {
 	$body_html .= '<p>See you around!</p>';
 	$body_html .= '<p>Much love,<br>Extra Chill</p>';
 
-	$result = ec_send_email(
+	$result = extrachill_send_registration_email(
 		array(
 			'to'       => $email,
 			'subject'  => $subject,


### PR DESCRIPTION
## Root cause

Community registration **welcome** and **admin-notification** emails were failing silently on every signup (users 613, 614, 615 over the last few days). The debug.log line:

```
extrachill-users registration-email failure [welcome_email_complete]: user_id=615 ... error=unknown error (ec_send_email returned non-array)
```

`ec_send_email()` (extrachill-multisite `inc/core/mail.php`) returns an array on **every** documented path, so a genuine "non-array" return had to come from the underlying ability layer.

It does. The chain:

1. Registration fires `extrachill_new_user_registered` → `extrachill_notify_admin_new_user`, and onboarding/cron fires the `extrachill/send-welcome-email` ability → `extrachill_send_welcome_email_complete/incomplete`.
2. All three call `ec_send_email()` → which delegates to the **`datamachine/send-email`** ability.
3. That ability's `permission_callback` gates on `PermissionHelper::can_manage()` (`datamachine_manage_flows|settings|agents`).
4. These sends run in an **unprivileged request context** — an anonymous visitor (registration POST) or a **brand-new subscriber** (onboarding) with none of those caps. So `can_manage()` returns `false`.
5. `WP_Ability::execute()` (WP core `wp-includes/abilities-api/class-wp-ability.php:612`) short-circuits on a failed permission check and returns a **`WP_Error`** (`ability_invalid_permissions`) — NOT the `[ 'success' => ... ]` array.
6. `ec_send_email()` returns that `WP_Error`; `is_array($result)` is `false` → the misleading "returned non-array" log line, and **no email is delivered**.

(The WP-CLI bypass in `PermissionHelper::can()` is why this never reproduced via `wp eval` until the bypass was explicitly disabled to simulate a frontend request — see test plan.)

```
Registration request (frontend, anon / new subscriber on community.extrachill.com, blog 2)
  ├─ extrachill_notify_admin_new_user ─┐
  └─ send-welcome-email ability ───────┤ ec_send_email()
                                       ▼
                       datamachine/send-email ability  (perm: can_manage() == FALSE)
                                       ▼
                       WP_Ability::execute() returns WP_Error (ability_invalid_permissions)
                                       ▼
                       ec_send_email() returns WP_Error → is_array() false → "non-array" failure
```

## The fix (root cause, not symptom)

The authorization decision for these transactional sends belongs at the **EC registration layer**, not to a Data Machine *management* capability. The EC flow has already decided the email should go out.

- New helper **`extrachill_send_registration_email()`** runs `ec_send_email()` inside **`PermissionHelper::run_as_authenticated()`** — the canonical seam for callers that have authorized an operation at their own layer and want to execute an ability through the standard path. It degrades gracefully to a direct `ec_send_email()` call when Data Machine / `PermissionHelper` is unavailable (no fatal).
- All three `ec_send_email()` call sites (admin notification, welcome-complete, welcome-incomplete) now route through the helper.
- **Hardened `extrachill_log_email_failure()`** so a `WP_Error` reports the real `code: message` (and `null` / unexpected-type detail) instead of the misleading "returned non-array" default — future failures are now diagnosable.

## Test plan

Run on live `community.extrachill.com` (blog 2) with the WP-CLI permission bypass disabled (`add_filter('datamachine_cli_bypass_permissions','__return_false')`) to faithfully simulate a frontend, non-admin registration request:

| Path | Result |
|------|--------|
| Direct `ec_send_email(...)` (current behavior) | `WP_Error(ability_invalid_permissions)` — reproduces the bug |
| `run_as_authenticated(... ec_send_email ...)` (the fix) | `array`, `success=true` — email sends |
| Branded welcome shape via wrapper | `array`, `success=true` |
| Hardened logger on a `WP_Error` | `ability_invalid_permissions: Ability "datamachine/send-email" does not have necessary permission.` |

To confirm in production after merge/deploy: complete a test signup on community.extrachill.com → the new user receives the welcome email, the admin receives the new-user notification, and **no** `registration-email failure` line appears in debug.log.

Closes #110