### PR TITLE
fix: guard ability category registration against double-fire _doing_it_wrong notice

### DIFF
--- a/inc/core/abilities/register.php
+++ b/inc/core/abilities/register.php
@@ -43,6 +43,17 @@ function extrachill_users_resolve_self_user_id() {
  * Register users ability category.
  */
 function extrachill_users_register_category() {
+	if ( ! function_exists( 'wp_register_ability_category' ) ) {
+		return;
+	}
+
+	// Core's wp_abilities_api_categories_init action can fire more than once per
+	// request on multisite; guard against re-registration to avoid a
+	// _doing_it_wrong notice ("category already registered").
+	if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( 'extrachill-users' ) ) {
+		return;
+	}
+
 	wp_register_ability_category(
 		'extrachill-users',
 		array(


### PR DESCRIPTION
## The notice

```
PHP Notice: Function WP_Ability_Categories_Registry::register was called incorrectly.
Ability category "extrachill-users" is already registered.
in /var/www/extrachill.com/wp-includes/functions.php on line 6170
```

## Root cause

On the multisite, WordPress core's `wp_abilities_api_categories_init` action fires more than once per request. The plugin's `extrachill_users_register_category()` callback called `wp_register_ability_category( 'extrachill-users', ... )` unconditionally, so the second fire re-registered the already-registered category and tripped core's `_doing_it_wrong` notice.

## The fix

Guard the registration with core's idempotency check `wp_has_ability_category()` so a repeat fire is a clean no-op. Also keeps a `function_exists()` guard for both `wp_register_ability_category` and `wp_has_ability_category` (they ship with the same core API). Slug, label, description, and hook are unchanged.

This is one of ~15 plugins fixed for the same network-wide root cause.