### PR TITLE
feat: per-person brand-socials access grant

### DIFF
--- a/inc/brand-socials-permissions.php
+++ b/inc/brand-socials-permissions.php
@@ -30,12 +30,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Capability that grants ONE specific person brand-socials access.
+ *
+ * This cap is deliberately NOT part of the `extra_chill_team` role's default
+ * cap set (see ec_users_get_team_role_caps() in inc/team-members/role.php).
+ * Adding it to the role would hand brand-socials access to EVERY team member,
+ * which defeats the purpose of keeping the `brand_socials` feature on an
+ * `admin` ceiling. Instead it is an explicit, per-user grant managed via
+ * {@see ec_grant_brand_socials()} / {@see ec_revoke_brand_socials()} and ORed
+ * into the gate below — broadening access for the granted individual without
+ * weakening the admin-only default for everyone else.
+ */
+const EC_BRAND_SOCIALS_CAP = 'manage_brand_socials';
+
+/**
  * Gate the shared brand social accounts behind the `brand_socials` feature.
  *
  * Hooks the generic `datamachine_socials_user_can` filter and ANDs the base
  * capability result with the EC rollout gate. A user who fails the feature gate
  * is denied even if they hold the raw post capability; a user who passes still
  * needs the base capability (we never grant access the socials plugin denied).
+ *
+ * The rollout gate is ORed with an explicit per-person capability grant
+ * ({@see EC_BRAND_SOCIALS_CAP}). A user who passes the feature tier OR holds
+ * the per-person grant is allowed (still subject to the base `$allowed`). The
+ * OR can only ever BROADEN access for an explicitly-granted individual — it
+ * never weakens the admin-only denial for anyone who lacks the grant, because
+ * the base `$allowed &&` short-circuits first.
  *
  * @since 1.0.0
  *
@@ -46,9 +67,106 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function ec_brand_socials_user_can( $allowed, $action, $user_id ) {
 	if ( in_array( $action, array( 'publish', 'edit', 'upload' ), true ) ) {
-		return $allowed && function_exists( 'ec_feature_available' ) && ec_feature_available( 'brand_socials', $user_id );
+		return $allowed && (
+			( function_exists( 'ec_feature_available' ) && ec_feature_available( 'brand_socials', $user_id ) )
+			// phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom per-person cap granted by ec_grant_brand_socials() (extrachill-users#133).
+			|| user_can( $user_id, EC_BRAND_SOCIALS_CAP )
+		);
 	}
 
 	return $allowed;
 }
 add_filter( 'datamachine_socials_user_can', 'ec_brand_socials_user_can', 10, 3 );
+
+/**
+ * Grant the per-person brand-socials capability to a user, network-wide.
+ *
+ * Brand-social credentials are network-shared, so the grant must be consistent
+ * across every site — a user granted on one subsite but not another would see
+ * the gate flip depending on which site's request resolved the cap. Mirrors
+ * the network-wide write pattern of ec_users_grant_team_role(): iterate every
+ * site, switch_to_blog(), add the cap on the user's row.
+ *
+ * Super-admins are skipped — they already pass the `admin` tier via
+ * manage_options, so the per-person grant is redundant noise on their account.
+ *
+ * @since 1.0.0
+ *
+ * @param int $user_id User ID.
+ * @return int[] Blog IDs the cap was newly added on (already-present sites omitted).
+ */
+function ec_grant_brand_socials( $user_id ) {
+	$user_id = (int) $user_id;
+	if ( $user_id <= 0 ) {
+		return array();
+	}
+
+	if ( function_exists( 'is_super_admin' ) && is_super_admin( $user_id ) ) {
+		return array();
+	}
+
+	$added = array();
+
+	foreach ( ec_users_get_network_site_ids() as $blog_id ) {
+		$blog_id = (int) $blog_id;
+		try {
+			switch_to_blog( $blog_id );
+
+			$user = new WP_User( $user_id );
+			if ( ! $user->exists() ) {
+				continue;
+			}
+
+			// phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom per-person cap (extrachill-users#133).
+			if ( ! $user->has_cap( EC_BRAND_SOCIALS_CAP ) ) {
+				$user->add_cap( EC_BRAND_SOCIALS_CAP );
+				$added[] = $blog_id;
+			}
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	return $added;
+}
+
+/**
+ * Revoke the per-person brand-socials capability from a user, network-wide.
+ *
+ * Pure write — counterpart to {@see ec_grant_brand_socials()}.
+ *
+ * @since 1.0.0
+ *
+ * @param int $user_id User ID.
+ * @return int[] Blog IDs the cap was removed from.
+ */
+function ec_revoke_brand_socials( $user_id ) {
+	$user_id = (int) $user_id;
+	if ( $user_id <= 0 ) {
+		return array();
+	}
+
+	$removed = array();
+
+	foreach ( ec_users_get_network_site_ids() as $blog_id ) {
+		$blog_id = (int) $blog_id;
+		try {
+			switch_to_blog( $blog_id );
+
+			$user = new WP_User( $user_id );
+			if ( ! $user->exists() ) {
+				continue;
+			}
+
+			// phpcs:ignore WordPress.WP.Capabilities.Unknown -- Custom per-person cap (extrachill-users#133).
+			if ( $user->has_cap( EC_BRAND_SOCIALS_CAP ) ) {
+				$user->remove_cap( EC_BRAND_SOCIALS_CAP );
+				$removed[] = $blog_id;
+			}
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	return $removed;
+}


### PR DESCRIPTION
## Summary

Adds an **optional per-person grant** ORed into the brand-socials gate, so one explicitly-granted individual (e.g. qrisg) can access the shared brand social accounts while the `brand_socials` feature tier stays admin-only for everyone else.

Closes #133.

## What changed

All changes are in `inc/brand-socials-permissions.php` (+119 / -1):

- **New cap constant** `EC_BRAND_SOCIALS_CAP = 'manage_brand_socials'` (line ~25). Deliberately **NOT** added to `ec_users_get_team_role_caps()` in `inc/team-members/role.php` — adding it there would hand the cap to *every* team member and defeat the admin-only ceiling. It is an explicit, per-user grant only.
- **Gate update** in `ec_brand_socials_user_can()` (line ~58): ORs the per-person cap into the existing feature-tier check, keeping the base `$allowed &&` short-circuit out front:
  ```php
  return $allowed && (
      ( function_exists( 'ec_feature_available' ) && ec_feature_available( 'brand_socials', $user_id ) )
      || user_can( $user_id, EC_BRAND_SOCIALS_CAP )
  );
  ```
  Includes `phpcs:ignore WordPress.WP.Capabilities.Unknown` for the custom cap, matching the extrachill-roadie `access_roadie` pattern.
- **Grant/revoke helpers** (line ~95+): `ec_grant_brand_socials( $user_id )` / `ec_revoke_brand_socials( $user_id )`. Network-wide (iterate `ec_users_get_network_site_ids()`, `switch_to_blog()`, `add_cap`/`remove_cap`), skip super-admins on grant, return the list of blog IDs touched — mirroring `ec_users_grant_team_role()` / `ec_users_revoke_team_role()`. Network-wide consistency matters because the brand-social credentials are network-shared.

## Logic trace

| User | Result | Why |
|------|--------|-----|
| Admin (`manage_options`) | **passes** | `ec_feature_available('brand_socials')` resolves true at the `admin` tier |
| Plain `extra_chill_team` member | **denied** | tier is `admin`, not a manage_options user, and lacks the per-person cap |
| Team member WITH `manage_brand_socials` | **passes** | fails the tier check but the `|| user_can(..., 'manage_brand_socials')` branch is true |
| Anyone the socials plugin already denied (`$allowed === false`) | **denied** | base `$allowed &&` short-circuits — the OR can never grant access the socials plugin denied |

The OR can only ever **broaden** access for an explicitly-granted user; it never weakens the admin-only denial for anyone lacking the grant.

## Scope notes
- Gate covers all three actions (`publish` / `edit` / `upload`) — the per-person grant applies to the whole brand-socials surface, matching the admin gate.
- Cap named `manage_brand_socials` per the issue; consistent with the repo's `manage_*` capability convention (`manage_shop`, `manage_artist`).

## Verification
- `php -l inc/brand-socials-permissions.php` → no syntax errors.
- `phpcs --standard=WordPress` on the changed file → **0 new findings**. (One pre-existing finding remains on line 5 — the file-header docblock starting with lowercase `data-machine-socials` — which is baseline and unrelated to this change; left untouched to keep the PR focused.)

## Follow-up (not in this PR)
The obvious place to surface grant/revoke in the UI is the **extrachill-admin-tools** team-management ability handler (`inc/core/abilities/handlers/team-members.php`), which already wraps `ec_users_grant_team_role()` / `ec_users_revoke_team_role()` via a `force_add` / `force_remove` action ability. A sibling per-person brand-socials toggle there would mirror the existing pattern cleanly — left as a follow-up to keep this PR focused on the cap + gate + helpers.