### PR TITLE
fix(deploy): add artifact_path to block version targets (#4614)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -17,15 +17,18 @@
     },
     {
       "file": "blocks/login-register/block.json",
-      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+      "pattern": "\"version\":\\s*\"([0-9.]+)\"",
+      "artifact_path": "build/login-register/block.json"
     },
     {
       "file": "blocks/onboarding/block.json",
-      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+      "pattern": "\"version\":\\s*\"([0-9.]+)\"",
+      "artifact_path": "build/onboarding/block.json"
     },
     {
       "file": "blocks/password-reset/block.json",
-      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+      "pattern": "\"version\":\\s*\"([0-9.]+)\"",
+      "artifact_path": "build/password-reset/block.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Unblocks `homeboy deploy` for this plugin (the failure originally reported in Extra-Chill/homeboy#4614, hit on v0.17.2).

Deploy artifact verification reads each version target from **inside the shipped ZIP**, which carries the compiled `build/<block>/block.json`. The `blocks/<block>/block.json` source is excluded from the production artifact, so verification aborted with:

> Artifact '…/extrachill-users.zip' does not contain version target 'blocks/login-register/block.json'

## Change

Adds `artifact_path` to each `blocks/*/block.json` version target so:
- the **version bump** keeps writing the source `blocks/<block>/block.json` (git-tracked)
- **deploy verification** resolves against the compiled `build/<block>/block.json` (what ships)

Targets updated: `login-register`, `onboarding`, `password-reset` → their `build/<block>/block.json`. Confirmed via `package.json` `copy:block-files`, which copies `block.json` into `build/<block>/`.

## Dependency

Requires the homeboy release containing Extra-Chill/homeboy#4618 (adds the `artifact_path` field). On older homeboy this field is simply ignored by serde, so it's safe to merge ahead of the homeboy release.