### PR TITLE
refactor: reference canonical analytics event-name constants (users#129)

### DIFF
--- a/inc/core/abilities/artist-access-stats.php
+++ b/inc/core/abilities/artist-access-stats.php
@@ -71,7 +71,7 @@ function extrachill_users_ability_get_artist_access_stats( $input ) {
 	// Windowed request count from the artist_access_requested event stream
 	// (single source). Falls back to the pending-request meta tally only
 	// when the analytics reader is unavailable.
-	$requests_in_window = extrachill_users_count_window_events( EC_USERS_EVENT_ARTIST_ACCESS_REQUESTED, $days );
+	$requests_in_window = extrachill_users_count_window_events( EC_ANALYTICS_EVENT_ARTIST_ACCESS_REQUESTED, $days );
 
 	$granted = extrachill_users_count_granted_access();
 

--- a/inc/core/abilities/artist-access-stats.php
+++ b/inc/core/abilities/artist-access-stats.php
@@ -71,7 +71,7 @@ function extrachill_users_ability_get_artist_access_stats( $input ) {
 	// Windowed request count from the artist_access_requested event stream
 	// (single source). Falls back to the pending-request meta tally only
 	// when the analytics reader is unavailable.
-	$requests_in_window = extrachill_users_count_window_events( 'artist_access_requested', $days );
+	$requests_in_window = extrachill_users_count_window_events( EC_USERS_EVENT_ARTIST_ACCESS_REQUESTED, $days );
 
 	$granted = extrachill_users_count_granted_access();
 

--- a/inc/core/abilities/artist-access.php
+++ b/inc/core/abilities/artist-access.php
@@ -219,7 +219,7 @@ function extrachill_users_ability_approve_artist_access( $input ) {
 	// approval lifecycle lives in extrachill-users.
 	if ( function_exists( 'ec_users_emit_team_experience_event' ) ) {
 		ec_users_emit_team_experience_event(
-			EC_USERS_EVENT_ARTIST_ACCESS_APPROVED,
+			EC_ANALYTICS_EVENT_ARTIST_ACCESS_APPROVED,
 			$user_id,
 			array( 'type' => $type )
 		);
@@ -321,7 +321,7 @@ function extrachill_users_ability_request_artist_access( $input ) {
 	// request lifecycle lives in extrachill-users.
 	if ( function_exists( 'ec_users_emit_team_experience_event' ) ) {
 		ec_users_emit_team_experience_event(
-			EC_USERS_EVENT_ARTIST_ACCESS_REQUESTED,
+			EC_ANALYTICS_EVENT_ARTIST_ACCESS_REQUESTED,
 			$user_id,
 			array( 'type' => $type )
 		);

--- a/inc/core/abilities/artist-access.php
+++ b/inc/core/abilities/artist-access.php
@@ -219,7 +219,7 @@ function extrachill_users_ability_approve_artist_access( $input ) {
 	// approval lifecycle lives in extrachill-users.
 	if ( function_exists( 'ec_users_emit_team_experience_event' ) ) {
 		ec_users_emit_team_experience_event(
-			'artist_access_approved',
+			EC_USERS_EVENT_ARTIST_ACCESS_APPROVED,
 			$user_id,
 			array( 'type' => $type )
 		);
@@ -321,7 +321,7 @@ function extrachill_users_ability_request_artist_access( $input ) {
 	// request lifecycle lives in extrachill-users.
 	if ( function_exists( 'ec_users_emit_team_experience_event' ) ) {
 		ec_users_emit_team_experience_event(
-			'artist_access_requested',
+			EC_USERS_EVENT_ARTIST_ACCESS_REQUESTED,
 			$user_id,
 			array( 'type' => $type )
 		);

--- a/inc/core/abilities/team-experience-stats.php
+++ b/inc/core/abilities/team-experience-stats.php
@@ -68,15 +68,10 @@ function extrachill_users_register_team_experience_stats_ability() {
 function extrachill_users_ability_get_team_experience_stats( $input ) {
 	$days = isset( $input['days'] ) ? (int) $input['days'] : 28;
 
-	$team_event_types = array(
-		'team_member_added',
-		'team_member_removed',
-		'studio_draft_created',
-		'studio_submitted_for_review',
-		'studio_transcription_run',
-		'roadie_session_started',
-		'roadie_tool_invoked',
-	);
+	// Single-source event contract (extrachill-users#129): iterate the
+	// shared group constant instead of re-listing string literals, so this
+	// reader can never desync from the emit constants in events.php.
+	$team_event_types = EC_USERS_TEAM_EXPERIENCE_EVENTS;
 
 	$events = array();
 	foreach ( $team_event_types as $event_type ) {
@@ -89,8 +84,8 @@ function extrachill_users_ability_get_team_experience_stats( $input ) {
 			? gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
 			: 'all time',
 		'team_member_count'    => extrachill_users_count_team_members(),
-		'team_members_added'   => $events['team_member_added'],
-		'team_members_removed' => $events['team_member_removed'],
+		'team_members_added'   => $events[ EC_USERS_EVENT_TEAM_MEMBER_ADDED ],
+		'team_members_removed' => $events[ EC_USERS_EVENT_TEAM_MEMBER_REMOVED ],
 		'events'               => $events,
 	);
 }

--- a/inc/core/abilities/team-experience-stats.php
+++ b/inc/core/abilities/team-experience-stats.php
@@ -69,9 +69,10 @@ function extrachill_users_ability_get_team_experience_stats( $input ) {
 	$days = isset( $input['days'] ) ? (int) $input['days'] : 28;
 
 	// Single-source event contract (extrachill-users#129): iterate the
-	// shared group constant instead of re-listing string literals, so this
-	// reader can never desync from the emit constants in events.php.
-	$team_event_types = EC_USERS_TEAM_EXPERIENCE_EVENTS;
+	// canonical group constant owned by extrachill-analytics instead of
+	// re-listing string literals, so this reader can never desync from the
+	// emit sites (which reference the same EC_ANALYTICS_EVENT_* constants).
+	$team_event_types = EC_ANALYTICS_TEAM_EXPERIENCE_EVENTS;
 
 	$events = array();
 	foreach ( $team_event_types as $event_type ) {
@@ -84,8 +85,8 @@ function extrachill_users_ability_get_team_experience_stats( $input ) {
 			? gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) . ' to ' . gmdate( 'Y-m-d' )
 			: 'all time',
 		'team_member_count'    => extrachill_users_count_team_members(),
-		'team_members_added'   => $events[ EC_USERS_EVENT_TEAM_MEMBER_ADDED ],
-		'team_members_removed' => $events[ EC_USERS_EVENT_TEAM_MEMBER_REMOVED ],
+		'team_members_added'   => $events[ EC_ANALYTICS_EVENT_TEAM_MEMBER_ADDED ],
+		'team_members_removed' => $events[ EC_ANALYTICS_EVENT_TEAM_MEMBER_REMOVED ],
 		'events'               => $events,
 	);
 }

--- a/inc/team-experience/events.php
+++ b/inc/team-experience/events.php
@@ -9,11 +9,12 @@
  * The team-experience instrumentation spans three plugins
  * (extrachill-users, extrachill-studio, extrachill-roadie) plus the
  * artist-funnel work (extrachill-artist-platform#72). The event NAMES
- * and payload shape are a shared contract: defined once here, reused
- * verbatim at every emit site. Each plugin owns its own emit helper but
- * uses the SAME event_type strings and the SAME `user_id`-in-payload
- * convention so the cohort rollups can join on the `extra_chill_team`
- * role.
+ * and payload shape are a shared contract. Each plugin owns its own
+ * emit helper and now defines its own event-name CONSTANTS (the names
+ * it emits/reads) so a rename is mechanical within the plugin rather
+ * than a scattered string edit (extrachill-users#129). Plugins use the
+ * SAME event_type strings and the SAME `user_id`-in-payload convention
+ * so the cohort rollups can join on the `extra_chill_team` role.
  *
  * Event types emitted by extrachill-users:
  *   - team_member_added        (ec_users_grant_team_role)
@@ -44,6 +45,55 @@
  */
 
 defined( 'ABSPATH' ) || exit;
+
+/*
+ * Event-name contract constants (Extra-Chill/extrachill-users#129).
+ * ----------------------------------------------------------------
+ * The analytics event_type strings are defined ONCE here and referenced
+ * by every extrachill-users emit site AND the read-side stats abilities,
+ * so a rename can never silently desync the emit and read halves of a
+ * metric (the "permanently-zero metric, no error" failure mode).
+ *
+ * Scope: these constants cover ONLY the event types extrachill-users
+ * itself emits and/or reads. Sibling-emitted events (studio_*, roadie_*,
+ * artist_profile_created) are owned by their own plugins and are NOT
+ * referenced here as cross-plugin constants — doing so would create a
+ * new load-time dependency on those plugins. The team-experience reader
+ * declares the sibling event names it READS as its own constants below;
+ * each emitting plugin independently owns the same string as its emit
+ * constant. Matching names remain a documented contract, but each side
+ * now has a single in-plugin source instead of scattered literals.
+ */
+
+/** Team-membership events emitted by extrachill-users. */
+const EC_USERS_EVENT_TEAM_MEMBER_ADDED   = 'team_member_added';
+const EC_USERS_EVENT_TEAM_MEMBER_REMOVED = 'team_member_removed';
+
+/** Artist-funnel events emitted by extrachill-users. */
+const EC_USERS_EVENT_ARTIST_ACCESS_REQUESTED = 'artist_access_requested';
+const EC_USERS_EVENT_ARTIST_ACCESS_APPROVED  = 'artist_access_approved';
+
+/** Sibling-emitted event types that the team-experience reader READS. */
+const EC_USERS_EVENT_STUDIO_DRAFT_CREATED        = 'studio_draft_created';
+const EC_USERS_EVENT_STUDIO_SUBMITTED_FOR_REVIEW = 'studio_submitted_for_review';
+const EC_USERS_EVENT_STUDIO_TRANSCRIPTION_RUN    = 'studio_transcription_run';
+const EC_USERS_EVENT_ROADIE_SESSION_STARTED      = 'roadie_session_started';
+const EC_USERS_EVENT_ROADIE_TOOL_INVOKED         = 'roadie_tool_invoked';
+
+/**
+ * Full set of event types surfaced by the team-experience cohort rollup
+ * (`extrachill/get-team-experience-stats`). The reader builds its query
+ * array from this group instead of re-listing string literals.
+ */
+const EC_USERS_TEAM_EXPERIENCE_EVENTS = array(
+	EC_USERS_EVENT_TEAM_MEMBER_ADDED,
+	EC_USERS_EVENT_TEAM_MEMBER_REMOVED,
+	EC_USERS_EVENT_STUDIO_DRAFT_CREATED,
+	EC_USERS_EVENT_STUDIO_SUBMITTED_FOR_REVIEW,
+	EC_USERS_EVENT_STUDIO_TRANSCRIPTION_RUN,
+	EC_USERS_EVENT_ROADIE_SESSION_STARTED,
+	EC_USERS_EVENT_ROADIE_TOOL_INVOKED,
+);
 
 /**
  * Emit a team-experience analytics event via the canonical ability.

--- a/inc/team-experience/events.php
+++ b/inc/team-experience/events.php
@@ -47,53 +47,20 @@
 defined( 'ABSPATH' ) || exit;
 
 /*
- * Event-name contract constants (Extra-Chill/extrachill-users#129).
- * ----------------------------------------------------------------
- * The analytics event_type strings are defined ONCE here and referenced
- * by every extrachill-users emit site AND the read-side stats abilities,
- * so a rename can never silently desync the emit and read halves of a
- * metric (the "permanently-zero metric, no error" failure mode).
+ * Event-name contract (Extra-Chill/extrachill-users#129).
+ * -------------------------------------------------------
+ * The canonical event_type names are defined ONCE in extrachill-analytics
+ * (inc/core/event-types.php) as the `EC_ANALYTICS_EVENT_*` constants plus
+ * the `EC_ANALYTICS_TEAM_EXPERIENCE_EVENTS` / `EC_ANALYTICS_ARTIST_FUNNEL_EVENTS`
+ * group constants. extrachill-analytics owns the analytics substrate and
+ * the `extrachill/track-analytics-event` ability this helper already calls
+ * at runtime, and is network-active, so those constants are guaranteed
+ * present wherever this code runs — referencing them adds no new coupling.
  *
- * Scope: these constants cover ONLY the event types extrachill-users
- * itself emits and/or reads. Sibling-emitted events (studio_*, roadie_*,
- * artist_profile_created) are owned by their own plugins and are NOT
- * referenced here as cross-plugin constants — doing so would create a
- * new load-time dependency on those plugins. The team-experience reader
- * declares the sibling event names it READS as its own constants below;
- * each emitting plugin independently owns the same string as its emit
- * constant. Matching names remain a documented contract, but each side
- * now has a single in-plugin source instead of scattered literals.
+ * Every emit site and every reader in this plugin references the analytics
+ * constants directly (no local copies of the literal strings), so a rename
+ * happens in exactly one place across the whole network.
  */
-
-/** Team-membership events emitted by extrachill-users. */
-const EC_USERS_EVENT_TEAM_MEMBER_ADDED   = 'team_member_added';
-const EC_USERS_EVENT_TEAM_MEMBER_REMOVED = 'team_member_removed';
-
-/** Artist-funnel events emitted by extrachill-users. */
-const EC_USERS_EVENT_ARTIST_ACCESS_REQUESTED = 'artist_access_requested';
-const EC_USERS_EVENT_ARTIST_ACCESS_APPROVED  = 'artist_access_approved';
-
-/** Sibling-emitted event types that the team-experience reader READS. */
-const EC_USERS_EVENT_STUDIO_DRAFT_CREATED        = 'studio_draft_created';
-const EC_USERS_EVENT_STUDIO_SUBMITTED_FOR_REVIEW = 'studio_submitted_for_review';
-const EC_USERS_EVENT_STUDIO_TRANSCRIPTION_RUN    = 'studio_transcription_run';
-const EC_USERS_EVENT_ROADIE_SESSION_STARTED      = 'roadie_session_started';
-const EC_USERS_EVENT_ROADIE_TOOL_INVOKED         = 'roadie_tool_invoked';
-
-/**
- * Full set of event types surfaced by the team-experience cohort rollup
- * (`extrachill/get-team-experience-stats`). The reader builds its query
- * array from this group instead of re-listing string literals.
- */
-const EC_USERS_TEAM_EXPERIENCE_EVENTS = array(
-	EC_USERS_EVENT_TEAM_MEMBER_ADDED,
-	EC_USERS_EVENT_TEAM_MEMBER_REMOVED,
-	EC_USERS_EVENT_STUDIO_DRAFT_CREATED,
-	EC_USERS_EVENT_STUDIO_SUBMITTED_FOR_REVIEW,
-	EC_USERS_EVENT_STUDIO_TRANSCRIPTION_RUN,
-	EC_USERS_EVENT_ROADIE_SESSION_STARTED,
-	EC_USERS_EVENT_ROADIE_TOOL_INVOKED,
-);
 
 /**
  * Emit a team-experience analytics event via the canonical ability.

--- a/inc/team-members/role.php
+++ b/inc/team-members/role.php
@@ -222,7 +222,7 @@ function ec_users_grant_team_role( $user_id ) {
 	// the legacy add_role() path never recorded (extrachill-users#127).
 	if ( ! empty( $added ) && function_exists( 'ec_users_emit_team_experience_event' ) ) {
 		ec_users_emit_team_experience_event(
-			'team_member_added',
+			EC_USERS_EVENT_TEAM_MEMBER_ADDED,
 			$user_id,
 			array( 'blog_ids' => $added )
 		);
@@ -270,7 +270,7 @@ function ec_users_revoke_team_role( $user_id ) {
 	// role was actually removed from at least one site (extrachill-users#127).
 	if ( ! empty( $removed ) && function_exists( 'ec_users_emit_team_experience_event' ) ) {
 		ec_users_emit_team_experience_event(
-			'team_member_removed',
+			EC_USERS_EVENT_TEAM_MEMBER_REMOVED,
 			$user_id,
 			array( 'blog_ids' => $removed )
 		);

--- a/inc/team-members/role.php
+++ b/inc/team-members/role.php
@@ -222,7 +222,7 @@ function ec_users_grant_team_role( $user_id ) {
 	// the legacy add_role() path never recorded (extrachill-users#127).
 	if ( ! empty( $added ) && function_exists( 'ec_users_emit_team_experience_event' ) ) {
 		ec_users_emit_team_experience_event(
-			EC_USERS_EVENT_TEAM_MEMBER_ADDED,
+			EC_ANALYTICS_EVENT_TEAM_MEMBER_ADDED,
 			$user_id,
 			array( 'blog_ids' => $added )
 		);
@@ -270,7 +270,7 @@ function ec_users_revoke_team_role( $user_id ) {
 	// role was actually removed from at least one site (extrachill-users#127).
 	if ( ! empty( $removed ) && function_exists( 'ec_users_emit_team_experience_event' ) ) {
 		ec_users_emit_team_experience_event(
-			EC_USERS_EVENT_TEAM_MEMBER_REMOVED,
+			EC_ANALYTICS_EVENT_TEAM_MEMBER_REMOVED,
 			$user_id,
 			array( 'blog_ids' => $removed )
 		);


### PR DESCRIPTION
## Summary
Repoints the extrachill-users team-experience + artist-funnel emit sites **and** read-side stats abilities at the **canonical event-name constants owned by extrachill-analytics** (Extra-Chill/extrachill-analytics#32). Part of a 5-PR set on branch `event-name-contract` resolving extrachill-users#129.

> **Revised approach:** the first pass introduced per-plugin constants, which still left the *cross-plugin* literal duplicated (users' reader-side copy of `studio_draft_created` vs studio's emit-side copy). That's the exact desync risk #129 targets. This revision collapses every event-name literal to a **single cross-plugin source** in extrachill-analytics.

## Why extrachill-analytics is the home (zero new coupling)
Every emit helper already calls `wp_get_ability('extrachill/track-analytics-event')` at runtime — an ability **owned by extrachill-analytics**. So a hard runtime dependency on analytics already exists; referencing its constants adds none. extrachill-analytics is also `Network: true`, so the constants are always defined. Full rationale in the keystone PR: Extra-Chill/extrachill-analytics#32.

## Changes (this repo)
- `inc/team-experience/events.php` — dropped the per-plugin `EC_USERS_EVENT_*` constants; documents that the canonical names live in analytics.
- `inc/team-members/role.php` — emit sites reference `EC_ANALYTICS_EVENT_TEAM_MEMBER_ADDED` / `_REMOVED`.
- `inc/core/abilities/artist-access.php` — request/approve emits reference `EC_ANALYTICS_EVENT_ARTIST_ACCESS_REQUESTED` / `_APPROVED`.
- `inc/core/abilities/artist-access-stats.php` — reader references `EC_ANALYTICS_EVENT_ARTIST_ACCESS_REQUESTED`.
- `inc/core/abilities/team-experience-stats.php` — reader **iterates `EC_ANALYTICS_TEAM_EXPERIENCE_EVENTS`** and keys its output by the analytics constants.

## Single-source proof
No bare event-name literal remains in this repo — all references are to `EC_ANALYTICS_EVENT_*` constants. Across all 5 plugins, each literal appears in exactly one file (`extrachill-analytics/inc/core/event-types.php`).

## No behavior change
Constants resolve to the byte-identical event_type strings used before.

## Verification
- `php -l` clean on all changed files.
- phpcs (WordPress): zero new findings in changed hunks (role.php:312, artist-access.php:132/139 are pre-existing, outside the diff).

## Related PRs (branch `event-name-contract`)
- **Keystone (constants home):** Extra-Chill/extrachill-analytics#32
- extrachill-studio: Extra-Chill/extrachill-studio#98
- extrachill-roadie: Extra-Chill/extrachill-roadie#52
- extrachill-artist-platform: Extra-Chill/extrachill-artist-platform#74

Refs Extra-Chill/extrachill-users#129. Review all 5 together; do not merge standalone.
