### PR TITLE
feat: capture external referrer + UTM on registration for source attribution

### DIFF
--- a/blocks/login-register/view.js
+++ b/blocks/login-register/view.js
@@ -43,6 +43,48 @@ function GoogleButtons( { redirectUrl } ) {
 	);
 }
 
+/**
+ * Capture last-touch source attribution from the browser at registration time.
+ *
+ * Reads the external referrer (document.referrer, only available client-side)
+ * and any utm_* query parameters from the current URL. The referrer is omitted
+ * when it points back to the same host (internal navigation) so we only attribute
+ * genuine external sources. Returns an object that is safe to spread into the
+ * registration request body — both fields are optional downstream.
+ *
+ * @return {{referrer: string, utm: Object}} Attribution payload (referrer may be
+ *   empty; utm may be an empty object).
+ */
+function captureAttribution() {
+	let referrer = '';
+	try {
+		const raw = document.referrer || '';
+		if ( raw ) {
+			const referrerHost = new URL( raw ).host;
+			if ( referrerHost && referrerHost !== window.location.host ) {
+				referrer = raw;
+			}
+		}
+	} catch ( e ) {
+		referrer = '';
+	}
+
+	const utm = {};
+	try {
+		const params = new URLSearchParams( window.location.search );
+		[ 'source', 'medium', 'campaign', 'term', 'content' ].forEach( ( key ) => {
+			const value = params.get( `utm_${ key }` );
+			if ( value ) {
+				utm[ key ] = value;
+			}
+		} );
+	} catch ( e ) {
+		// Leave utm empty on any parsing failure.
+	}
+
+	return { referrer, utm };
+}
+
 function renderTurnstile( container ) {
 	if ( ! container || ! window.turnstile ) {
 		return;
@@ -245,6 +287,7 @@ function RegisterPanel( { config, notice, setNotice } ) {
 		const submitButton = form.querySelector( 'input[type="submit"], button[type="submit"]' );
 		const restore = utils?.setSubmitting ? utils.setSubmitting( submitButton, 'Creating account…' ) : () => {};
 		const fromJoin = Boolean( config.fromJoin );
+		const { referrer, utm } = captureAttribution();
 
 		try {
 			const url = new URL( 'extrachill/v1/auth/register', utils.getRestRoot() );
@@ -268,6 +311,8 @@ function RegisterPanel( { config, notice, setNotice } ) {
 					invite_token: inviteToken,
 					invite_artist_id: inviteArtistId,
 					from_join: fromJoin,
+					referrer,
+					utm,
 				} ),
 			} );
 

--- a/inc/auth-tokens/service.php
+++ b/inc/auth-tokens/service.php
@@ -326,6 +326,10 @@ function extrachill_users_register_with_tokens( array $payload ) {
 	$registration_source  = isset( $payload['registration_source'] ) ? sanitize_text_field( (string) $payload['registration_source'] ) : '';
 	$registration_method  = isset( $payload['registration_method'] ) ? sanitize_text_field( (string) $payload['registration_method'] ) : '';
 	$success_redirect_url = isset( $payload['success_redirect_url'] ) ? esc_url_raw( (string) $payload['success_redirect_url'] ) : '';
+	$referrer             = isset( $payload['referrer'] ) ? esc_url_raw( (string) $payload['referrer'] ) : '';
+	$utm                  = ( isset( $payload['utm'] ) && function_exists( 'extrachill_users_sanitize_utm' ) )
+		? extrachill_users_sanitize_utm( $payload['utm'] )
+		: array();
 
 	$is_app_client = isset( $_SERVER['HTTP_EXTRACHILL_CLIENT'] )
 		&& 'app' === sanitize_text_field( wp_unslash( $_SERVER['HTTP_EXTRACHILL_CLIENT'] ) );
@@ -418,6 +422,17 @@ function extrachill_users_register_with_tokens( array $payload ) {
 
 	if ( ! empty( $registration_page ) ) {
 		$registration_data['registration_page'] = $registration_page;
+	}
+
+	// Source attribution (last-touch): forward the external referrer and any
+	// UTM parameters to the create-user ability, which persists them and folds
+	// them into the user_registration analytics event.
+	if ( ! empty( $referrer ) ) {
+		$registration_data['referrer'] = $referrer;
+	}
+
+	if ( ! empty( $utm ) ) {
+		$registration_data['utm'] = $utm;
 	}
 
 	if ( $is_app_client ) {

--- a/inc/core/abilities/create-user.php
+++ b/inc/core/abilities/create-user.php
@@ -54,6 +54,14 @@ function extrachill_users_register_create_user_ability() {
 						'type'        => 'string',
 						'description' => __( 'Method label (e.g. standard, google).', 'extrachill-users' ),
 					),
+					'referrer'            => array(
+						'type'        => 'string',
+						'description' => __( 'External referrer URL captured at registration (last-touch attribution). Optional.', 'extrachill-users' ),
+					),
+					'utm'                 => array(
+						'type'        => 'object',
+						'description' => __( 'UTM query parameters (utm_source/medium/campaign/term/content) captured at registration. Optional.', 'extrachill-users' ),
+					),
 				),
 				'required'   => array( 'email', 'password', 'username' ),
 			),
@@ -76,12 +84,54 @@ function extrachill_users_register_create_user_ability() {
 }
 
 /**
+ * Canonical UTM parameter keys captured for source attribution.
+ *
+ * @return string[] The five standard UTM parameter names (without the utm_ prefix).
+ */
+function extrachill_users_utm_keys() {
+	return array( 'source', 'medium', 'campaign', 'term', 'content' );
+}
+
+/**
+ * Sanitize a raw UTM array down to the canonical keys with text-field values.
+ *
+ * Accepts either short keys (source, medium, ...) or full keys (utm_source, ...).
+ * Drops anything outside the canonical set and any empty values so the stored
+ * payload contains only meaningful, attributable parameters.
+ *
+ * @param mixed $raw Raw UTM input (expected associative array; anything else yields empty).
+ * @return array Sanitized map of short-key => value, possibly empty.
+ */
+function extrachill_users_sanitize_utm( $raw ) {
+	if ( ! is_array( $raw ) ) {
+		return array();
+	}
+
+	$clean = array();
+	foreach ( extrachill_users_utm_keys() as $key ) {
+		$value = '';
+		if ( isset( $raw[ $key ] ) ) {
+			$value = $raw[ $key ];
+		} elseif ( isset( $raw[ 'utm_' . $key ] ) ) {
+			$value = $raw[ 'utm_' . $key ];
+		}
+
+		$value = sanitize_text_field( (string) $value );
+		if ( '' !== $value ) {
+			$clean[ $key ] = $value;
+		}
+	}
+
+	return $clean;
+}
+
+/**
  * Create a community user account.
  *
  * Switches to the community blog, creates the WordPress user, sets onboarding
  * meta, fires the registration hook, and tracks analytics.
  *
- * @param array $input {email, password, username, from_join, registration_page, registration_source, registration_method}.
+ * @param array $input {email, password, username, from_join, registration_page, registration_source, registration_method, referrer, utm}.
  * @return int|WP_Error User ID on success, WP_Error on failure.
  */
 function extrachill_users_ability_create_user( $input ) {
@@ -92,6 +142,8 @@ function extrachill_users_ability_create_user( $input ) {
 	$registration_page   = isset( $input['registration_page'] ) ? $input['registration_page'] : '';
 	$registration_source = isset( $input['registration_source'] ) ? $input['registration_source'] : '';
 	$registration_method = isset( $input['registration_method'] ) ? $input['registration_method'] : '';
+	$referrer            = isset( $input['referrer'] ) ? esc_url_raw( (string) $input['referrer'] ) : '';
+	$utm                 = extrachill_users_sanitize_utm( isset( $input['utm'] ) ? $input['utm'] : array() );
 
 	if ( empty( $username ) || empty( $password ) || empty( $email ) ) {
 		return new WP_Error( 'missing_fields', 'Username, password, and email are required.' );
@@ -122,6 +174,18 @@ function extrachill_users_ability_create_user( $input ) {
 			update_user_meta( $user_id, 'registration_method', sanitize_text_field( (string) $registration_method ) );
 		}
 
+		// Source attribution (last-touch): persist the external referrer and any
+		// UTM parameters captured at registration so new-member growth can be
+		// attributed to its traffic source. Both are optional and absent for
+		// legacy/internal-only signups.
+		if ( ! empty( $referrer ) ) {
+			update_user_meta( $user_id, 'registration_referrer', $referrer );
+		}
+
+		if ( ! empty( $utm ) ) {
+			update_user_meta( $user_id, 'registration_utm', $utm );
+		}
+
 		if ( function_exists( 'ec_mark_user_for_onboarding' ) ) {
 			ec_mark_user_for_onboarding( $user_id, $from_join );
 		} else {
@@ -150,14 +214,27 @@ function extrachill_users_ability_create_user( $input ) {
 		// Track analytics via ability if available.
 		$analytics_ability = wp_get_ability( 'extrachill/track-analytics-event' );
 		if ( $analytics_ability ) {
+			$event_data = array(
+				'user_id' => $user_id,
+				'source'  => $registration_source,
+				'method'  => $registration_method,
+			);
+
+			// Source attribution is nullable: only fold referrer/utm into the
+			// event payload when actually captured, keeping existing signups
+			// (and their stored event_data shape) unchanged.
+			if ( ! empty( $referrer ) ) {
+				$event_data['referrer'] = $referrer;
+			}
+
+			if ( ! empty( $utm ) ) {
+				$event_data['utm'] = $utm;
+			}
+
 			$analytics_ability->execute(
 				array(
 					'event_type' => 'user_registration',
-					'event_data' => array(
-						'user_id' => $user_id,
-						'source'  => $registration_source,
-						'method'  => $registration_method,
-					),
+					'event_data' => $event_data,
 					'source_url' => $registration_page,
 				)
 			);

--- a/tests/integration/UserCreationTest.php
+++ b/tests/integration/UserCreationTest.php
@@ -141,6 +141,88 @@ class Test_User_Creation extends WP_UnitTestCase {
 		$this->assertSame( 1, did_action( 'extrachill_new_user_registered' ) );
 	}
 
+	public function test_create_user_persists_referrer_and_utm(): void {
+		$user_id = $this->create_user(
+			array(
+				'username' => 'attruser',
+				'email'    => 'attr@example.com',
+				'referrer' => 'https://www.reddit.com/r/Charleston/',
+				'utm'      => array(
+					'source'   => 'reddit',
+					'medium'   => 'social',
+					'campaign' => 'festival-wire',
+				),
+			)
+		);
+
+		$this->assertIsInt( $user_id );
+		$this->assertSame( 'https://www.reddit.com/r/Charleston/', get_user_meta( $user_id, 'registration_referrer', true ) );
+
+		$stored_utm = get_user_meta( $user_id, 'registration_utm', true );
+		$this->assertSame(
+			array(
+				'source'   => 'reddit',
+				'medium'   => 'social',
+				'campaign' => 'festival-wire',
+			),
+			$stored_utm
+		);
+	}
+
+	public function test_create_user_without_attribution_stores_nothing(): void {
+		$user_id = $this->create_user(
+			array(
+				'username' => 'noattruser',
+				'email'    => 'noattr@example.com',
+			)
+		);
+
+		$this->assertSame( '', get_user_meta( $user_id, 'registration_referrer', true ) );
+		$this->assertSame( '', get_user_meta( $user_id, 'registration_utm', true ) );
+	}
+
+	public function test_sanitize_utm_filters_to_canonical_keys(): void {
+		$clean = extrachill_users_sanitize_utm(
+			array(
+				'source'    => 'reddit',
+				'medium'    => '',
+				'gclid'     => 'should-be-dropped',
+				'campaign'  => 'spring',
+			)
+		);
+
+		// Empty medium is dropped; unknown gclid is dropped.
+		$this->assertSame(
+			array(
+				'source'   => 'reddit',
+				'campaign' => 'spring',
+			),
+			$clean
+		);
+	}
+
+	public function test_sanitize_utm_accepts_full_utm_prefixed_keys(): void {
+		$clean = extrachill_users_sanitize_utm(
+			array(
+				'utm_source'   => 'newsletter',
+				'utm_campaign' => 'sunday-chill',
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'source'   => 'newsletter',
+				'campaign' => 'sunday-chill',
+			),
+			$clean
+		);
+	}
+
+	public function test_sanitize_utm_non_array_yields_empty(): void {
+		$this->assertSame( array(), extrachill_users_sanitize_utm( 'not-an-array' ) );
+		$this->assertSame( array(), extrachill_users_sanitize_utm( null ) );
+	}
+
 	public function test_create_user_via_filter(): void {
 		$user_id = apply_filters(
 			'extrachill_create_community_user',


### PR DESCRIPTION
Closes Extra-Chill/extrachill-users#145.

Implements **last-touch** source attribution (approach b from the issue) so new-member growth can be attributed to its traffic source. Requires the companion arg-schema change in **Extra-Chill/extrachill-api#92** to reach the live web registration route.

## What changed

**`inc/core/abilities/create-user.php`** (load-bearing — all registration paths converge here)
- `extrachill/create-user` ability now accepts optional `referrer` (string) and `utm` (object) inputs.
- Persists them as user_meta `registration_referrer` and `registration_utm` (only when present).
- Folds them into the `user_registration` analytics `event_data` (nullable — omitted when not captured, so existing signups and their stored event_data shape are unchanged).
- Adds shared `extrachill_users_sanitize_utm()` + `extrachill_users_utm_keys()` helpers: normalizes UTM keys to the canonical five (`source`, `medium`, `campaign`, `term`, `content`), accepts both short and `utm_`-prefixed keys, drops empties and unknown params.

**`inc/auth-tokens/service.php`** (REST register service)
- Reads `referrer` + `utm` from the payload and forwards them into `registration_data` passed to the create-user ability.

**`blocks/login-register/view.js`** (React register form — last-touch capture point)
- New `captureAttribution()` reads `document.referrer` (the true external referrer, only available client-side) and parses `utm_*` from the current URL.
- Internal referrers (same host) are dropped so we only attribute genuine external sources.
- Sends `referrer` + `utm` in the register request body.

**`tests/integration/UserCreationTest.php`**
- Referrer + UTM persisted to user_meta; folded shape verified.
- Legacy signups (no attribution) store nothing.
- `sanitize_utm` filters to canonical keys, drops empties/unknowns, accepts `utm_`-prefixed keys, and returns empty for non-arrays.

## Coverage across surfaces
Because every registration path flows through the `extrachill/create-user` ability via `registration_data`, the app-token path and Google OAuth path inherit pass-through support for free once they choose to send `referrer`/`utm`. The web form is wired end-to-end here.

## Acceptance criteria (from #145)
- ✅ New `user_registration` event `event_data` includes `referrer` + `utm` (nullable).
- ✅ Existing signups unaffected (fields absent → nothing stored, event shape unchanged).
- ✅ No new PII beyond what GA already sees (referrer URL + UTM only; client only sends external referrers).
- ✅ Works across all network sites (capture is in the shared register block + ability).

## Coordinate with in-flight work
Per #145, coordinate with `extrachill-analytics@surface-growth-instrument` (commit `fb5d84d`, get-surface-growth ability) so source attribution and surface growth-rate reads compose cleanly. A future first-touch enhancement (approach a, keyed by the existing `visitor_id`) can build on this without breaking the event shape.

## Verification
- `php -l` clean on all changed PHP files.
- `homeboy lint` PHPCS gate **passes** on all changed files. PHPStan single-file scoped analysis shows only the pre-existing baseline-noise class (WP core functions/constants reported "not found" because core isn't loaded in scope — e.g. `esc_url_raw not found`); the only delta my change adds is one more `esc_url_raw` occurrence in that same baseline class, no new finding kind.
- Integration test additions follow the existing `UserCreationTest` pattern. Note: the WP Codebox test harness `wp_die()`s at plugin activation (`requires a WordPress multisite installation`) before any test runs — a pre-existing harness/environment limitation, not introduced here.