### PR TITLE
feat: gate shared brand socials behind admin-only brand_socials feature

### DIFF
--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -140,6 +140,7 @@ function extrachill_users_init() {
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/onboarding/service.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/lifetime-membership.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/shop-permissions.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/brand-socials-permissions.php';
 
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/comment-auto-approval.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/footer/online-users-stats.php';

--- a/inc/brand-socials-permissions.php
+++ b/inc/brand-socials-permissions.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Brand socials permission bridge.
+ *
+ * data-machine-socials operates the SHARED official Extra Chill brand social
+ * accounts (Instagram / Twitter / Bluesky / Facebook), whose credentials are
+ * stored network-wide. Its REST endpoints gate only on raw post capabilities
+ * (`publish_posts` / `edit_posts` / `upload_files`), which the
+ * `extra_chill_team` role already has — meaning any team member could post or
+ * comment immediately, live, to the official accounts with no review.
+ *
+ * This bridge wires Data Machine Socials' generic
+ * `datamachine_socials_user_can` filter (data-machine-socials#174) into EC's
+ * feature-rollout ladder. It is the correct layer for this policy: the socials
+ * plugin knows nothing about Extra Chill; this plugin is the one place where
+ * EC-specific knowledge meets that generic permission surface — exactly how
+ * extrachill-roadie bridges `access_roadie` into `datamachine_can_access_agent`.
+ *
+ * The whole brand-socials surface (publish / edit / upload) is gated as one
+ * clean boundary behind the `brand_socials` feature, which ships with an
+ * `admin` ceiling (see ec_feature_ceilings() in inc/core/gating.php). It can be
+ * promoted to the team — and later the public — by flipping the network option,
+ * exactly how the `shop` feature works, with no code change here.
+ *
+ * @package ExtraChill\Users
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Gate the shared brand social accounts behind the `brand_socials` feature.
+ *
+ * Hooks the generic `datamachine_socials_user_can` filter and ANDs the base
+ * capability result with the EC rollout gate. A user who fails the feature gate
+ * is denied even if they hold the raw post capability; a user who passes still
+ * needs the base capability (we never grant access the socials plugin denied).
+ *
+ * @since 1.0.0
+ *
+ * @param bool   $allowed Whether the base capability check passed.
+ * @param string $action  The action being gated: one of `publish` | `edit` | `upload`.
+ * @param int    $user_id The current user ID.
+ * @return bool
+ */
+function ec_brand_socials_user_can( $allowed, $action, $user_id ) {
+	if ( in_array( $action, array( 'publish', 'edit', 'upload' ), true ) ) {
+		return $allowed && function_exists( 'ec_feature_available' ) && ec_feature_available( 'brand_socials', $user_id );
+	}
+
+	return $allowed;
+}
+add_filter( 'datamachine_socials_user_can', 'ec_brand_socials_user_can', 10, 3 );

--- a/inc/core/gating.php
+++ b/inc/core/gating.php
@@ -49,7 +49,10 @@ function ec_feature_tier_ladder() {
 function ec_feature_ceilings() {
 	$ceilings = array(
 		// Shop manager: admin-only until the system is ready for the team.
-		'shop' => 'admin',
+		'shop'          => 'admin',
+		// Shared brand social accounts: admin-only until a review workflow
+		// exists for the team (the official accounts post immediately live).
+		'brand_socials' => 'admin',
 	);
 
 	/**


### PR DESCRIPTION
## What changed

The shared official Extra Chill brand social accounts (IG/Twitter/Bluesky/Facebook — creds stored network-wide) were gated only on raw post caps, so any `extra_chill_team` member could post/comment **immediately live** to the official accounts with no review. This registers a `brand_socials` rollout feature (admin-only by default) and bridges EC's feature ladder into data-machine-socials' new generic permission filter, making the whole brand-socials surface admin-only as one clean boundary — promotable later exactly like `shop`.

## File / lines

- `inc/core/gating.php` (`ec_feature_ceilings()`, ~L50) — register `'brand_socials' => 'admin'` alongside `shop`.
- `inc/brand-socials-permissions.php` (new) — `ec_brand_socials_user_can()` hooks `datamachine_socials_user_can` (priority 10, 3 args) and ANDs the base capability with `ec_feature_available( 'brand_socials', $user_id )` for `publish`/`edit`/`upload`.
- `extrachill-users.php` (~L143) — `require_once` the new bridge file.

## Filter contract (must match data-machine-socials#174 / #175 exactly)

```php
add_filter( 'datamachine_socials_user_can', 'ec_brand_socials_user_can', 10, 3 );
function ec_brand_socials_user_can( bool $allowed, string $action, int $user_id ) {
    if ( in_array( $action, array( 'publish', 'edit', 'upload' ), true ) ) {
        return $allowed && ec_feature_available( 'brand_socials', $user_id );
    }
    return $allowed;
}
```

Same filter name, same 3-arg order (`$allowed, $action, $user_id`) as the DMS `apply_filters`. The bridge never grants access DMS denied (AND, not OR). This is the correct layer for EC business logic — DMS stays generic; EC owns the policy — mirroring how extrachill-roadie bridges `access_roadie` into `datamachine_can_access_agent`.

## Promotion path

`brand_socials` ships at the `admin` ceiling with no network-option override → preserves admin-only behavior. Promoting to the team is a one-flag flip of the network option; going public is a reviewed ceiling bump — no code change.

## Verification

- `php -l` on all three changed files → no syntax errors.

Closes #131