### PR TITLE
refactor: read online-users count from NetworkStats primitive (delete duplicate function)

### DIFF
--- a/inc/core/online-users.php
+++ b/inc/core/online-users.php
@@ -2,7 +2,14 @@
 /**
  * Network-Wide Online Users Tracking
  *
- * Tracks activity across all multisite network sites with centralized storage on community.extrachill.com.
+ * Records per-user activity on community.extrachill.com (the centralized store)
+ * that feeds the network-wide "online now" count.
+ *
+ * The COUNT itself is owned by the NetworkStats `online_users` metric provider
+ * in extrachill-multisite — that primitive is the single source and single
+ * cache for the number. Consumers read it directly via
+ * ec_get_network_stats(['online_users']); this plugin only records activity and
+ * invalidates the metric cache when a user becomes active.
  *
  * @package ExtraChill\Users
  */
@@ -11,89 +18,53 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-global $online_users_count;
-
 /**
  * Record user activity network-wide with centralized storage.
  *
- * Updates every 15 minutes, stores on community.extrachill.com regardless of active site.
+ * Writes `last_active` user meta (throttled to once per 15 minutes per user via
+ * the `user_activity_<id>` transient) on community.extrachill.com regardless of
+ * the active site, then invalidates the NetworkStats online_users metric cache
+ * so the next read reflects the new activity.
  */
 function ec_record_user_activity() {
 	$user_id = get_current_user_id();
-	if ( $user_id ) {
-		$current_time            = time();
-		$user_activity_cache_key = 'user_activity_' . $user_id;
-
-		$community_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'community' ) : null;
-
-		if ( $community_blog_id && function_exists( 'switch_to_blog' ) ) {
-			global $current_user;
-
-			if ( isset( $current_user ) && $current_user instanceof WP_User ) {
-				switch_to_blog( $community_blog_id );
-				try {
-					$last_update = get_transient( $user_activity_cache_key );
-
-					if ( false === $last_update || ( $current_time - intval( $last_update ) ) > 900 ) {
-						update_user_meta( $user_id, 'last_active', $current_time );
-						delete_transient( 'online_users_count' );
-						set_transient( $user_activity_cache_key, $current_time, 900 );
-					}
-				} finally {
-					restore_current_blog();
-				}
-			}
-		}
+	if ( ! $user_id ) {
+		return;
 	}
 
-	global $online_users_count;
-	if ( ! isset( $online_users_count ) ) {
-		$online_users_count = ec_get_online_users_count();
+	$current_time            = time();
+	$user_activity_cache_key = 'user_activity_' . $user_id;
+
+	$community_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'community' ) : null;
+
+	if ( ! $community_blog_id || ! function_exists( 'switch_to_blog' ) ) {
+		return;
+	}
+
+	global $current_user;
+
+	if ( ! isset( $current_user ) || ! ( $current_user instanceof WP_User ) ) {
+		return;
+	}
+
+	switch_to_blog( $community_blog_id );
+	try {
+		$last_update = get_transient( $user_activity_cache_key );
+
+		if ( false === $last_update || ( $current_time - intval( $last_update ) ) > 900 ) {
+			update_user_meta( $user_id, 'last_active', $current_time );
+			set_transient( $user_activity_cache_key, $current_time, 900 );
+
+			// The online-users count is owned + cached by the NetworkStats
+			// primitive (extrachill-multisite). Bust just that metric so the
+			// next read reflects this activity. Guarded so a version skew
+			// during deploy (multisite a version behind) never fatals.
+			if ( function_exists( 'ec_network_stats_forget' ) ) {
+				ec_network_stats_forget( 'online_users' );
+			}
+		}
+	} finally {
+		restore_current_blog();
 	}
 }
 add_action( 'wp', 'ec_record_user_activity' );
-
-/**
- * Get network-wide online users count with 5-minute caching.
- *
- * @return int Users active within last 15 minutes across network
- */
-function ec_get_online_users_count() {
-	global $wpdb;
-
-	$transient_key     = 'online_users_count';
-	$community_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'community' ) : null;
-
-	if ( $community_blog_id && function_exists( 'switch_to_blog' ) ) {
-		global $current_user;
-
-		if ( isset( $current_user ) && $current_user instanceof WP_User ) {
-			switch_to_blog( $community_blog_id );
-			try {
-				$online_users_count = get_transient( $transient_key );
-
-				if ( false === $online_users_count ) {
-					$time_limit     = 15 * MINUTE_IN_SECONDS;
-					$time_threshold = time() - $time_limit;
-
-					$online_users_count = $wpdb->get_var(
-						$wpdb->prepare(
-							"SELECT COUNT(*) FROM $wpdb->usermeta WHERE meta_key = 'last_active' AND meta_value > %d",
-							$time_threshold
-						)
-					);
-
-					set_transient( $transient_key, intval( $online_users_count ), 5 * MINUTE_IN_SECONDS );
-				}
-			} finally {
-				restore_current_blog();
-			}
-		} else {
-			$online_users_count = 0;
-		}
-	} else {
-		$online_users_count = 0;
-	}
-
-	return intval( $online_users_count );
-}

