### PR TITLE
style(notifications): align assignment operators in emailed_at backfill

### DIFF
--- a/inc/notifications/db.php
+++ b/inc/notifications/db.php
@@ -118,9 +118,9 @@ function extrachill_users_install_notifications_table() {
 function extrachill_users_backfill_notifications_emailed_at() {
 	global $wpdb;
 
-	$table     = extrachill_users_notifications_table_name();
-	$meta_key  = 'ec_notifications_last_emailed';
-	$usermeta  = $wpdb->usermeta;
+	$table    = extrachill_users_notifications_table_name();
+	$meta_key = 'ec_notifications_last_emailed';
+	$usermeta = $wpdb->usermeta;
 
 	// Pull every user with a recorded last-emailed timestamp. User_meta is
 	// network-wide, so this is correct from the (single) owner-site install run.


### PR DESCRIPTION
Trivial PHPCS alignment fix for the schema v2 backfill helper added in #113. No behavior change. Unblocks the release preflight lint gate.