### PR TITLE
feat: team-experience instrumentation + cohort read abilities

### DIFF
--- a/inc/core/abilities/artist-access-stats.php
+++ b/inc/core/abilities/artist-access-stats.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Artist Access Stats Ability
+ *
+ * Read-side rollup for the artist access funnel
+ * (Extra-Chill/extrachill-cli#31). Business logic lives here; the
+ * `wp extrachill users access stats` CLI command is a thin wrapper.
+ *
+ * Single-source design: the windowed REQUEST count is read from the
+ * `artist_access_requested` analytics event (emitted by the
+ * request-artist-access ability) via the canonical analytics counter —
+ * NOT re-derived from `artist_access_request.requested_at` meta. This
+ * keeps one source of truth per extrachill-users#127 / extrachill-cli#31
+ * coordination. The current GRANTED count is a point-in-time meta tally
+ * (user_is_artist / user_is_professional) the events stream doesn't carry.
+ *
+ * @package ExtraChill\Users
+ * @since   0.18.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_users_register_artist_access_stats_ability' );
+
+/**
+ * Register the get-artist-access-stats ability.
+ */
+function extrachill_users_register_artist_access_stats_ability() {
+	wp_register_ability(
+		'extrachill/get-artist-access-stats',
+		array(
+			'label'               => __( 'Get Artist Access Stats', 'extrachill-users' ),
+			'description'         => __( 'Windowed artist access-request count plus current granted artist/professional counts.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'days' => array(
+						'type'        => 'integer',
+						'description' => __( 'Window in days for the request count. 0 for all time.', 'extrachill-users' ),
+						'default'     => 28,
+					),
+				),
+			),
+			'output_schema'       => array( 'type' => 'object' ),
+			'execute_callback'    => 'extrachill_users_ability_get_artist_access_stats',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-artist-access-stats ability.
+ *
+ * @param array $input Input parameters with optional 'days'.
+ * @return array Stats rollup.
+ */
+function extrachill_users_ability_get_artist_access_stats( $input ) {
+	$days = isset( $input['days'] ) ? (int) $input['days'] : 28;
+
+	// Windowed request count from the artist_access_requested event stream
+	// (single source). Falls back to the pending-request meta tally only
+	// when the analytics reader is unavailable.
+	$requests_in_window = extrachill_users_count_window_events( 'artist_access_requested', $days );
+
+	$granted = extrachill_users_count_granted_access();
+
+	return array(
+		'days'                 => $days,
+		'period'               => $days > 0
+			? gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
+			: 'all time',
+		'requests_in_window'   => $requests_in_window,
+		'pending_requests'     => extrachill_users_count_pending_requests(),
+		'granted_artist'       => $granted['artist'],
+		'granted_professional' => $granted['professional'],
+		'granted_total'        => $granted['artist'] + $granted['professional'],
+	);
+}
+
+/**
+ * Count users currently granted artist and professional access.
+ *
+ * @return array{artist:int,professional:int}
+ */
+function extrachill_users_count_granted_access() {
+	// phpcs:disable WordPress.DB.SlowDBQuery -- Infrequent admin/CLI read-side counts.
+	$artist_query = new WP_User_Query(
+		array(
+			'blog_id'     => 0,
+			'meta_key'    => 'user_is_artist',
+			'meta_value'  => '1',
+			'fields'      => 'ID',
+			'count_total' => true,
+			'number'      => 1,
+		)
+	);
+
+	$professional_query = new WP_User_Query(
+		array(
+			'blog_id'     => 0,
+			'meta_key'    => 'user_is_professional',
+			'meta_value'  => '1',
+			'fields'      => 'ID',
+			'count_total' => true,
+			'number'      => 1,
+		)
+	);
+	// phpcs:enable WordPress.DB.SlowDBQuery
+
+	return array(
+		'artist'       => (int) $artist_query->get_total(),
+		'professional' => (int) $professional_query->get_total(),
+	);
+}
+
+/**
+ * Count users with a pending (un-approved) artist access request.
+ *
+ * @return int
+ */
+function extrachill_users_count_pending_requests() {
+	$query = new WP_User_Query(
+		array(
+			'blog_id'     => 0,
+			// phpcs:ignore WordPress.DB.SlowDBQuery -- Infrequent admin/CLI read-side count.
+			'meta_key'    => 'artist_access_request',
+			'fields'      => 'ID',
+			'count_total' => true,
+			'number'      => 1,
+		)
+	);
+
+	return (int) $query->get_total();
+}

--- a/inc/core/abilities/artist-access.php
+++ b/inc/core/abilities/artist-access.php
@@ -214,6 +214,17 @@ function extrachill_users_ability_approve_artist_access( $input ) {
 	update_user_meta( $user_id, $meta_key, '1' );
 	delete_user_meta( $user_id, 'artist_access_request' );
 
+	// Emit artist_access_approved (artist-funnel contract — extrachill-users#127,
+	// coordinates with extrachill-artist-platform#72). Owned here because the
+	// approval lifecycle lives in extrachill-users.
+	if ( function_exists( 'ec_users_emit_team_experience_event' ) ) {
+		ec_users_emit_team_experience_event(
+			'artist_access_approved',
+			$user_id,
+			array( 'type' => $type )
+		);
+	}
+
 	// Send approval notification email.
 	extrachill_users_send_artist_access_approval_email( $user, $type );
 
@@ -304,6 +315,17 @@ function extrachill_users_ability_request_artist_access( $input ) {
 		'user_email'   => $user->user_email,
 	);
 	update_user_meta( $user_id, 'artist_access_request', $request_data );
+
+	// Emit artist_access_requested (artist-funnel contract — extrachill-users#127,
+	// coordinates with extrachill-artist-platform#72). Owned here because the
+	// request lifecycle lives in extrachill-users.
+	if ( function_exists( 'ec_users_emit_team_experience_event' ) ) {
+		ec_users_emit_team_experience_event(
+			'artist_access_requested',
+			$user_id,
+			array( 'type' => $type )
+		);
+	}
 
 	// Send admin notification email.
 	extrachill_users_send_artist_access_request_email( $user_id, $user, $type );

--- a/inc/core/abilities/register.php
+++ b/inc/core/abilities/register.php
@@ -80,3 +80,5 @@ require_once __DIR__ . '/users-search.php';
 require_once __DIR__ . '/get-user-by-id.php';
 require_once __DIR__ . '/get-user-artists.php';
 require_once __DIR__ . '/get-user-artist-access.php';
+require_once __DIR__ . '/team-experience-stats.php';
+require_once __DIR__ . '/artist-access-stats.php';

--- a/inc/core/abilities/team-experience-stats.php
+++ b/inc/core/abilities/team-experience-stats.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Team Experience Stats Ability
+ *
+ * Read-side cohort rollup for the team-experience instrumentation
+ * (Extra-Chill/extrachill-users#127). Business logic lives here; the
+ * `wp extrachill users team stats` CLI command is a thin wrapper.
+ *
+ * Why a dedicated ability and not just the raw analytics summary: the
+ * existing `extrachill/get-analytics-summary` reader already exposes per
+ * event_type windowed counts and is the read path for those. This ability
+ * adds ONLY the cohort rollup that summary can't express — the current
+ * `extra_chill_team` membership count plus a curated view of the
+ * team/tool event counts in one call. It composes the existing reader; it
+ * does not reimplement event counting.
+ *
+ * @package ExtraChill\Users
+ * @since   0.18.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_users_register_team_experience_stats_ability' );
+
+/**
+ * Register the get-team-experience-stats ability.
+ */
+function extrachill_users_register_team_experience_stats_ability() {
+	wp_register_ability(
+		'extrachill/get-team-experience-stats',
+		array(
+			'label'               => __( 'Get Team Experience Stats', 'extrachill-users' ),
+			'description'         => __( 'Team cohort rollup: current extra_chill_team count, members added/removed in window, and Studio/Roadie/submission event counts.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'days' => array(
+						'type'        => 'integer',
+						'description' => __( 'Window in days for event counts. 0 for all time.', 'extrachill-users' ),
+						'default'     => 28,
+					),
+				),
+			),
+			'output_schema'       => array( 'type' => 'object' ),
+			'execute_callback'    => 'extrachill_users_ability_get_team_experience_stats',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for get-team-experience-stats ability.
+ *
+ * @param array $input Input parameters with optional 'days'.
+ * @return array Cohort rollup.
+ */
+function extrachill_users_ability_get_team_experience_stats( $input ) {
+	$days = isset( $input['days'] ) ? (int) $input['days'] : 28;
+
+	$team_event_types = array(
+		'team_member_added',
+		'team_member_removed',
+		'studio_draft_created',
+		'studio_submitted_for_review',
+		'studio_transcription_run',
+		'roadie_session_started',
+		'roadie_tool_invoked',
+	);
+
+	$events = array();
+	foreach ( $team_event_types as $event_type ) {
+		$events[ $event_type ] = extrachill_users_count_window_events( $event_type, $days );
+	}
+
+	return array(
+		'days'                 => $days,
+		'period'               => $days > 0
+			? gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
+			: 'all time',
+		'team_member_count'    => extrachill_users_count_team_members(),
+		'team_members_added'   => $events['team_member_added'],
+		'team_members_removed' => $events['team_member_removed'],
+		'events'               => $events,
+	);
+}
+
+/**
+ * Count current extra_chill_team role holders on the main site.
+ *
+ * The role is assigned network-wide, so counting on any one site is
+ * representative; the main site is canonical.
+ *
+ * @return int
+ */
+function extrachill_users_count_team_members() {
+	$role = defined( 'EC_USERS_TEAM_ROLE' ) ? EC_USERS_TEAM_ROLE : 'extra_chill_team';
+
+	$counts = count_users();
+	if ( isset( $counts['avail_roles'][ $role ] ) ) {
+		return (int) $counts['avail_roles'][ $role ];
+	}
+
+	return 0;
+}
+
+/**
+ * Count analytics events of a type within a day window.
+ *
+ * Delegates to the existing extrachill-analytics counter (the canonical
+ * read path) rather than reimplementing the query. Returns 0 when the
+ * analytics reader is unavailable.
+ *
+ * @param string $event_type Event type identifier.
+ * @param int    $days       Window in days. 0 for all time.
+ * @return int
+ */
+function extrachill_users_count_window_events( $event_type, $days ) {
+	if ( ! function_exists( 'extrachill_count_analytics_events' ) ) {
+		return 0;
+	}
+
+	$args = array( 'event_type' => $event_type );
+
+	if ( $days > 0 ) {
+		$args['date_from'] = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+	}
+
+	return extrachill_count_analytics_events( $args );
+}

--- a/inc/team-experience/events.php
+++ b/inc/team-experience/events.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Team Experience Analytics Events
+ *
+ * Thin emit helper for team-experience + artist-funnel analytics events.
+ *
+ * SHARED EVENT CONTRACT (Extra-Chill/extrachill-users#127)
+ * --------------------------------------------------------
+ * The team-experience instrumentation spans three plugins
+ * (extrachill-users, extrachill-studio, extrachill-roadie) plus the
+ * artist-funnel work (extrachill-artist-platform#72). The event NAMES
+ * and payload shape are a shared contract: defined once here, reused
+ * verbatim at every emit site. Each plugin owns its own emit helper but
+ * uses the SAME event_type strings and the SAME `user_id`-in-payload
+ * convention so the cohort rollups can join on the `extra_chill_team`
+ * role.
+ *
+ * Event types emitted by extrachill-users:
+ *   - team_member_added        (ec_users_grant_team_role)
+ *   - team_member_removed      (ec_users_revoke_team_role)
+ *   - artist_access_requested  (request-artist-access ability)
+ *   - artist_access_approved   (approve-artist-access ability)
+ *
+ * Event types emitted by sibling plugins (documented here for the
+ * single-source contract — emitted in their own plugins):
+ *   - extrachill-studio:  studio_draft_created, studio_submitted_for_review,
+ *                         studio_transcription_run
+ *   - extrachill-roadie:  roadie_session_started, roadie_tool_invoked
+ *   - extrachill-artist-platform: artist_profile_created (sibling-owned)
+ *
+ * Payload convention: every event carries a `user_id` key in event_data
+ * identifying the SUBJECT of the event (the user the action is about),
+ * which may differ from the acting/authenticated user the analytics
+ * table records in its own `user_id` column. This lets cohort rollups
+ * join the subject against the `extra_chill_team` role regardless of who
+ * triggered the action.
+ *
+ * All emits route through the existing `extrachill/track-analytics-event`
+ * ability — never write the `c8c_extrachill_analytics_events` table
+ * directly (RULES.md: use the ability).
+ *
+ * @package ExtraChill\Users
+ * @since   0.18.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Emit a team-experience analytics event via the canonical ability.
+ *
+ * No-op (returns 0) when the analytics ability is unavailable, so emit
+ * sites never need to guard the call themselves.
+ *
+ * @param string $event_type Event type identifier from the shared contract.
+ * @param int    $user_id    Subject user ID (the user the event is about).
+ * @param array  $extra      Optional additional payload keys merged into event_data.
+ * @return int Event ID on success, 0 on failure / when unavailable.
+ */
+function ec_users_emit_team_experience_event( $event_type, $user_id, $extra = array() ) {
+	if ( empty( $event_type ) ) {
+		return 0;
+	}
+
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		return 0;
+	}
+
+	$ability = wp_get_ability( 'extrachill/track-analytics-event' );
+	if ( ! $ability ) {
+		return 0;
+	}
+
+	$event_data = array_merge(
+		array( 'user_id' => (int) $user_id ),
+		is_array( $extra ) ? $extra : array()
+	);
+
+	$result = $ability->execute(
+		array(
+			'event_type' => $event_type,
+			'event_data' => $event_data,
+		)
+	);
+
+	return is_int( $result ) ? $result : 0;
+}

--- a/inc/team-members.php
+++ b/inc/team-members.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once __DIR__ . '/team-members/role.php';
+require_once __DIR__ . '/team-experience/events.php';
 
 /**
  * Check team member status.

--- a/inc/team-members/role.php
+++ b/inc/team-members/role.php
@@ -217,6 +217,17 @@ function ec_users_grant_team_role( $user_id ) {
 		}
 	}
 
+	// Emit team_member_added once per grant (not once per site) when the
+	// role was newly added on at least one site. Timestamps the adoption
+	// the legacy add_role() path never recorded (extrachill-users#127).
+	if ( ! empty( $added ) && function_exists( 'ec_users_emit_team_experience_event' ) ) {
+		ec_users_emit_team_experience_event(
+			'team_member_added',
+			$user_id,
+			array( 'blog_ids' => $added )
+		);
+	}
+
 	return $added;
 }
 
@@ -253,6 +264,16 @@ function ec_users_revoke_team_role( $user_id ) {
 		} finally {
 			restore_current_blog();
 		}
+	}
+
+	// Emit team_member_removed once per revoke (not once per site) when the
+	// role was actually removed from at least one site (extrachill-users#127).
+	if ( ! empty( $removed ) && function_exists( 'ec_users_emit_team_experience_event' ) ) {
+		ec_users_emit_team_experience_event(
+			'team_member_removed',
+			$user_id,
+			array( 'blog_ids' => $removed )
+		);
 	}
 
 	return $removed;


### PR DESCRIPTION
## Summary

Implements the **extrachill-users** portion of team-experience instrumentation (#127) and the access-stats reader for the CLI measurability wins (Extra-Chill/extrachill-cli#31). This is the central PR of a 4-repo change set.

## Events emitted (via existing `extrachill/track-analytics-event` ability — never the table directly)

| Event | Emit site |
|-------|-----------|
| `team_member_added` | `ec_users_grant_team_role` (once per grant, when role newly added on ≥1 site) |
| `team_member_removed` | `ec_users_revoke_team_role` (once per revoke) |
| `artist_access_requested` | `request-artist-access` ability |
| `artist_access_approved` | `approve-artist-access` ability |

Every event carries `user_id` in `event_data` (the **subject** of the action), so cohort rollups can join against the `extra_chill_team` role regardless of who triggered the action. The analytics table additionally records the acting user in its own column.

## Read abilities (logic in the ability, CLI thin)

- **`extrachill/get-team-experience-stats`** — current `extra_chill_team` count, members added/removed in window, and Studio/Roadie/submission event counts. Composes the existing `extrachill_count_analytics_events()` reader (the canonical read path) — does **not** reimplement event counting.
- **`extrachill/get-artist-access-stats`** — windowed access-request count (read from the `artist_access_requested` event stream, single source) + current granted artist/professional totals.

Wrapped by `wp extrachill users team stats` and `wp extrachill users access stats` in the CLI PR.

## Shared event-name contract

The event NAMES + payload shape are a **single-source contract** documented in `inc/team-experience/events.php` and reused verbatim by the sibling PRs (extrachill-studio, extrachill-roadie). Each plugin owns its own thin emit helper but uses identical `event_type` strings and the same `user_id`-in-payload convention.

## Artist-funnel coordination (with extrachill-artist-platform#72)

A sibling change implements the artist funnel on `artist-funnel-events`. The artist access **request/approve lifecycle lives in extrachill-users**, so **this PR owns** `artist_access_requested` + `artist_access_approved`. The sibling owns `artist_profile_created` + the artist-stats ability. The two compose: requested → profile_created → approved is the full funnel, all reading through the existing analytics summary.

## Verification

- `php -l` clean on all changed files; phpcs (WordPress) 0/0 on new files.
- Functional round-trip confirmed on the live install: emitting each contract event via the ability lands a row, `wp extrachill analytics summary --days=1` shows the new types, and `extrachill_count_analytics_events()` returns correct windowed counts. Test rows were cleaned up afterward.
- Both new ability callbacks executed against live data: team count 45, granted artist/professional 229/117.

Refs #127
Refs Extra-Chill/extrachill-cli#31