### PR TITLE
style: fix phpcs assignment alignment in notification reminder code

### DIFF
--- a/inc/concert-tracking/notifications.php
+++ b/inc/concert-tracking/notifications.php
@@ -444,8 +444,8 @@ function ec_users_ordinal( int $number ): string {
  * ec_notifications_email_maybe_schedule().
  */
 function ec_users_stale_reminder_sweep_maybe_schedule() {
-	$scheduler  = EC_USERS_STALE_REMINDER_RECURRING_SCHEDULER;
-	$is_owner   = function_exists( 'ec_notifications_email_is_owner_site' )
+	$scheduler = EC_USERS_STALE_REMINDER_RECURRING_SCHEDULER;
+	$is_owner  = function_exists( 'ec_notifications_email_is_owner_site' )
 		? ec_notifications_email_is_owner_site()
 		: ( function_exists( 'is_main_site' ) && is_main_site() );
 

--- a/inc/notifications/email.php
+++ b/inc/notifications/email.php
@@ -458,7 +458,7 @@ function ec_notifications_email_send_digest( $user_id ) {
 		// The previewed page was entirely stale reminders even though
 		// non-stale unread items exist deeper in the list. Pull a wider page so
 		// the digest body is never empty while the count is positive.
-		$wide = ec_users_get_notifications(
+		$wide    = ec_users_get_notifications(
 			$user_id,
 			array(
 				'unread'   => true,


### PR DESCRIPTION
Aligns three assignment operators flagged by phpcs `Generic.Formatting.MultipleStatementAlignment` in the stale-reminder code added by #149. No behavior change — whitespace only. Unblocks the release preflight phpcs check.

Refs #148