### PR TITLE
fix: compute event timing cross-site instead of silently returning 'past'

### DIFF
--- a/inc/concert-tracking/service.php
+++ b/inc/concert-tracking/service.php
@@ -240,13 +240,51 @@ function ec_users_get_user_event_count( int $user_id, int $blog_id = 0 ): int {
 /**
  * Determine the timing state of an event.
  *
+ * extrachill-users is network-activated and runs on every site, but the
+ * data-machine-events plugin that owns datamachine_get_event_timing() is
+ * Network: false and only active on the events site. Delegating to that
+ * function therefore fails (or silently returns 'past') on every other site.
+ *
+ * Instead we read the per-site datamachine_event_dates table directly using
+ * the events-blog prefix — mirroring ec_users_get_user_events() — so timing is
+ * computed correctly from any site in the network. The timing rules match the
+ * datamachine_get_event_timing() primitive:
+ *   upcoming = start >= now
+ *   ongoing  = start < now AND end >= now
+ *   past     = start < now AND (end < now OR end IS NULL), or no start date.
+ *
  * @param int $event_id Event post ID.
  * @return string 'upcoming' | 'ongoing' | 'past'
  */
 function ec_users_get_event_timing( int $event_id ): string {
-	// Delegate to the core primitive in data-machine-events.
-	if ( function_exists( 'datamachine_get_event_timing' ) ) {
-		return datamachine_get_event_timing( $event_id );
+	global $wpdb;
+
+	$blog_id       = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : 7;
+	$events_prefix = $wpdb->get_blog_prefix( $blog_id );
+	$dates_table   = $events_prefix . 'datamachine_event_dates';
+
+	$dates = $wpdb->get_row(
+		$wpdb->prepare(
+			"SELECT start_datetime, end_datetime FROM {$dates_table} WHERE post_id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name built from trusted blog prefix.
+			$event_id
+		)
+	);
+
+	if ( ! $dates || empty( $dates->start_datetime ) ) {
+		return 'past';
+	}
+
+	// Event datetimes are stored in site-local time; compare against the same.
+	$now         = current_time( 'mysql' );
+	$event_start = $dates->start_datetime;
+	$event_end   = $dates->end_datetime ?? null;
+
+	if ( $event_start >= $now ) {
+		return 'upcoming';
+	}
+
+	if ( $event_end && $event_end >= $now ) {
+		return 'ongoing';
 	}
 
 	return 'past';


### PR DESCRIPTION
## Summary

A PHP fatal on the live network (`Call to undefined function datamachine_get_event_timing()` from a `wp eval-file` run against blog 1) was the visible symptom of a **latent cross-site correctness bug** in concert-tracking.

- `ec_users_get_event_timing()` delegated to `datamachine_get_event_timing()`.
- That primitive is owned by **data-machine-events**, a `Network: false` plugin active **only on the events site** (blog 7).
- **extrachill-users is network-activated** and runs on every site, so on all 8 other sites the function is undefined and the `function_exists()` guard **silently returned `'past'`** for every event.

## Impact of the latent bug
- Off the events site, **upcoming events were mislabeled "past"** → wrong button labels ("%d were there" instead of "%d going").
- The upcoming-only notification guard (`notifications.php:118`) read every event as past, so **show reminders were silently suppressed** wherever this ran outside blog 7.

## Fix
Read the per-site `datamachine_event_dates` table directly using the events-blog prefix (mirroring `ec_users_get_user_events()` at service.php:324) and compute timing inline with the **same rules** as the primitive:

- `upcoming` = start >= now
- `ongoing`  = start < now AND end >= now
- `past`     = start < now AND (end < now OR end IS NULL), or no start date

This removes the dependency on a non-network plugin's function being loaded and makes timing correct from **any** site in the network.

## Verification
On blog 1 (where `data-machine-events` is inactive and the function does **not** exist), the new direct read of `c8c_7_datamachine_event_dates` correctly returns `upcoming` for future events that the old guard would have labeled `past`:

```
current blog: 1
timing fn exists on blog 1? NO
  event 235977: start=2037-12-13 ... => upcoming
  event 248523: start=2037-11-08 ... => upcoming
```

`php -l` clean. No release/version/changelog changes (homeboy owns those).

## Note on the fatal itself
The eval-file invocation was a throwaway ad-hoc script (nothing in cron/host scripts references the function); it only fired once. The durable fix is this cross-site read, which would also have prevented the fatal had that script gone through the wrapper.