### PR TITLE
feat: optional hard-delete (purge) content path for moderation

### DIFF
--- a/inc/core/abilities/moderation.php
+++ b/inc/core/abilities/moderation.php
@@ -40,18 +40,23 @@ function extrachill_users_register_moderation_abilities() {
 		'extrachill/moderate-user',
 		array(
 			'label'               => __( 'Moderate User', 'extrachill-users' ),
-			'description'         => __( 'Apply a moderation action such as ban or suspension to a user account. The reason_key is also the suspend-vs-hide-content switch: spam, abuse and fraud additionally hide the user\'s content (posts to draft, bbPress topics/replies and comments to spam; spam also flags content as spam), while impersonation and other suspend login only and leave all content live.', 'extrachill-users' ),
+			'description'         => __( 'Apply a moderation action such as ban or suspension to a user account. The reason_key is also the suspend-vs-hide-content switch: spam, abuse and fraud additionally hide the user\'s content (posts to draft, bbPress topics/replies and comments to spam; spam also flags content as spam), while impersonation and other suspend login only and leave all content live. Set purge_content to true to instead PERMANENTLY hard-delete the user\'s content network-wide (posts, bbPress topics/replies, comments and owned/orphaned attachments) — this is destructive, irreversible, opt-in only, and supersedes the hide behavior.', 'extrachill-users' ),
 			'category'            => 'extrachill-users',
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'user_id'    => array( 'type' => 'integer' ),
-					'state'      => array( 'type' => 'string' ),
-					'reason_key' => array( 'type' => 'string' ),
-					'reason'     => array( 'type' => 'string' ),
-					'note'       => array( 'type' => 'string' ),
-					'source'     => array( 'type' => 'string' ),
-					'acted_by'   => array( 'type' => 'integer' ),
+					'user_id'       => array( 'type' => 'integer' ),
+					'state'         => array( 'type' => 'string' ),
+					'reason_key'    => array( 'type' => 'string' ),
+					'reason'        => array( 'type' => 'string' ),
+					'note'          => array( 'type' => 'string' ),
+					'source'        => array( 'type' => 'string' ),
+					'acted_by'      => array( 'type' => 'integer' ),
+					'purge_content' => array(
+						'type'        => 'boolean',
+						'description' => __( 'When true, PERMANENTLY hard-delete the user\'s content network-wide instead of hiding it. Destructive and irreversible. Defaults to false.', 'extrachill-users' ),
+						'default'     => false,
+					),
 				),
 				'required'   => array( 'user_id', 'state', 'reason_key' ),
 			),
@@ -108,12 +113,13 @@ function extrachill_users_ability_moderate_user( $input ) {
 	return extrachill_users_apply_moderation_action(
 		$user_id,
 		array(
-			'state'      => isset( $input['state'] ) ? (string) $input['state'] : 'banned',
-			'reason_key' => isset( $input['reason_key'] ) ? (string) $input['reason_key'] : 'other',
-			'reason'     => isset( $input['reason'] ) ? (string) $input['reason'] : '',
-			'note'       => isset( $input['note'] ) ? (string) $input['note'] : '',
-			'source'     => isset( $input['source'] ) ? (string) $input['source'] : '',
-			'acted_by'   => isset( $input['acted_by'] ) ? absint( $input['acted_by'] ) : get_current_user_id(),
+			'state'         => isset( $input['state'] ) ? (string) $input['state'] : 'banned',
+			'reason_key'    => isset( $input['reason_key'] ) ? (string) $input['reason_key'] : 'other',
+			'reason'        => isset( $input['reason'] ) ? (string) $input['reason'] : '',
+			'note'          => isset( $input['note'] ) ? (string) $input['note'] : '',
+			'source'        => isset( $input['source'] ) ? (string) $input['source'] : '',
+			'acted_by'      => isset( $input['acted_by'] ) ? absint( $input['acted_by'] ) : get_current_user_id(),
+			'purge_content' => ! empty( $input['purge_content'] ),
 		)
 	);
 }

--- a/inc/core/moderation/actions.php
+++ b/inc/core/moderation/actions.php
@@ -41,8 +41,16 @@ function extrachill_users_apply_moderation_action( int $user_id, array $args = a
 		$manager->destroy_all();
 	}
 
