### PR TITLE
Stop emailing stale show reminders + auto-mark them read after the event passes

### DIFF
--- a/inc/concert-tracking/notifications.php
+++ b/inc/concert-tracking/notifications.php
@@ -38,6 +38,15 @@ defined( 'ABSPATH' ) || exit;
 const EC_USERS_SHOW_REMINDER_ACTION = 'ec_users_send_show_reminder';
 
 /**
+ * Notification `type` value for a show reminder.
+ *
+ * Canonical home for the time-sensitive reminder type. Other consumers (e.g.
+ * the email digest channel) reference this constant rather than re-declaring
+ * the literal, so the staleness logic and the producer can never drift.
+ */
+const EC_USERS_SHOW_REMINDER_TYPE = 'show_reminder';
+
+/**
  * Action Scheduler group for concert reminders (eases bulk inspection/cancel).
  */
 const EC_USERS_SHOW_REMINDER_GROUP = 'ec-users-show-reminders';
@@ -56,11 +65,39 @@ const EC_USERS_SHOW_REMINDER_LEAD = 2 * DAY_IN_SECONDS;
  */
 const EC_USERS_SHOW_REMINDER_MIN_LEAD = HOUR_IN_SECONDS;
 
+/**
+ * Recurring hook that resolves stale (past-event) unread show reminders.
+ *
+ * A `show_reminder` notification is created while a show is upcoming. Once the
+ * show passes it is meaningless — its title ("X is tomorrow") is no longer true.
+ * If the user never read it, the unread row would otherwise linger forever in
+ * the bell/count and could be picked up by the unread-notification email
+ * digest. This sweep marks such rows read so a passed show's reminder becomes a
+ * true no-op everywhere (bell, in-app list, count, and email).
+ */
+const EC_USERS_STALE_REMINDER_SWEEP_HOOK = 'ec_users_resolve_stale_show_reminders';
+
+/**
+ * Recurrence interval for the stale-reminder sweep (RecurringScheduler).
+ */
+const EC_USERS_STALE_REMINDER_SWEEP_INTERVAL = 'hourly';
+
+/**
+ * Fully qualified Data Machine RecurringScheduler class name.
+ *
+ * The sweep is scheduled through Data Machine's shared recurring-scheduling
+ * primitive (Action Scheduler-backed) rather than a hand-rolled
+ * wp_schedule_event(). Mirrors the digest sweep in inc/notifications/email.php.
+ */
+const EC_USERS_STALE_REMINDER_RECURRING_SCHEDULER = '\\DataMachine\\Engine\\Tasks\\RecurringScheduler';
+
 // ─── Hook Wiring ───────────────────────────────────────────────────────────────
 
 add_action( 'ec_users_event_marked', 'ec_users_on_event_marked', 10, 3 );
 add_action( 'ec_users_event_unmarked', 'ec_users_on_event_unmarked', 10, 3 );
 add_action( EC_USERS_SHOW_REMINDER_ACTION, 'ec_users_deliver_show_reminder', 10, 3 );
