### PR TITLE
fix(notifications): nudge digest email once per notification

### DIFF
--- a/inc/notifications/db.php
+++ b/inc/notifications/db.php
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
  * upgrade path).
  */
 if ( ! defined( 'EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION' ) ) {
-	define( 'EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION', '1' );
+	define( 'EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION', '2' );
 }
 
 /**
@@ -58,10 +58,15 @@ function extrachill_users_notifications_table_name() {
  *   - item_id    optional related object ID (post/topic/reply/event)
  *   - is_read    0 unread, 1 read
  *   - created_at when the notification was generated (UTC)
+ *   - emailed_at when this notification was first included in a digest email
+ *                (NULL == never emailed). Drives "nudge once per notification":
+ *                a notification is eligible for the digest exactly once, then
+ *                its emailed_at is stamped so it never re-triggers an email.
  *
  * Indexes:
  *   - idx_user_unread  (user_id, is_read, created_at) — bell badge + unread list
  *   - idx_user_created (user_id, created_at)          — full paginated list
+ *   - idx_email_sweep  (is_read, emailed_at, created_at) — digest eligibility scan
  */
 function extrachill_users_install_notifications_table() {
 	global $wpdb;
@@ -81,10 +86,67 @@ function extrachill_users_install_notifications_table() {
 		item_id bigint(20) unsigned DEFAULT NULL,
 		is_read tinyint(1) NOT NULL DEFAULT 0,
 		created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		emailed_at datetime DEFAULT NULL,
 		PRIMARY KEY  (id),
 		KEY idx_user_unread (user_id, is_read, created_at),
-		KEY idx_user_created (user_id, created_at)
+		KEY idx_user_created (user_id, created_at),
+		KEY idx_email_sweep (is_read, emailed_at, created_at)
 	) {$charset_collate};";
 
 	dbDelta( $sql );
+
+	extrachill_users_backfill_notifications_emailed_at();
+}
+
+/**
+ * Backfill emailed_at for notifications that predate the column (schema v1 → v2).
+ *
+ * Without this, adding the column leaves every pre-existing unread notification
+ * with emailed_at = NULL, so the once-per-notification sweep would treat them as
+ * never-emailed and send one more digest for notifications users were already
+ * nudged about. We approximate "already emailed" from the legacy per-user
+ * ec_notifications_last_emailed timestamp: any unread notification created at or
+ * before a user's last-emailed time was included in that prior digest, so we
+ * stamp it as emailed (using the user's last-emailed time as the stamp).
+ *
+ * Idempotent: only touches rows where emailed_at IS NULL, so re-running (or
+ * running after new notifications arrive) never re-stamps already-handled rows.
+ * Runs once per install via the version-gated maybe-install guard.
+ *
+ * @return void
+ */
+function extrachill_users_backfill_notifications_emailed_at() {
+	global $wpdb;
+
+	$table     = extrachill_users_notifications_table_name();
+	$meta_key  = 'ec_notifications_last_emailed';
+	$usermeta  = $wpdb->usermeta;
+
+	// Pull every user with a recorded last-emailed timestamp. User_meta is
+	// network-wide, so this is correct from the (single) owner-site install run.
+	$rows = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT user_id, meta_value FROM {$usermeta} WHERE meta_key = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from $wpdb.
+			$meta_key
+		)
+	);
+
+	foreach ( (array) $rows as $row ) {
+		$user_id = (int) $row->user_id;
+		$last    = (int) $row->meta_value;
+		if ( $user_id <= 0 || $last <= 0 ) {
+			continue;
+		}
+
+		$stamp = gmdate( 'Y-m-d H:i:s', $last );
+
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table} SET emailed_at = %s WHERE user_id = %d AND emailed_at IS NULL AND created_at <= %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+				$stamp,
+				$user_id,
+				$stamp
+			)
+		);
+	}
 }