+	// Explicit, opt-in hard delete. DESTRUCTIVE AND IRREVERSIBLE — only fires
+	// when the operator explicitly requests it; it is never derived from the
+	// reason_key policy effects. When set, purge supersedes the hide path so we
+	// don't draft/spam content we're about to permanently delete.
+	$purge_content = ! empty( $args['purge_content'] );
+
 	$results = array();
-	if ( ! empty( $policy['effects']['mark_content_spam'] ) || ! empty( $policy['effects']['hide_content'] ) ) {
+	if ( $purge_content ) {
+		$results['purged'] = extrachill_users_purge_user_content( $user_id );
+	} elseif ( ! empty( $policy['effects']['mark_content_spam'] ) || ! empty( $policy['effects']['hide_content'] ) ) {
 		$results['content'] = extrachill_users_apply_spam_visibility_to_user_content( $user_id );
 	}
 

--- a/inc/core/moderation/content.php
+++ b/inc/core/moderation/content.php
@@ -202,3 +202,127 @@ function extrachill_users_apply_spam_visibility_to_user_content( int $user_id ) 
 
 	return $results;
 }
+
+/**
+ * Hard-delete (purge) all of a user's content network-wide.
+ *
+ * DESTRUCTIVE AND IRREVERSIBLE. This is an explicit, opt-in operation and is
+ * NEVER the default moderation behavior — hiding (draft/spam) remains the
+ * default for every reason. Purge is only invoked when an operator explicitly
+ * requests it (e.g. the `purge_content` ability input / `--purge` CLI flag).
+ *
+ * Reuses the same network-wide post/comment collection and artist-platform
+ * collection that the hide path uses, so it catches the identical scope —
+ * including bbPress `topic`/`reply` CPTs and artist link pages. Unlike the
+ * hide path (which skips attachments), purge ALSO removes the user's owned
+ * attachments and any attachments parented to the deleted posts, so orphaned
+ * link-page logo attachments are caught.
+ *
+ * @param int $user_id User whose content should be permanently deleted.
+ * @return array{posts:int,comments:int,attachments:int} Counts of removed objects.
+ */
+function extrachill_users_purge_user_content( int $user_id ) {
+	$objects = array_merge(
+		extrachill_users_get_user_content_objects( $user_id ),
+		extrachill_users_get_owned_artist_platform_objects( $user_id )
+	);
+
+	$objects = array_values(
+		array_reduce(
+			$objects,
+			function ( $carry, $object_value ) {
+				$key           = $object_value['type'] . ':' . $object_value['blog_id'] . ':' . $object_value['object_id'];
+				$carry[ $key ] = $object_value;
+				return $carry;
+			},
+			array()
+		)
+	);
+
+	$results = array(
+		'posts'       => 0,
+		'comments'    => 0,
+		'attachments' => 0,
+	);
+
+	// Defer attachment deletion so we delete child attachments alongside their
+	// parent post in the same loop iteration, and standalone author-owned
+	// attachments after, avoiding double-deleting a child we already removed.
+	$deleted_attachments = array();
+
+	foreach ( $objects as $object ) {
+		switch_to_blog( (int) $object['blog_id'] );
+		try {
+			if ( 'comment' === $object['type'] ) {
+				if ( wp_delete_comment( (int) $object['object_id'], true ) ) {
+					++$results['comments'];
+				}
+				continue;
+			}
+
+			$post_id   = (int) $object['object_id'];
+			$post_type = isset( $object['post_type'] ) ? (string) $object['post_type'] : '';
+
+			if ( 'attachment' === $post_type ) {
+				$key = (int) $object['blog_id'] . ':' . $post_id;
+				if ( empty( $deleted_attachments[ $key ] ) ) {
+					if ( wp_delete_attachment( $post_id, true ) ) {
+						++$results['attachments'];
+						$deleted_attachments[ $key ] = true;
+					}
+				}
+				continue;
+			}
+
+			// Remove attachments parented to this post (e.g. link-page logos)
+			// before deleting the post, so they don't linger as orphans.
+			$child_attachments = get_children(
+				array(
+					'post_parent'    => $post_id,
+					'post_type'      => 'attachment',
+					'post_status'    => 'any',
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+				)
+			);
+
+			if ( is_array( $child_attachments ) ) {
+				foreach ( $child_attachments as $attachment_id ) {
+					$attachment_id = (int) $attachment_id;
+					$key           = (int) $object['blog_id'] . ':' . $attachment_id;
+					if ( ! empty( $deleted_attachments[ $key ] ) ) {
+						continue;
+					}
+					if ( wp_delete_attachment( $attachment_id, true ) ) {
+						++$results['attachments'];
+						$deleted_attachments[ $key ] = true;
+					}
+				}
+			}
+
+			// Featured image (thumbnail) may not be a post_parent child.
+			$thumbnail_id = (int) get_post_thumbnail_id( $post_id );
+			if ( $thumbnail_id > 0 ) {
+				$key = (int) $object['blog_id'] . ':' . $thumbnail_id;
+				if ( empty( $deleted_attachments[ $key ] ) ) {
+					if ( wp_delete_attachment( $thumbnail_id, true ) ) {
+						++$results['attachments'];
+						$deleted_attachments[ $key ] = true;
+					}
+				}
+			}
+
+			// bbPress topics/replies and all other posts are force-deleted the
+			// same way — wp_delete_post( $id, true ) bypasses the trash and
+			// removes meta/terms. For topics this also unhooks replies via
+			// bbPress' own delete callbacks where registered.
+			if ( wp_delete_post( $post_id, true ) ) {
+				++$results['posts'];
+			}
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	return $results;
+}


### PR DESCRIPTION
## Summary
Adds an explicit, **opt-in** hard-delete (purge) path to the moderation system. Today moderation never deletes content — `hide_content`/`mark_content_spam` only draft posts, spam bbPress topics/replies, spam comments, and skip attachments entirely. Operators handling clear-cut spam/scam (SEO backlink-farm link pages, fake scam posts) had to manually `wp post delete --force` afterward. This makes purge a first-class, one-step option.

## What changed
- **`inc/core/moderation/content.php`** — new `extrachill_users_purge_user_content()` that **reuses the existing collectors** (`extrachill_users_get_user_content_objects()` + `extrachill_users_get_owned_artist_platform_objects()`) so it catches the identical network-wide + artist-platform scope, including bbPress `topic`/`reply` CPTs and artist link pages. It force-deletes:
  - posts (incl. `artist_profile`/`artist_link_page`) via `wp_delete_post( $id, true )`
  - bbPress topics/replies (same force-delete path)
  - comments via `wp_delete_comment( $id, true )`
  - **attachments** — owned attachments, attachments parented to a deleted post, and featured-image attachments. The hide path skips attachments; purge catches them, including the **orphaned link-page logo attachments** the issue calls out. Dedup guards prevent double-deletes.
- **`inc/core/moderation/actions.php`** — orchestration branches to purge when `purge_content` is set, **superseding** the hide branch (so we don't draft/spam content we're about to permanently delete). The existing effects system is left intact.
- **`inc/core/abilities/moderation.php`** — `extrachill/moderate-user` gains a boolean `purge_content` input (default `false`), documented as destructive/irreversible, plus an updated ability description.

## Safety / behavior
- **Opt-in only, never the default.** Hiding (draft/spam) stays the default behavior for **every** `reason_key`. Purge is never derived from policy effects — it fires only when the operator explicitly passes `purge_content`.
- **Destructive + irreversible** — guarded accordingly and clearly documented in the ability input/description.

## CLI flag
The matching `--purge` flag on `wp extrachill users ban` lives in the separate **extrachill-cli** repo and is shipped in its own PR: Extra-Chill/extrachill-cli#TBD (branch `issue-135-purge-cli`). It wraps this ability's new `purge_content` input behind an interactive confirmation.

## Verification
- `php -l` clean on all three edited files.
- `phpcs --standard=WordPress` introduces **zero new findings** (pre-existing baseline debt on untouched functions remains; the new `extrachill_users_purge_user_content()` is fully documented).

Closes #135