+add_action( 'init', 'ec_users_stale_reminder_sweep_maybe_schedule' );
+add_action( EC_USERS_STALE_REMINDER_SWEEP_HOOK, 'ec_users_resolve_stale_show_reminders' );
 
 /**
  * React to a newly-marked event: schedule a reminder + check milestones.
@@ -231,7 +268,7 @@ function ec_users_deliver_show_reminder( $user_id, $event_id, $blog_id ) {
 		$user_id,
 		array(
 			'actor_id' => $user_id, // System reminder: attribute to the recipient (substrate requires a valid actor).
-			'type'     => 'show_reminder',
+			'type'     => EC_USERS_SHOW_REMINDER_TYPE,
 			'title'    => $title,
 			'link'     => $details['permalink'],
 			'item_id'  => $event_id,
@@ -391,6 +428,141 @@ function ec_users_ordinal( int $number ): string {
 	return $number . $suffix;
 }
 
+// ─── Stale Reminder Sweep ─────────────────────────────────────────────────────
+
+/**
+ * Ensure the recurring stale-reminder sweep is scheduled (idempotent).
+ *
+ * The notification substrate is one base_prefix table shared by the whole
+ * network, so only ONE site needs to run the sweep. We pin it to the
+ * SMTP-configured mail site (reusing the digest's owner-site resolver) so
+ * exactly one scheduler owns it. Non-owner sites clear any stray schedule.
+ *
+ * Scheduling goes through Data Machine's RecurringScheduler when available
+ * (Action Scheduler-backed, idempotent), falling back to WP-Cron otherwise so
+ * the sweep keeps working in isolation. Mirrors
+ * ec_notifications_email_maybe_schedule().
+ */
+function ec_users_stale_reminder_sweep_maybe_schedule() {
+	$scheduler  = EC_USERS_STALE_REMINDER_RECURRING_SCHEDULER;
+	$is_owner   = function_exists( 'ec_notifications_email_is_owner_site' )
+		? ec_notifications_email_is_owner_site()
+		: ( function_exists( 'is_main_site' ) && is_main_site() );
+
+	if ( ! $is_owner ) {
+		// Not the owner site — make sure no stray schedule lingers here.
+		if ( wp_next_scheduled( EC_USERS_STALE_REMINDER_SWEEP_HOOK ) ) {
+			wp_clear_scheduled_hook( EC_USERS_STALE_REMINDER_SWEEP_HOOK );
+		}
+		if ( class_exists( $scheduler ) ) {
+			$scheduler::unschedule( EC_USERS_STALE_REMINDER_SWEEP_HOOK, array() );
+		}
+		return;
+	}
+
+	if ( class_exists( $scheduler ) ) {
+		// Clear any legacy WP-Cron registration so the sweep cannot double-fire
+		// (once via WP-Cron and once via Action Scheduler) on the upgrade path.
+		if ( wp_next_scheduled( EC_USERS_STALE_REMINDER_SWEEP_HOOK ) ) {
+			wp_clear_scheduled_hook( EC_USERS_STALE_REMINDER_SWEEP_HOOK );
+		}
+
+		$scheduler::ensureSchedule(
+			EC_USERS_STALE_REMINDER_SWEEP_HOOK,
+			array(),
+			EC_USERS_STALE_REMINDER_SWEEP_INTERVAL
+		);
+		return;
+	}
+
+	// Fallback: Data Machine not loaded — keep a WP-Cron schedule.
+	if ( ! wp_next_scheduled( EC_USERS_STALE_REMINDER_SWEEP_HOOK ) ) {
+		wp_schedule_event( time() + HOUR_IN_SECONDS, 'hourly', EC_USERS_STALE_REMINDER_SWEEP_HOOK );
+	}
+}
+
+/**
+ * Mark every unread show reminder whose event has passed as read.
+ *
+ * The recurring sweep callback. Loads all unread `show_reminder` rows, resolves
+ * each distinct event's timing ONCE (many users can track the same show), then
+ * marks the rows for past/ongoing events read in a single bulk UPDATE per stale
+ * event and flushes the affected users' unread-count caches so the bell badge
+ * updates immediately. Upcoming shows are left untouched.
+ *
+ * Network-wide: the table is keyed by base_prefix, so this single owner-site run
+ * covers reminders created from any site. Timing is resolved in the events-blog
+ * context via ec_users_reminder_event_timing().
+ *
+ * @return int Number of notification rows marked read.
+ */
+function ec_users_resolve_stale_show_reminders() {
+	global $wpdb;
+
+	$table = extrachill_users_notifications_table_name();
+
+	// All distinct events with at least one unread reminder. One timing lookup
+	// per event rather than per row.
+	$event_ids = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT DISTINCT item_id FROM {$table} WHERE is_read = 0 AND type = %s AND item_id IS NOT NULL AND item_id > 0", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+			EC_USERS_SHOW_REMINDER_TYPE
+		)
+	);
+
+	if ( empty( $event_ids ) ) {
+		return 0;
+	}
+
+	$events_blog = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'events' ) : 0;
+	if ( $events_blog <= 0 ) {
+		// Cannot resolve timing without the events blog — do nothing rather than
+		// risk marking upcoming reminders read.
+		return 0;
+	}
+
+	$total_read = 0;
+
+	foreach ( $event_ids as $event_id ) {
+		$event_id = (int) $event_id;
+		if ( $event_id <= 0 ) {
+			continue;
+		}
+
+		// Only past/ongoing events are stale; an upcoming reminder is still live.
+		if ( 'upcoming' === ec_users_reminder_event_timing( $event_id, $events_blog ) ) {
+			continue;
+		}
+
+		// Capture the affected users BEFORE the update so their bell caches can
+		// be flushed (the substrate's mark-read helper flushes per-user, but we
+		// update in bulk here for efficiency).
+		$user_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT user_id FROM {$table} WHERE is_read = 0 AND type = %s AND item_id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+				EC_USERS_SHOW_REMINDER_TYPE,
+				$event_id
+			)
+		);
+
+		$updated = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table} SET is_read = 1 WHERE is_read = 0 AND type = %s AND item_id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+				EC_USERS_SHOW_REMINDER_TYPE,
+				$event_id
+			)
+		);
+
+		if ( $updated && function_exists( 'ec_users_flush_unread_count_cache' ) ) {
+			ec_users_flush_unread_count_cache( array_map( 'intval', (array) $user_ids ) );
+		}
+
+		$total_read += (int) $updated;
+	}
+
+	return $total_read;
+}
+
 // ─── Event Lookup Helpers ──────────────────────────────────────────────────────
 
 /**
@@ -401,10 +573,6 @@ function ec_users_ordinal( int $number ): string {
  * @return string 'upcoming' | 'ongoing' | 'past'
  */
 function ec_users_reminder_event_timing( int $event_id, int $blog_id ): string {
-	if ( ! function_exists( 'ec_users_get_event_timing' ) ) {
-		return 'past';
-	}
-
 	$switched     = false;
 	$current_blog = get_current_blog_id();
 	if ( $blog_id && $current_blog !== $blog_id ) {
@@ -413,12 +581,76 @@ function ec_users_reminder_event_timing( int $event_id, int $blog_id ): string {
 	}
 
 	try {
-		return ec_users_get_event_timing( $event_id );
+		// Prefer the events plugin's primitive when it is actually loaded in
+		// this context. It is NOT network-activated, so on the cron/owner site
+		// (main/community) the function is undefined even after switch_to_blog()
+		// — switching tables/timezone does not load another site's plugins. In
+		// that case fall back to a direct dates-table read (equivalent logic),
+		// rather than the ec_users_get_event_timing() 'past' fallback which
+		// would wrongly mark every upcoming reminder stale.
+		if ( function_exists( 'datamachine_get_event_timing' ) ) {
+			return datamachine_get_event_timing( $event_id );
+		}
+
+		return ec_users_reminder_event_timing_direct( $event_id );
 	} finally {
 		if ( $switched ) {
 			restore_current_blog();
 		}
 	}
+}
+
+/**
+ * Compute event timing directly from the event_dates table (no plugin dep).
+ *
+ * Mirrors datamachine_get_event_timing() exactly for use in contexts where the
+ * data-machine-events plugin is not loaded (e.g. the digest/sweep crons running
+ * on the mail/owner site). MUST be called with the events blog already current
+ * (the caller switch_to_blog()s) so both the table prefix and current_time()
+ * resolve in the event's own timezone — start_datetime is stored in that local
+ * timezone and compared against the local "now".
+ *
+ *   upcoming = start >= now
+ *   ongoing  = start < now AND end >= now
+ *   past     = start < now AND (end < now OR end IS NULL)
+ *
+ * Returns 'upcoming' when the row is missing/unparseable so an unknown event is
+ * never wrongly treated as stale (fail-safe: never suppress a live reminder).
+ *
+ * @param int $event_id Event post ID.
+ * @return string 'upcoming' | 'ongoing' | 'past'
+ */
+function ec_users_reminder_event_timing_direct( int $event_id ): string {
+	global $wpdb;
+
+	$dates_table = $wpdb->prefix . 'datamachine_event_dates';
+
+	$row = $wpdb->get_row(
+		$wpdb->prepare(
+			"SELECT start_datetime, end_datetime FROM {$dates_table} WHERE post_id = %d LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from $wpdb->prefix.
+			$event_id
+		)
+	);
+
+	if ( ! $row || empty( $row->start_datetime ) || '0000-00-00 00:00:00' === $row->start_datetime ) {
+		// Unknown timing — fail safe toward 'upcoming' so a live reminder is
+		// never suppressed by a missing/bad dates row.
+		return 'upcoming';
+	}
+
+	$now   = current_time( 'mysql' );
+	$start = (string) $row->start_datetime;
+	$end   = ! empty( $row->end_datetime ) ? (string) $row->end_datetime : null;
+
+	if ( $start >= $now ) {
+		return 'upcoming';
+	}
+
+	if ( $end && $end >= $now ) {
+		return 'ongoing';
+	}
+
+	return 'past';
 }
 
 /**

--- a/inc/notifications/email.php
+++ b/inc/notifications/email.php
@@ -437,7 +437,41 @@ function ec_notifications_email_send_digest( $user_id ) {
 		return false;
 	}
 
-	$preview = $result['notifications'];
+	// Discount stale show reminders. A `show_reminder` notification is created
+	// while a show is upcoming, but if the user never reads it the row lingers
+	// after the show has passed. The generic digest sweep would otherwise email
+	// "X is tomorrow" for a long-past show. Exclude any unread show reminder
+	// whose event is no longer upcoming from BOTH the trigger count and the
+	// preview, so a stale reminder neither sends a digest nor appears in one.
+	$stale_reminders = ec_notifications_email_count_stale_unread_reminders( $user_id );
+	$unread_count   -= $stale_reminders;
+	if ( $unread_count <= 0 ) {
+		// Every unread item was a stale show reminder — nothing worth nudging.
+		// Stamp them emailed so they never re-trigger a sweep, but send nothing
+		// and don't burn the cooldown on a real digest.
+		ec_notifications_email_mark_unread_as_emailed( $user_id );
+		return false;
+	}
+
+	$preview = ec_notifications_email_filter_stale_reminders( $result['notifications'] );
+	if ( empty( $preview ) ) {
+		// The previewed page was entirely stale reminders even though
+		// non-stale unread items exist deeper in the list. Pull a wider page so
+		// the digest body is never empty while the count is positive.
+		$wide = ec_users_get_notifications(
+			$user_id,
+			array(
+				'unread'   => true,
+				'page'     => 1,
+				'per_page' => 100,
+			)
+		);
+		$preview = array_slice(
+			ec_notifications_email_filter_stale_reminders( $wide['notifications'] ),
+			0,
+			EC_NOTIFICATIONS_EMAIL_PREVIEW_COUNT
+		);
+	}
 
 	$digest = ec_notifications_email_build_digest( $user, $unread_count, $preview );
 
@@ -515,6 +549,117 @@ function ec_notifications_email_count_unmailed_unread( $user_id ) {
 			$user_id
 		)
 	);
+}
+
+/**
+ * Notification type that carries time-sensitive (event-bound) content.
+ *
+ * A `show_reminder` is created while a tracked show is upcoming. Once the show
+ * passes, an un-read reminder row is stale: its title ("X is tomorrow") is no
+ * longer true and must never be surfaced in a digest email.
+ */
+const EC_NOTIFICATIONS_REMINDER_TYPE = 'show_reminder';
+
+/**
+ * Count a user's unread `show_reminder` notifications whose event has passed.
+ *
+ * Loads only the unread reminder rows (a small set — one per tracked upcoming
+ * show) and resolves each event's timing in the events-site context. Any
+ * reminder whose event is no longer `upcoming` is counted as stale so the
+ * digest can discount it from the unread total that justifies sending.
+ *
+ * Returns 0 when the event-timing primitive is unavailable rather than guessing,
+ * so a missing dependency can never over-suppress a digest.
+ *
+ * @param int $user_id User ID.
+ * @return int Number of unread, stale show reminders.
+ */
+function ec_notifications_email_count_stale_unread_reminders( $user_id ) {
+	global $wpdb;
+
+	$user_id = (int) $user_id;
+	if ( $user_id <= 0 ) {
+		return 0;
+	}
+
+	$table = extrachill_users_notifications_table_name();
+
+	$rows = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT item_id FROM {$table} WHERE user_id = %d AND is_read = 0 AND type = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+			$user_id,
+			EC_NOTIFICATIONS_REMINDER_TYPE
+		),
+		ARRAY_A
+	);
+
+	$stale = 0;
+	foreach ( (array) $rows as $row ) {
+		$event_id = isset( $row['item_id'] ) ? (int) $row['item_id'] : 0;
+		if ( $event_id <= 0 ) {
+			continue;
+		}
+		if ( ec_notifications_email_reminder_is_stale( $event_id ) ) {
+			++$stale;
+		}
+	}
+
+	return $stale;
+}
+
+/**
+ * Drop stale `show_reminder` items from an enriched notification list.
+ *
+ * Used to clean the digest preview so a past show never appears in the email
+ * body. Non-reminder notifications always pass through untouched.
+ *
+ * @param array $notifications Enriched notifications (from ec_users_get_notifications()).
+ * @return array Filtered notifications, original order preserved.
+ */
+function ec_notifications_email_filter_stale_reminders( array $notifications ) {
+	$kept = array();
+
+	foreach ( $notifications as $note ) {
+		$type = isset( $note['type'] ) ? (string) $note['type'] : '';
+		if ( EC_NOTIFICATIONS_REMINDER_TYPE === $type ) {
+			$event_id = isset( $note['item_id'] ) ? (int) $note['item_id'] : 0;
+			if ( $event_id > 0 && ec_notifications_email_reminder_is_stale( $event_id ) ) {
+				continue;
+			}
+		}
+		$kept[] = $note;
+	}
+
+	return $kept;
+}
+
+/**
+ * Whether an event-bound reminder is stale (its event is no longer upcoming).
+ *
+ * Resolves event timing in the events-site context (show reminders are created
+ * for events on the events blog). Returns false — i.e. NOT stale — when the
+ * timing primitive or the events blog cannot be resolved, so an inability to
+ * verify never suppresses a notification.
+ *
+ * @param int $event_id Event post ID (the notification's item_id).
+ * @return bool True when the event has passed / is no longer upcoming.
+ */
+function ec_notifications_email_reminder_is_stale( $event_id ) {
+	$event_id = (int) $event_id;
+	if ( $event_id <= 0 ) {
+		return false;
+	}
+
+	if ( ! function_exists( 'ec_users_reminder_event_timing' ) ) {
+		return false;
+	}
+
+	$events_blog = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'events' ) : 0;
+	if ( $events_blog <= 0 ) {
+		return false;
+	}
+
+	return 'upcoming' !== ec_users_reminder_event_timing( $event_id, $events_blog );
 }
 
 /**

--- a/inc/notifications/email.php
+++ b/inc/notifications/email.php
@@ -552,15 +552,6 @@ function ec_notifications_email_count_unmailed_unread( $user_id ) {
 }
 
 /**
- * Notification type that carries time-sensitive (event-bound) content.
- *
- * A `show_reminder` is created while a tracked show is upcoming. Once the show
- * passes, an un-read reminder row is stale: its title ("X is tomorrow") is no
- * longer true and must never be surfaced in a digest email.
- */
-const EC_NOTIFICATIONS_REMINDER_TYPE = 'show_reminder';
-
-/**
  * Count a user's unread `show_reminder` notifications whose event has passed.
  *
  * Loads only the unread reminder rows (a small set — one per tracked upcoming
@@ -588,7 +579,7 @@ function ec_notifications_email_count_stale_unread_reminders( $user_id ) {
 		$wpdb->prepare(
 			"SELECT item_id FROM {$table} WHERE user_id = %d AND is_read = 0 AND type = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
 			$user_id,
-			EC_NOTIFICATIONS_REMINDER_TYPE
+			EC_USERS_SHOW_REMINDER_TYPE
 		),
 		ARRAY_A
 	);
@@ -621,7 +612,7 @@ function ec_notifications_email_filter_stale_reminders( array $notifications ) {
 
 	foreach ( $notifications as $note ) {
 		$type = isset( $note['type'] ) ? (string) $note['type'] : '';
-		if ( EC_NOTIFICATIONS_REMINDER_TYPE === $type ) {
+		if ( EC_USERS_SHOW_REMINDER_TYPE === $type ) {
 			$event_id = isset( $note['item_id'] ) ? (int) $note['item_id'] : 0;
 			if ( $event_id > 0 && ec_notifications_email_reminder_is_stale( $event_id ) ) {
 				continue;


### PR DESCRIPTION
## Summary

Fixes the bug where Chris Gardner got a digest email referencing a **"Burgundy: Extra Chill Wednesdays"** show ~25 days *after* it happened — the body literally said *"...is tomorrow"* for a long-past show.

Root cause: the in-app `show_reminder` layer is correctly gated on event timing, but the **generic email digest sweep** had no time-awareness and picked up any unread, never-emailed notification — including a reminder that went stale because the user never read it in-app.

This PR fixes it in two layers and makes a stale reminder a **true no-op everywhere**.

## Commit 1 — don't email stale reminders (`inc/notifications/email.php`)

- `ec_notifications_email_send_digest()` discounts stale show reminders from the unread count that justifies sending, and filters them out of the digest preview body.
- If every unread item is a stale reminder, nothing is sent, the cooldown isn't burned, and the stale rows are stamped `emailed_at` so they never re-sweep.
- New helpers: `ec_notifications_email_count_stale_unread_reminders()`, `ec_notifications_email_filter_stale_reminders()`, `ec_notifications_email_reminder_is_stale()`.

## Commit 2 — auto-mark stale reminders read (`inc/concert-tracking/notifications.php`)

- New **hourly recurring sweep** `ec_users_resolve_stale_show_reminders()` marks every unread `show_reminder` whose event is no longer upcoming as **read**, and flushes affected users' unread-count caches so the bell/list/count update immediately. A passed show's reminder now disappears everywhere, not just from email.
- Scheduled via Data Machine's `RecurringScheduler` (Action Scheduler-backed) pinned to the owner/mail site, with a WP-Cron fallback — mirrors the existing digest scheduler.
- Promotes the `'show_reminder'` literal to a canonical `EC_USERS_SHOW_REMINDER_TYPE` constant in the producing layer; the email digest references it so producer and staleness logic can't drift.

### ⚠️ Critical correctness fix found while testing against live data

`data-machine-events` is **NOT network-activated** — `datamachine_get_event_timing()` is undefined on the cron/owner site (main/community) *even after `switch_to_blog()`*, because switching tables/timezone does not load another site's plugins. The old `ec_users_reminder_event_timing()` fallback returned `'past'` in that case, which would have marked **every upcoming reminder read** (and the email staleness check would have suppressed every reminder).

Fix: `ec_users_reminder_event_timing()` now prefers the plugin primitive when loaded, else falls back to a **direct `event_dates` table read** (`ec_users_reminder_event_timing_direct()`) replicating the exact `upcoming/ongoing/past` rule, failing safe toward `upcoming` on a missing row so a live reminder is never wrongly suppressed. This also hardens the existing reminder-scheduling path that used the same helper.

## Validation (against production data)

Confirmed the sweep marks genuinely-past reminders read while leaving same-day upcoming shows alone:

```
event 174568 (2026-06-06):             past     -> marked read (user 613)
event 214418 (Wolf Mask, today 21:00): upcoming -> skipped
event 4129   (Mo Lowda, today 18:00):  upcoming -> skipped
event 236689 (Burgundy, 2026-06-03):   past     -> (already cleaned)
```

The one-time cleanup for the reported incident (corrected digest re-sent to qrisg with only the two upcoming shows; Burgundy marked read) was handled operationally, separate from this code.

## Notes
- No change to the generic substrate (`db.php` / `service.php`) — both behaviors live in the layers that own them (digest channel + reminder lifecycle).
- `php -l` clean on both files. No existing automated coverage for the notifications-email/reminder cron layers (would need a WP/multisite + events bootstrap the current suite doesn't provide); logic is guarded, fail-safe, and validated against live data.

Fixes #148