--- a/inc/notifications/email.php
+++ b/inc/notifications/email.php
@@ -228,9 +228,15 @@ add_action( EC_NOTIFICATIONS_EMAIL_CRON_HOOK, 'ec_notifications_email_run' );
 /**
  * Find users eligible for a digest email.
  *
- * Eligible == has at least one unread notification whose created_at is older
- * than EC_NOTIFICATIONS_EMAIL_DELAY. Uses the idx_user_unread index
- * (user_id, is_read, created_at) — one grouped scan, no per-row loading.
+ * Eligible == has at least one unread, NEVER-EMAILED notification whose
+ * created_at is older than EC_NOTIFICATIONS_EMAIL_DELAY. The emailed_at IS NULL
+ * predicate is what makes the digest "nudge once per notification": once a
+ * notification has been included in a digest its emailed_at is stamped, so it
+ * can never make the user eligible again. Without it the sweep re-nudged the
+ * same stale unread notification every cooldown window, forever, until read.
+ *
+ * Uses the idx_email_sweep index (is_read, emailed_at, created_at) — one
+ * grouped scan, no per-row loading.
  *
  * Cooldown + opt-out are filtered in PHP after the cheap DB pass so the SQL
  * stays index-friendly and decoupled from user_meta storage.
@@ -252,9 +258,13 @@ function ec_notifications_email_find_eligible_users( $limit = 50 ) {
 	// the longest-waiting users are nudged first.
 	$candidate_limit = $limit * 4;
 
+	// Only users with an unread notification that has NEVER been emailed
+	// (emailed_at IS NULL) are candidates — this is the once-per-notification
+	// guard. A user whose every unread notification has already been emailed is
+	// not eligible no matter how long it stays unread.
 	$rows = $wpdb->get_col(
 		$wpdb->prepare(
-			"SELECT user_id FROM {$table} WHERE is_read = 0 AND created_at <= %s GROUP BY user_id ORDER BY MIN(created_at) ASC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+			"SELECT user_id FROM {$table} WHERE is_read = 0 AND emailed_at IS NULL AND created_at <= %s GROUP BY user_id ORDER BY MIN(created_at) ASC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
 			$cutoff,
 			$candidate_limit
 		)
@@ -376,6 +386,11 @@ function ec_notifications_email_in_cooldown( $user_id, $now ) {
  * here, and the worker re-builds nothing. ec_send_email_queued() resolves the
  * SMTP-configured site and handles switch_to_blog() internally — do NOT wrap.
  *
+ * On a confirmed enqueue, every unread notification that had not yet been
+ * emailed is stamped with emailed_at = now so it can never trigger another
+ * digest (the once-per-notification guard). A user only receives a fresh digest
+ * when NEW (never-emailed) notifications arrive.
+ *
  * @param int $user_id Recipient user ID.
  * @return bool True when a digest send was enqueued.
  */
@@ -395,6 +410,14 @@ function ec_notifications_email_send_digest( $user_id ) {
 		return false;
 	}
 	if ( ec_notifications_email_in_cooldown( $user_id, time() ) ) {
+		return false;
+	}
+
+	// There must be at least one unread notification we have NOT already
+	// emailed about — otherwise this is a stale candidate (all unread items were
+	// nudged in a prior digest) and re-sending would be the exact daily-repeat
+	// bug this guard exists to prevent.
+	if ( ec_notifications_email_count_unmailed_unread( $user_id ) <= 0 ) {
 		return false;
 	}
 
@@ -453,12 +476,76 @@ function ec_notifications_email_send_digest( $user_id ) {
 		return false;
 	}
 
+	// Mark every currently-unread, not-yet-emailed notification as emailed so it
+	// can never re-trigger a digest (the once-per-notification guard). Done on a
+	// confirmed enqueue: the send is async, but eligibility is already verified
+	// and the worker re-builds nothing, so stamping here is correct.
+	ec_notifications_email_mark_unread_as_emailed( $user_id );
+
 	// Stamp the cooldown on a confirmed enqueue. The actual send happens
 	// asynchronously via Action Scheduler (with its own retry/backoff), so we
 	// cannot wait for delivery to record the cooldown.
 	update_user_meta( $user_id, EC_NOTIFICATIONS_LAST_EMAILED_META, time() );
 
 	return true;
