### PR TITLE
fix(auth): guard WP_Error before array access in password reset email path

### DIFF
--- a/inc/auth/password-reset.php
+++ b/inc/auth/password-reset.php
@@ -298,6 +298,19 @@ add_action( 'admin_post_ec_reset_password', 'ec_handle_reset_password' );
 /**
  * Send password reset email.
  *
+ * Password reset requests run in an unprivileged context (anonymous
+ * `admin_post_nopriv` POST), so this routes through
+ * {@see extrachill_send_registration_email()} which executes the underlying
+ * `datamachine/send-email` ability inside
+ * `PermissionHelper::run_as_authenticated()`. Calling `ec_send_email()`
+ * directly from this context makes `WP_Ability::execute()` short-circuit on
+ * its permission callback and return a `WP_Error` instead of the documented
+ * array envelope — array-indexing that WP_Error was a hard fatal on the
+ * user-facing reset flow (and the email never sent). Same root cause as #110.
+ *
+ * The authorization decision is made at THIS layer: the request is
+ * nonce-verified and rate-limited before we get here.
+ *
  * @param WP_User $user      User object
  * @param string  $reset_key Reset key
  * @return bool Whether email was sent successfully
@@ -348,7 +361,7 @@ function ec_send_password_reset_email( $user, $reset_key ) {
 	 */
 	$body_html = apply_filters( 'retrieve_password_message', $body_html, $reset_key, $user->user_login, $user );
 
