### PR TITLE
feat: group digest notification preview lines by target

### DIFF
--- a/inc/notifications/email.php
+++ b/inc/notifications/email.php
@@ -575,24 +575,67 @@ function ec_notifications_email_build_digest( WP_User $user, $unread_count, arra
 		$unread_count
 	) . '</p>';
 
-	$preview_items = array();
+	// Group preview notifications by their target (item_id + type) so a busy
+	// thread collapses to one counted line ("3 new replies on your topic X")
+	// instead of N separate lines. Notifications without a title are skipped.
+	// Grouping preserves first-seen order and tracks how many actual
+	// notifications each group represents so the "…and N more" footer stays
+	// accurate against the total unread count.
+	$groups = array();
 	foreach ( $preview as $note ) {
 		$title = isset( $note['title'] ) ? (string) $note['title'] : '';
 		if ( '' === $title ) {
 			continue;
 		}
-		$link = isset( $note['link'] ) ? (string) $note['link'] : '';
-		if ( '' !== $link ) {
-			$preview_items[] = '<li><a href="' . esc_url( $link ) . '">' . esc_html( $title ) . '</a></li>';
-		} else {
-			$preview_items[] = '<li>' . esc_html( $title ) . '</li>';
+
+		$type    = isset( $note['type'] ) ? (string) $note['type'] : '';
+		$item_id = isset( $note['item_id'] ) ? (int) $note['item_id'] : 0;
+		$link    = isset( $note['link'] ) ? (string) $note['link'] : '';
+
+		// Only collapse when there is a concrete target to group on; an
+		// item_id of 0 means there is nothing shared to merge against, so each
+		// such notification stays a singleton line (keyed uniquely).
+		$key = ( $item_id > 0 )
+			? $type . '|' . $item_id
+			: 'single|' . count( $groups );
+
+		if ( ! isset( $groups[ $key ] ) ) {
+			$groups[ $key ] = array(
+				'title' => $title,
+				'link'  => $link,
+				'type'  => $type,
+				'count' => 0,
+			);
 		}
+
+		++$groups[ $key ]['count'];
 	}
 
-	if ( ! empty( $preview_items ) ) {
+	if ( ! empty( $groups ) ) {
+		$preview_items   = array();
+		$previewed_total = 0;
+		foreach ( $groups as $group ) {
+			$previewed_total += (int) $group['count'];
+
+			if ( (int) $group['count'] > 1 ) {
+				$label = ec_notifications_email_group_label( $group['type'], (int) $group['count'], (string) $group['title'] );
+			} else {
+				$label = esc_html( (string) $group['title'] );
+			}
+
+			if ( '' !== $group['link'] ) {
+				$preview_items[] = '<li><a href="' . esc_url( $group['link'] ) . '">' . $label . '</a></li>';
+			} else {
+				$preview_items[] = '<li>' . $label . '</li>';
+			}
+		}
+
 		$body_html .= '<ul>' . implode( '', $preview_items ) . '</ul>';
 
-		$remaining = $unread_count - count( $preview_items );
+		// Remaining counts the unread notifications NOT represented in the
+		// preview, not the number of rendered lines — grouping must never
+		// inflate the "…and N more" footer.
+		$remaining = $unread_count - $previewed_total;
 		if ( $remaining > 0 ) {
 			$body_html .= '<p>' . sprintf(
 				/* translators: %d: number of additional unread notifications not shown. */
@@ -616,6 +659,52 @@ function ec_notifications_email_build_digest( WP_User $user, $unread_count, arra
 		'body_html' => $body_html,
 		'cta_url'   => $notifications_url,
 	);
+}
+
+/**
+ * Build the escaped HTML label for a grouped preview line.
+ *
+ * When more than one unread notification shares the same target (item_id +
+ * type), the digest collapses them into a single counted line instead of N
+ * lines. The phrasing is type-aware ("3 new replies on your topic X",
+ * "2 new mentions in X") with a generic fallback for any other type, and the
+ * count drives _n() pluralization. The title is interpolated escaped; the
+ * whole label is safe to embed directly in the <li>.
+ *
+ * @param string $type  Notification type (reply, mention, …).
+ * @param int    $count Number of notifications in the group (always > 1).
+ * @param string $title Shared target title.
+ * @return string Escaped HTML label.
+ */
+function ec_notifications_email_group_label( $type, $count, $title ) {
+	$count      = (int) $count;
+	$title_html = esc_html( $title );
+
+	switch ( $type ) {
+		case 'reply':
+			return sprintf(
+				/* translators: 1: number of new replies, 2: topic title (already escaped). */
+				esc_html( _n( '%1$d new reply on your topic %2$s', '%1$d new replies on your topic %2$s', $count, 'extrachill-users' ) ),
+				$count,
+				$title_html
+			);
+
+		case 'mention':
+			return sprintf(
+				/* translators: 1: number of new mentions, 2: title (already escaped). */
+				esc_html( _n( '%1$d new mention in %2$s', '%1$d new mentions in %2$s', $count, 'extrachill-users' ) ),
+				$count,
+				$title_html
+			);
+
+		default:
+			return sprintf(
+				/* translators: 1: number of new notifications, 2: title (already escaped). */
+				esc_html( _n( '%1$d new notification on %2$s', '%1$d new notifications on %2$s', $count, 'extrachill-users' ) ),
+				$count,
+				$title_html
+			);
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

Refs #117. The unread-notification email digest (`inc/notifications/email.php`) listed each notification as its own preview line — five replies on one topic produced five line items. Now that we nudge once per notification (#112), a busy thread produced a noisy digest. This collapses notifications sharing the same target into a single counted line.

## Grouping rule

- Group preview notifications by **target** = `item_id` + `type`.
- A group with **>1** notification renders **one counted line** (e.g. *"3 new replies on your topic X"*, *"2 new mentions in X"*, generic *"N new notifications on X"* fallback for other types).
- A **singleton** group renders exactly as before (plain title, linked if a link exists).
- Notifications with `item_id = 0` (no concrete shared target) are kept as unique singletons so unrelated items never merge.
- First-seen order is preserved.

## Unread count stays accurate

- The total `$unread_count` (subject, intro line, preheader) is **unchanged** — only preview rendering collapses.
- The **"…and N more"** footer is computed from the number of *previewed notifications represented* (`$previewed_total`), not the number of rendered `<li>` lines, so grouping can never inflate or deflate the remaining count.

## Implementation notes

- Pure change in `ec_notifications_email_build_digest()` (already side-effect-free / unit-testable) plus a new pure helper `ec_notifications_email_group_label()`.
- **No schema change.**
- Escaping matches existing style: `esc_url()` for links, `esc_html()` for titles/labels, `_n()` for count pluralization, proper `%1$d`/`%2$s` ordered placeholders with translator comments. The grouped title is escaped once (`$title_html`) and interpolated into an escaped format string — no double-escape, no injection gap. Singletons keep the original `esc_html( $title )` path.

## Verification

- `php -l inc/notifications/email.php` → **No syntax errors detected**.
- `homeboy lint --path . --extension wordpress` → **zero findings on the changed file** (`email.php` does not appear in the PHPCS findings; only the pre-existing baseline in other files remains). Fixed the two alignment warnings the linter flagged on my own lines before committing.