--- a/inc/footer/online-users-stats.php
+++ b/inc/footer/online-users-stats.php
@@ -2,8 +2,12 @@
 /**
  * Online Users Stats Widget
  *
- * Displays network-wide online users count in footer.
- * Data provided by ec_get_online_users_count() function.
+ * Displays the network-wide "online now" count plus total members in the footer.
+ *
+ * The online count is read directly from the NetworkStats `online_users` metric
+ * provider (extrachill-multisite) via ec_get_network_stats() — the single source
+ * and single cache for that number. Total members is counted from the community
+ * blog and cached locally for a day.
  *
  * @package ExtraChill\Users
  */
@@ -16,17 +20,21 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Display online users stats widget.
  */
 function extrachill_users_display_online_stats() {
-	if ( ! function_exists( 'ec_get_online_users_count' ) ) {
-		return;
-	}
-
-	$online_users_count = ec_get_online_users_count();
-
 	$community_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'community' ) : null;
 	if ( ! $community_blog_id ) {
 		return;
 	}
 
+	// Online-now count: read straight from the NetworkStats primitive (single
+	// source, single cache). When the primitive is unavailable (e.g. multisite
+	// a version behind during deploy) fall back to 0.
+	$online_users_count = 0;
+	if ( function_exists( 'ec_get_network_stats' ) ) {
+		$stats              = ec_get_network_stats( array( 'online_users' ) );
+		$online_users_count = (int) ( $stats['online_users']['value'] ?? 0 );
+	}
+
+	$total_members = 0;
 	if ( function_exists( 'switch_to_blog' ) ) {
 		global $current_user;
 
@@ -39,11 +47,7 @@ function extrachill_users_display_online_stats() {
 				set_transient( 'total_members_count', $total_members, DAY_IN_SECONDS );
 			}
 			restore_current_blog();
-		} else {
-			$total_members = 0;
 		}
-	} else {
-		$total_members = 0;
 	}
 	?>
 	<div class="online-stats-card">


### PR DESCRIPTION
## Summary
Closes #143. Makes the online-users count CONSUME the `NetworkStats` primitive (single source, single cache) instead of running its own parallel query + transient. Companion to Extra-Chill/extrachill-multisite#68.

**No shim** — `ec_get_online_users_count()` is deleted outright and its one caller (the footer widget) now reads the primitive directly.

Previously two transients cached the *same* number: this plugin's `online_users_count` and the NetworkStats `online_users` provider's per-metric transient (which merely wrapped this plugin's function). This inverts ownership so the primitive is authoritative.

## What changed
- **Deleted `ec_get_online_users_count()` entirely** — no back-compat shim. Removed with it: the standalone `online_users_count` transient and the inline `switch_to_blog(community)` + `COUNT(*) usermeta last_active` query. That logic now lives in its canonical home, `OnlineUsersProvider::value()` (multisite PR #68).
- **Footer widget** (`inc/footer/online-users-stats.php`) — the only caller — now reads the value directly via `ec_get_network_stats(['online_users'])['online_users']['value']`, guarded with `function_exists()`. Output is byte-for-byte identical.
- **`ec_record_user_activity()`** busts the primitive's metric cache via `ec_network_stats_forget('online_users')` instead of `delete_transient('online_users_count')`. The per-user 15-min activity-write throttle (`user_activity_<id>` transient) is unchanged. (Also dropped the vestigial `global $online_users_count` warm — nothing consumed it.)

## Single-cache result
Exactly one cache for the number: the NetworkStats per-metric transient (`ec_network_stat_online_users`, 5-min TTL) in extrachill-multisite. The old `online_users_count` transient is gone. Activity invalidation still refreshes the count, now by forgetting the primitive's metric cache.

## Deploy-order + function_exists guard safety
- Deploy order: **multisite first, then users.**
- Every cross-plugin call is guarded with `function_exists()` and degrades gracefully: the footer widget falls back to `0` if `ec_get_network_stats()` is unavailable; `ec_record_user_activity()` skips invalidation if `ec_network_stats_forget()` is unavailable (the activity write still happens).
- The guards make **either deploy order non-fatal** even though multisite-first is preferred.

Closes #143