-	$result = ec_send_email(
+	$result = extrachill_send_registration_email(
 		array(
 			'to'         => $user->user_email,
 			'subject'    => $subject,
@@ -366,5 +379,13 @@ function ec_send_password_reset_email( $user, $reset_key ) {
 		)
 	);
 
-	return ! empty( $result['success'] );
+	// Defensive: the envelope is documented as an array, but WP_Ability::execute()
+	// returns WP_Error on permission/validation failure (the production fatal:
+	// "Cannot use object of type WP_Error as array"). Never index blindly.
+	if ( ! is_array( $result ) || empty( $result['success'] ) ) {
+		extrachill_log_email_failure( 'password_reset', $user->ID, $user->user_email, $subject, $result );
+		return false;
+	}
+
+	return true;
 }

--- a/tests/unit/PasswordResetEmailFailureTest.php
+++ b/tests/unit/PasswordResetEmailFailureTest.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Unit tests for password-reset email failure handling.
+ *
+ * Regression coverage for the production fatal:
+ *   "Cannot use object of type WP_Error as array" at inc/auth/password-reset.php:369
+ *
+ * Root cause: `ec_send_password_reset_email()` called `ec_send_email()` directly
+ * from the anonymous `admin_post_nopriv` context. The underlying
+ * `datamachine/send-email` ability gates on PermissionHelper::can_manage(), so
+ * `WP_Ability::execute()` short-circuited and returned a `WP_Error` — NOT the
+ * documented array envelope — and `! empty( $result['success'] )` fataled.
+ *
+ * The fix routes the send through extrachill_send_registration_email()
+ * (run_as_authenticated seam, same as #110) and guards the envelope with
+ * is_wp_error()/is_array() before indexing.
+ *
+ * These tests run in separate processes so we can define our own
+ * ec_send_email() stub (the real one lives in extrachill-multisite and is
+ * unavailable in the unit-test bootstrap).
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+
+class Test_Password_Reset_Email_Failure extends WP_UnitTestCase {
+
+	/**
+	 * @var string Path to the captured error_log file for the current test.
+	 */
+	private $error_log_file;
+
+	/**
+	 * @var string|null Original error_log ini setting so we can restore it.
+	 */
+	private $original_error_log;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Capture error_log() output to a per-test temp file.
+		$this->error_log_file     = tempnam( sys_get_temp_dir(), 'ec_users_test_log_' );
+		$this->original_error_log = ini_get( 'error_log' );
+		ini_set( 'error_log', $this->error_log_file );
+
+		// Load the SUT, the registration-email wrapper it routes through, and
+		// the canonical ec_send_email() stub. The stub return value is flipped
+		// via a global before exercising the SUT.
+		require_once dirname( __DIR__, 2 ) . '/inc/core/registration-emails.php';
+		require_once dirname( __DIR__, 2 ) . '/inc/auth/password-reset.php';
+
+		if ( ! function_exists( 'ec_send_email' ) ) {
+			eval(
+				'function ec_send_email( array $args ) {' .
+				'    $GLOBALS["test_ec_send_email_last_args"] = $args;' .
+				'    if ( isset( $GLOBALS["test_ec_send_email_result"] ) ) {' .
+				'        return $GLOBALS["test_ec_send_email_result"];' .
+				'    }' .
+				'    return array( "success" => true );' .
+				'}'
+			);
+		}
+
+		if ( ! function_exists( 'ec_get_site_url' ) ) {
+			eval( 'function ec_get_site_url( $site ) { return "https://community.extrachill.com"; }' );
+		}
+	}
+
+	protected function tearDown(): void {
+		if ( $this->error_log_file && file_exists( $this->error_log_file ) ) {
+			@unlink( $this->error_log_file );
+		}
+		if ( null !== $this->original_error_log ) {
+			ini_set( 'error_log', $this->original_error_log );
+		}
+
+		unset( $GLOBALS['test_ec_send_email_result'], $GLOBALS['test_ec_send_email_last_args'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Read the captured error_log file for this test.
+	 */
+	private function read_error_log(): string {
+		return $this->error_log_file && file_exists( $this->error_log_file )
+			? (string) file_get_contents( $this->error_log_file )
+			: '';
+	}
+
+	private function make_user(): WP_User {
+		$user_id = $this->factory->user->create(
+			array(
+				'user_login' => 'resettest_' . wp_generate_password( 6, false ),
+				'user_email' => 'resettest_' . wp_generate_password( 6, false ) . '@example.com',
+			)
+		);
+
+		return get_userdata( $user_id );
+	}
+
+	// ---------------------------------------------------------------------
+	// ec_send_password_reset_email()
+	// ---------------------------------------------------------------------
+
+	public function test_returns_true_on_success_envelope(): void {
+		$GLOBALS['test_ec_send_email_result'] = array( 'success' => true );
+
+		$user = $this->make_user();
+
+		$this->assertTrue( ec_send_password_reset_email( $user, 'dummy-reset-key' ) );
+		$this->assertSame( '', $this->read_error_log(), 'No failure should be logged on success.' );
+	}
+
+	public function test_wp_error_result_does_not_fatal_and_returns_false(): void {
+		// This is the exact production failure mode: WP_Ability::execute()
+		// returns WP_Error( 'ability_invalid_permissions', ... ) when the
+		// anonymous reset request fails the ability's permission callback.
+		$GLOBALS['test_ec_send_email_result'] = new WP_Error(
+			'ability_invalid_permissions',
+			'The current user does not have permission to execute this ability.'
+		);
+
+		$user = $this->make_user();
+
+		$result = ec_send_password_reset_email( $user, 'dummy-reset-key' );
+
+		$this->assertFalse(
+			$result,
+			'A WP_Error envelope must yield false (graceful "Failed to send reset email" path), not a fatal.'
+		);
+
+		$log = $this->read_error_log();
+		$this->assertStringContainsString( 'password_reset', $log );
+		$this->assertStringContainsString( 'user_id=' . $user->ID, $log );
+		$this->assertStringContainsString( 'ability_invalid_permissions', $log );
+	}
+
+	public function test_failure_envelope_returns_false_and_logs(): void {
+		$GLOBALS['test_ec_send_email_result'] = array(
+			'success' => false,
+			'error'   => 'Ability datamachine/send-email is not registered. Is the Data Machine plugin active?',
+		);
+
+		$user = $this->make_user();
+
+		$this->assertFalse( ec_send_password_reset_email( $user, 'dummy-reset-key' ) );
+
+		$log = $this->read_error_log();
+		$this->assertStringContainsString( 'password_reset', $log );
+		$this->assertStringContainsString( 'datamachine/send-email is not registered', $log );
+	}
+
+	public function test_send_routes_through_registration_email_wrapper_args(): void {
+		$GLOBALS['test_ec_send_email_result'] = array( 'success' => true );
+
+		$user = $this->make_user();
+		ec_send_password_reset_email( $user, 'the-reset-key' );
+
+		$args = $GLOBALS['test_ec_send_email_last_args'] ?? null;
+		$this->assertIsArray( $args, 'ec_send_email() must receive the send args through the wrapper.' );
+		$this->assertSame( $user->user_email, $args['to'] );
+		$this->assertSame( 'extrachill/minimal', $args['template'] );
+		$this->assertStringContainsString( 'key=the-reset-key', $args['context']['cta_url'] );
+		$this->assertStringContainsString( '/reset-password/', $args['context']['cta_url'] );
+	}
+}


### PR DESCRIPTION
## Production fatal

```
[06-Jun-2026 17:13:24 UTC] PHP Fatal error:  Uncaught Error: Cannot use object of type WP_Error as array in
/var/www/extrachill.com/wp-content/plugins/extrachill-users/inc/auth/password-reset.php:369
#0 /var/www/extrachill.com/wp-content/plugins/extrachill-users/inc/auth/password-reset.php(234):
ec_send_password_reset_email()
  thrown in .../password-reset.php on line 369
```

Fired 2× in an 11-day window (Jun 1–12) on extrachill.com production. Low volume but it is a **hard fatal on a user-facing auth path** — a real human submitting the password reset form got a white screen, and the reset email never went out.

## Root cause

`ec_send_password_reset_email()` called `ec_send_email()` directly. The reset request runs in an **unprivileged context** (`admin_post_nopriv_ec_password_reset_request` — anonymous visitor POST). The underlying `datamachine/send-email` ability gates on `PermissionHelper::can_manage()`, so `WP_Ability::execute()` short-circuits on its permission callback and returns `WP_Error( 'ability_invalid_permissions', ... )` — **not** the documented `[ 'success' => bool, ... ]` array envelope.

Line 369 then did:

```php
return ! empty( $result['success'] );
```

Array-indexing a `WP_Error` object is an uncaught `Error` in PHP 8 → fatal.

This is the **exact same root cause as #110** (registration emails), which was fixed by introducing `extrachill_send_registration_email()` — a wrapper that executes the ability inside `PermissionHelper::run_as_authenticated()`, the canonical seam for callers that have authorized the operation at their own layer. The password-reset path was simply never migrated to it.

Why only 2 fatals instead of every reset: most reset requests come from already-logged-in flows or contexts where the permission check passes; the fatal hits when a genuinely anonymous visitor uses the form.

## What the user experienced

Anonymous user fills out `/reset-password/` → submits → white screen (fatal during `admin-post.php`), no email, no error message.

## Fix

1. **Route the send through `extrachill_send_registration_email()`** so the ability executes inside `run_as_authenticated()`. Authorization is decided at this layer: the request is nonce-verified (`EC_Redirect_Handler::verify_nonce`) and IP rate-limited (5/15min) before reaching the send. This both fixes the fatal *and* makes the email actually send for anonymous requesters.
2. **Guard the envelope before indexing** — `is_array( $result ) && ! empty( $result['success'] )`. On any non-success (including a `WP_Error`), log via the existing `extrachill_log_email_failure()` helper (which already formats `WP_Error` codes properly) and return `false`, so the caller at line 234 degrades to the existing graceful `'Failed to send reset email. Please try again.'` redirect.

## Sibling call sites audited

- `inc/core/moderation/email.php` — `! empty( $result['success'] )` but only runs from admin/CLI moderation contexts (privileged); not migrated here to keep the fix scoped.
- `inc/core/abilities/user-settings.php` (email change) — same pattern, but executes inside the `extrachill/update-user-settings` ability for a logged-in user; lower risk.
- `inc/core/abilities/artist-access.php` — return value unused, can't fatal.
- `inc/notifications/email.php` — queued variant, runs from cron (privileged).

The password-reset path was the only one reachable by **anonymous** visitors, which is why it's the one that fataled in production.

## Tests

Added `tests/unit/PasswordResetEmailFailureTest.php` (mirrors the existing `RegistrationEmailFailureTest` pattern):
- `WP_Error` envelope → returns `false`, logs `ability_invalid_permissions`, **no fatal** (the regression case)
- failure array envelope → returns `false` + logs
- success envelope → returns `true`, nothing logged
- args still flow through to `ec_send_email()` with correct `to` / template / reset URL

`php -l` passes on both changed files.