+}
+
+/**
+ * Count a user's unread notifications that have NOT yet been emailed.
+ *
+ * The once-per-notification eligibility signal: only notifications with
+ * emailed_at IS NULL can justify a digest. Uses the idx_email_sweep index.
+ *
+ * @param int $user_id User ID.
+ * @return int Number of unread, never-emailed notifications.
+ */
+function ec_notifications_email_count_unmailed_unread( $user_id ) {
+	global $wpdb;
+
+	$user_id = (int) $user_id;
+	if ( $user_id <= 0 ) {
+		return 0;
+	}
+
+	$table = extrachill_users_notifications_table_name();
+
+	return (int) $wpdb->get_var(
+		$wpdb->prepare(
+			"SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND is_read = 0 AND emailed_at IS NULL", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+			$user_id
+		)
+	);
+}
+
+/**
+ * Stamp emailed_at = now on a user's unread, not-yet-emailed notifications.
+ *
+ * After a digest is enqueued, every unread notification that was eligible to be
+ * nudged is marked so it never triggers another email. Only unread + NULL
+ * rows are touched: already-read rows are irrelevant and already-emailed rows
+ * keep their original (earlier) stamp.
+ *
+ * @param int $user_id User ID.
+ * @return int Number of rows stamped.
+ */
+function ec_notifications_email_mark_unread_as_emailed( $user_id ) {
+	global $wpdb;
+
+	$user_id = (int) $user_id;
+	if ( $user_id <= 0 ) {
+		return 0;
+	}
+
+	$table = extrachill_users_notifications_table_name();
+	$now   = gmdate( 'Y-m-d H:i:s' );
+
+	return (int) $wpdb->query(
+		$wpdb->prepare(
+			"UPDATE {$table} SET emailed_at = %s WHERE user_id = %d AND is_read = 0 AND emailed_at IS NULL", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+			$now,
+			$user_id
+		)
+	);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #112 — the unread-notification digest was re-emailing the **same** unread notification every day, forever, until the user read it. The only throttle was a user-level `ec_notifications_last_emailed` timestamp + 24h cooldown, which limited *frequency* but never *stopped* re-nudging a stale notification.

## The bug, visualized

```
HOURLY SWEEP
   |
   v
Find users with unread notification older than 1h   <-- no per-notification state
   |
   v
Skip if last_emailed within 24h   <-- only throttle, resets every 24h
   |
   v
Send digest  -->  stamp last_emailed = now
   |
   v
(notification still unread tomorrow) --> eligible AGAIN --> email AGAIN --> forever
```

**Live proof (prod 2026-06-06):** user 383 had 3 unread replies (oldest June 2), re-emailed daily; user 38 and user 1 same pattern.

## Fix — nudge once per notification

- **`emailed_at datetime NULL` column** added to `ec_notifications` (schema v1 → v2, dbDelta-driven) + `idx_email_sweep (is_read, emailed_at, created_at)`.
- **Eligibility query** gains `AND emailed_at IS NULL` — only never-emailed unread notifications make a user eligible.
- **On confirmed enqueue**, stamp `emailed_at = now` on the user's unread, not-yet-emailed notifications so they can never re-trigger.
- **Dispatch re-check** `ec_notifications_email_count_unmailed_unread()` so a stale candidate (all unread already nudged) never sends.
- **One-time backfill** approximates "already emailed" from the legacy `ec_notifications_last_emailed` timestamp so existing stale unread notifications don't each fire one extra digest. Idempotent (only touches `emailed_at IS NULL` rows).

## Net behavior

Each notification triggers **at most one** digest email, ever. Users only get a fresh digest when genuinely new notifications arrive. The 24h cooldown is retained as a secondary anti-spam guard (a burst of new notifications within a day still collapses into one digest).

## Testing notes

- `php -l` clean on both files.
- Migration auto-runs on next `init` via the version-gated `ec_users_maybe_install_notifications_table()` guard (no manual step).
- Reads/writes only `inc/notifications/{db,email}.php`; substrate (`service.php`, abilities) untouched.