### PR TITLE
docs: surface suspend-vs-hide reason_key behavior in moderation

### DIFF
--- a/inc/core/abilities/moderation.php
+++ b/inc/core/abilities/moderation.php
@@ -40,7 +40,7 @@ function extrachill_users_register_moderation_abilities() {
 		'extrachill/moderate-user',
 		array(
 			'label'               => __( 'Moderate User', 'extrachill-users' ),
-			'description'         => __( 'Apply a moderation action such as ban or suspension to a user account.', 'extrachill-users' ),
+			'description'         => __( 'Apply a moderation action such as ban or suspension to a user account. The reason_key is also the suspend-vs-hide-content switch: spam, abuse and fraud additionally hide the user\'s content (posts to draft, bbPress topics/replies and comments to spam; spam also flags content as spam), while impersonation and other suspend login only and leave all content live.', 'extrachill-users' ),
 			'category'            => 'extrachill-users',
 			'input_schema'        => array(
 				'type'       => 'object',

--- a/inc/core/moderation/policies.php
+++ b/inc/core/moderation/policies.php
@@ -7,6 +7,33 @@
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Per-reason moderation policy map.
+ *
+ * The `reason_key` chosen for a ban is also the suspend-vs-hide-content switch:
+ * the same value that records *why* a user was banned silently decides whether
+ * their existing content stays live or gets hidden. Operators who want to ban a
+ * user but keep their content (a pure login suspension) should pick `other` or
+ * `impersonation`; `spam`/`abuse`/`fraud` additionally hide content.
+ *
+ * Effects per reason_key:
+ *
+ *   reason_key    | block_login | revoke_sessions | send_email | hide_content | mark_content_spam
+ *   --------------|-------------|-----------------|------------|--------------|------------------
+ *   spam          | yes         | yes             | yes        | YES          | YES
+ *   abuse         | yes         | yes             | yes        | YES          | no
+ *   impersonation | yes         | yes             | yes        | no           | no
+ *   fraud         | yes         | yes             | yes        | YES          | no
+ *   other         | yes         | yes             | yes        | no           | no
+ *
+ * When `hide_content` is set, the user's content is hidden via
+ * extrachill_users_apply_spam_visibility_to_user_content(): posts go to draft and
+ * bbPress topics/replies and comments are marked spam. `mark_content_spam`
+ * (spam only) additionally flags the content as spam rather than merely hiding it.
+ * `impersonation`/`other` leave all content live and only suspend login.
+ *
+ * @return array Map of reason_key => array{ label: string, effects: array<string,bool> }.
+ */
 function extrachill_users_get_moderation_policy_definitions() {
 	return array(
 		'spam'          => array(


### PR DESCRIPTION
## Summary

The `reason_key` passed to a ban silently doubles as the **suspend-vs-hide-content switch** — the same value that records *why* a user was banned also decides whether their existing content stays live or gets hidden. Nothing told operators this, so the answer to "can we ban without deleting content?" (yes — pick `other`/`impersonation`) was invisible.

This is a **docs/discoverability-only** change. No behavior, policy values, or CLI flags were touched.

### Per-reason effect table (source of truth: `inc/core/moderation/policies.php`)

| reason_key | block_login | revoke_sessions | send_email | hide_content | mark_content_spam |
|---|---|---|---|---|---|
| spam | yes | yes | yes | **YES** | **YES** |
| abuse | yes | yes | yes | **YES** | no |
| impersonation | yes | yes | yes | **no** | no |
| fraud | yes | yes | yes | **YES** | no |
| other | yes | yes | yes | **no** | no |

So `spam`/`abuse`/`fraud` also hide the user's content (posts → draft; bbPress topics/replies and comments → spam; `spam` additionally flags content as spam), while `impersonation`/`other` suspend login only and **leave all content live**.

## Changes

- **`inc/core/moderation/policies.php`** — expanded the docblock above `extrachill_users_get_moderation_policy_definitions()` with the full effect table, the one-line "reason_key is also the suspend-vs-hide switch" note, and an explanation of how `hide_content`/`mark_content_spam` are applied.
- **`inc/core/abilities/moderation.php`** — enriched the `extrachill/moderate-user` ability description so the `reason_key` content side-effects surface in REST / ability introspection.

## Why in-repo (not the CLI)

Issue #136 is filed on `extrachill-users`, which owns the policy map (source of truth). The CLI command (`wp extrachill users ban`) and its `--reason-key` help text live in a **different repo** (`extrachill-cli/inc/Commands/Users/BanCommand.php`). Documenting in the owning repo — in the policy docblock and the ability description — keeps the explanation next to the behavior and surfaces it via ability introspection.

## Follow-up (separate repo / scope, not in this PR)

`extrachill-cli`'s `BanCommand` `--reason-key` help should carry the same note so it shows up in `wp extrachill users ban --help`. That is a separate repo and out of scope here; worth a follow-up issue/PR against `extrachill-cli`.

## Verification

- `php -l` clean on both edited files.
- `phpcs --standard=WordPress` on both files introduces **zero new findings**; the new docblock actually resolved one pre-existing "missing doc comment" error. Remaining phpcs errors are pre-existing baseline house-style debt on untouched functions.

Closes #136