### PR TITLE
fix: defer concert-import auth provider requires until Data Machine base class is loaded

### DIFF
--- a/inc/concert-tracking/import/Sources/PhishNetImportSource.php
+++ b/inc/concert-tracking/import/Sources/PhishNetImportSource.php
@@ -199,6 +199,13 @@ final class PhishNetImportSource implements ImportSource {
 	 * provider. Returns empty string when no credential has been provisioned.
 	 */
 	private function get_api_key(): string {
+		// PhishNetAuthProvider extends Data Machine's BaseAuthProvider, which is
+		// only loaded (by bootstrap.php) once Data Machine's autoloader has
+		// declared the parent. Guard so a DM-absent fetch cannot fatal — it
+		// simply yields no credential, which the caller treats as "unprovisioned".
+		if ( ! class_exists( PhishNetAuthProvider::class ) ) {
+			return '';
+		}
 		$provider = new PhishNetAuthProvider();
 		return $provider->get_api_key();
 	}

--- a/inc/concert-tracking/import/Sources/SetlistFmImportSource.php
+++ b/inc/concert-tracking/import/Sources/SetlistFmImportSource.php
@@ -212,6 +212,13 @@ final class SetlistFmImportSource implements ImportSource {
 	 * provider. Returns empty string when no credential has been provisioned.
 	 */
 	private function get_api_key(): string {
+		// SetlistFmAuthProvider extends Data Machine's BaseAuthProvider, which is
+		// only loaded (by bootstrap.php) once Data Machine's autoloader has
+		// declared the parent. Guard so a DM-absent fetch cannot fatal — it
+		// simply yields no credential, which the caller treats as "unprovisioned".
+		if ( ! class_exists( SetlistFmAuthProvider::class ) ) {
+			return '';
+		}
 		$provider = new SetlistFmAuthProvider();
 		return $provider->get_api_key();
 	}

--- a/inc/concert-tracking/import/bootstrap.php
+++ b/inc/concert-tracking/import/bootstrap.php
@@ -18,9 +18,6 @@ require_once __DIR__ . '/ImportSource.php';
 require_once __DIR__ . '/EventMatcher.php';
 require_once __DIR__ . '/ImportOrchestrator.php';
 require_once __DIR__ . '/EventCreator.php';
-require_once __DIR__ . '/Sources/ConcertImportAuthProvider.php';
-require_once __DIR__ . '/Sources/SetlistFmAuthProvider.php';
-require_once __DIR__ . '/Sources/PhishNetAuthProvider.php';
 require_once __DIR__ . '/Sources/SetlistFmImportSource.php';
 require_once __DIR__ . '/Sources/PhishNetImportSource.php';
 
@@ -30,14 +27,32 @@ require_once __DIR__ . '/Sources/PhishNetImportSource.php';
 // Register each source's API key with Data Machine's encrypted auth provider
 // registry. This makes the credentials discoverable via
 // `wp datamachine auth status` and encrypts them at rest via the standard
-// AES-256-GCM envelope. Wired on plugins_loaded so Data Machine has finished
-// declaring its base classes.
+// AES-256-GCM envelope.
+//
+// The AuthProvider classes (ConcertImportAuthProvider + its SetlistFm/PhishNet
+// subclasses) extend Data Machine's `DataMachine\Core\OAuth\BaseAuthProvider`.
+// That parent is supplied by Data Machine's PSR-4 autoloader, which is not
+// guaranteed to be registered at the moment this bootstrap runs (it loads on an
+// `init` hook in extrachill-users.php). Requiring the subclass files eagerly at
+// the top level therefore intermittently fataled with a front-end white screen
+// ("Class DataMachine\Core\OAuth\BaseAuthProvider not found") on cold-boot races
+// where DM's autoloader had not yet declared the parent.
+//
+// Fix: defer the require_once of every DM-dependent AuthProvider file until DM's
+// base class is confirmed present, inside the existing class_exists guard on
+// plugins_loaded priority 30. When Data Machine is absent the concert-import
+// auth providers are simply not registered and the rest of the plugin boots
+// cleanly. The non-DM Sources (the ImportSource subclasses) only instantiate an
+// AuthProvider at fetch time, so they remain safe to load eagerly above.
 add_action(
 	'plugins_loaded',
 	static function () {
 		if ( ! class_exists( '\\DataMachine\\Core\\OAuth\\BaseAuthProvider' ) ) {
 			return;
 		}
+		require_once __DIR__ . '/Sources/ConcertImportAuthProvider.php';
+		require_once __DIR__ . '/Sources/SetlistFmAuthProvider.php';
+		require_once __DIR__ . '/Sources/PhishNetAuthProvider.php';
 		\ExtraChill\Users\Concert_Import\Sources\ConcertImportAuthProvider::register_with_datamachine();
 	},
 	30


### PR DESCRIPTION
## Summary

Fixes an **intermittent front-end white-screen fatal** on cold plugin boot in the concert-import framework.

## The fatal

```
PHP Fatal error: Uncaught Error: Class "DataMachine\Core\OAuth\BaseAuthProvider" not found
  in inc/concert-tracking/import/Sources/ConcertImportAuthProvider.php:39
#0 inc/concert-tracking/import/bootstrap.php(21): require_once()
#1 extrachill-users.php(151): require_once()
#2 ... extrachill_users_init()  (fires on an init hook)
... wp-settings.php -> wp-config.php -> wp-load.php -> wp-blog-header.php -> index.php  (FRONT-END)
```

This is not a user-facing concert-import action — it fires at plugin load on a normal front-end `index.php` request.

## Root cause

`inc/concert-tracking/import/bootstrap.php` eagerly `require_once`'d the AuthProvider source files at the top level:

```php
require_once __DIR__ . '/Sources/ConcertImportAuthProvider.php';   // abstract class extends BaseAuthProvider
require_once __DIR__ . '/Sources/SetlistFmAuthProvider.php';
require_once __DIR__ . '/Sources/PhishNetAuthProvider.php';
```

`ConcertImportAuthProvider` declares `extends BaseAuthProvider` where `BaseAuthProvider` = `DataMachine\Core\OAuth\BaseAuthProvider`. PHP must resolve the **parent class at the moment the subclass file is required**. Data Machine supplies that parent via its **PSR-4 composer autoloader**. On cold-boot races where DM's autoloader had not yet registered `BaseAuthProvider` at this point in the boot order, the eager require fataled.

The bootstrap *already* had a correct `class_exists( '\\DataMachine\\Core\\OAuth\\BaseAuthProvider' )` guard — but only around the `register_with_datamachine()` **call** on `plugins_loaded` priority 30. That guard was structurally dead: the eager `require_once` at the top fataled long before the guarded call ever ran.

The class genuinely exists (`data-machine/inc/Core/OAuth/BaseAuthProvider.php`, `abstract class BaseAuthProvider`). This is purely a **load-order / eager-require** bug, not a missing dependency.

## The fix

1. **Move the three DM-dependent `require_once` calls** out of the unconditional top-level block and **into the existing `class_exists( BaseAuthProvider )`-guarded `plugins_loaded` priority-30 closure.** The files now load only once DM's base class is confirmed present.
2. The non-DM `ImportSource` subclasses (`SetlistFmImportSource`, `PhishNetImportSource`) stay eager — they only `new` an AuthProvider inside `get_api_key()` at **fetch time**, not at construction.
3. **Belt-and-suspenders:** `get_api_key()` in both ImportSource files now guards on `class_exists( ...AuthProvider::class )` and returns an empty credential when DM is absent, so the fatal can't be relocated to fetch time.

This matches the canonical pattern used by `data-machine-events` (`TicketmasterAuth`) and `data-machine-socials` (`RedditAuth`), which rely on the autoloader + hook timing and never eagerly require a DM parent class.

## Verification

- `php -l` clean on all three touched files.
- Grep confirms `ConcertImportAuthProvider.php` is the only file in the plugin extending a `DataMachine\` class, and all three of its requires now live exclusively inside the `class_exists`-guarded block — no eager DM-parent require remains anywhere.
- DM-present behavior unchanged: `register_with_datamachine()` still runs on `plugins_loaded` 30 and the concert-import provider slugs still surface via `wp datamachine auth status`.
- DM-absent behavior: concert-import auth providers are cleanly skipped; the rest of the plugin boots without fatal.

## Files changed

- `inc/concert-tracking/import/bootstrap.php` — defer the 3 DM-dependent requires into the guarded closure
- `inc/concert-tracking/import/Sources/SetlistFmImportSource.php` — guard `get_api_key()`
- `inc/concert-tracking/import/Sources/PhishNetImportSource.php` — guard `get_api_key()`