### PR TITLE
fix: verify block.json version targets against shipped build/ path on deploy

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -17,14 +17,17 @@
     },
     {
       "file": "blocks/login-register/block.json",
+      "artifact_path": "build/login-register/block.json",
       "pattern": "\"version\":\\s*\"([0-9.]+)\""
     },
     {
       "file": "blocks/onboarding/block.json",
+      "artifact_path": "build/onboarding/block.json",
       "pattern": "\"version\":\\s*\"([0-9.]+)\""
     },
     {
       "file": "blocks/password-reset/block.json",
+      "artifact_path": "build/password-reset/block.json",
       "pattern": "\"version\":\\s*\"([0-9.]+)\""
     }
   ]


### PR DESCRIPTION
## Summary

Unblocks `homeboy deploy extrachill-users`, which was aborting on every release with:

```
Artifact '.../extrachill-users.zip' does not contain version target
'blocks/login-register/block.json' for component 'extrachill-users'.
Refusing to deploy unverified content.
```

## Root cause

The production ZIP ships compiled blocks at `build/<block>/block.json` and **excludes the source `blocks/` directory**. homeboy's pre-deploy artifact verification was looking for the **source** path (`blocks/<block>/block.json`) *inside the ZIP*, where it doesn't exist — so it refused to deploy. The `version` bump correctly writes the source `blocks/` paths (git-tracked); only the deploy-side verification needed a different path.

## Fix

homeboy added an optional per-target `artifact_path` field (Extra-Chill/homeboy#4614, PR #4618): the bump keeps using `file` (git-tracked source), while pre-deploy verification resolves against `artifact_path` inside the shipped artifact. This points the three `block.json` targets at their compiled `build/` counterparts.

```diff
     {
       "file": "blocks/login-register/block.json",
+      "artifact_path": "build/login-register/block.json",
       "pattern": "\"version\":\\s*\"([0-9.]+)\""
     },
```

The shipped `build/<block>/block.json` already carries the bumped version (verified: `0.17.2`), so verification now checks real shipped content. Bump behavior is unchanged.

## Verification

- `homeboy component show extrachill-users` now reports the `artifact_path` on all three block.json targets.
- `homeboy deploy extrachill-users` passes artifact verification (previously hard-failed).