### PR TITLE
feat: grant datamachine_view_analytics to extra_chill_team

### DIFF
--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -141,6 +141,7 @@ function extrachill_users_init() {
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/lifetime-membership.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/shop-permissions.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/brand-socials-permissions.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/datamachine-permissions.php';
 
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/comment-auto-approval.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/footer/online-users-stats.php';

--- a/inc/datamachine-permissions.php
+++ b/inc/datamachine-permissions.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Data Machine analytics permission bridge.
+ *
+ * Data Machine exposes a read-only analytics surface (the GA4 / Search
+ * Console routes behind data-machine-business) gated on the
+ * `datamachine_view_analytics` capability tier added in data-machine#2807.
+ * That cap tier exists precisely so analytics-READ can be handed out without
+ * granting the Data Machine write/admin surface. The Studio Network tab
+ * (extrachill-studio#104) consumes the GA route and gracefully degrades to
+ * "coming soon" whenever the caller lacks the cap.
+ *
+ * This bridge wires the EC `extra_chill_team` concept into that generic
+ * Data Machine capability. It is the correct layer for this policy: Data
+ * Machine knows nothing about Extra Chill; this plugin is the one place where
+ * EC-specific knowledge (the team role) meets that generic permission surface
+ * — exactly how `inc/brand-socials-permissions.php` bridges the team into the
+ * socials surface and how extrachill-roadie bridges `access_roadie` into
+ * `datamachine_can_access_agent`.
+ *
+ * Precedent A (extrachill-roadie/inc/contribute-code/capabilities.php): the
+ * grant is a pure `user_has_cap` filter. `datamachine_view_analytics` lives in
+ * a FOREIGN namespace (Data Machine's), so we deliberately do NOT write it onto
+ * the `extra_chill_team` role object via add_cap / ec_users_get_team_role_caps().
+ * Keeping it out of the role's persisted cap set means the EC role stays the
+ * source of truth for EC-owned caps only, and the foreign cap is resolved
+ * dynamically at check time without touching stored role state.
+ *
+ * @package ExtraChill\Users
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * The Data Machine read-only analytics capability granted to the team.
+ *
+ * Owned by Data Machine (data-machine#2807), not by this plugin. Named here as
+ * a constant only so the filter below reads cleanly; it is intentionally absent
+ * from ec_users_get_team_role_caps() — see the file docblock.
+ */
+const EC_DATAMACHINE_VIEW_ANALYTICS_CAP = 'datamachine_view_analytics';
+
+/**
+ * Grant `datamachine_view_analytics` to Extra Chill team members.
+ *
+ * Hooks `user_has_cap` and dynamically resolves the foreign-namespace cap to
+ * true for any user holding the `extra_chill_team` role. This can only ever
+ * BROADEN access for a team member — it never strips a cap (an existing true
+ * value short-circuits) and never touches non-team users.
+ *
+ * @since 0.21.2
+ *
+ * @param array<string,bool> $allcaps All capabilities currently resolved for the user.
+ * @param string[]           $caps    Required primitive caps for the check (unused).
+ * @param array              $args    [0] requested cap, [1] user ID, [2] object ID (unused).
+ * @param WP_User|null       $user    The user object being checked.
+ * @return array<string,bool> Filtered capability map.
+ */
+function ec_grant_datamachine_view_analytics_cap( array $allcaps, array $caps, array $args, $user ): array {
+	unset( $caps, $args );
+
+	if ( ! $user || empty( $user->roles ) ) {
+		return $allcaps;
+	}
+
+	// Already granted (e.g. an admin/super-admin) — nothing to add.
+	if ( ! empty( $allcaps[ EC_DATAMACHINE_VIEW_ANALYTICS_CAP ] ) ) {
+		return $allcaps;
+	}
+
+	$team_role = defined( 'EC_USERS_TEAM_ROLE' ) ? EC_USERS_TEAM_ROLE : 'extra_chill_team';
+
+	if ( in_array( $team_role, (array) $user->roles, true ) ) {
+		$allcaps[ EC_DATAMACHINE_VIEW_ANALYTICS_CAP ] = true;
+	}
+
+	return $allcaps;
+}
+add_filter( 'user_has_cap', 'ec_grant_datamachine_view_analytics_cap', 10, 4 );


### PR DESCRIPTION
## Summary

Adds a cross-plugin permission bridge so Extra Chill `extra_chill_team` members hold the read-only Data Machine capability `datamachine_view_analytics`, lighting up the GA4 sessions-over-time chart in the Studio Network tab (extrachill-studio#104) which currently degrades to "coming soon" for the team.

`data-machine#2807` (merged) added the `datamachine_view_analytics` cap tier precisely so analytics-READ can be granted **without** handing over the Data Machine write/admin surface. This PR does the EC-side grant.

## What changed

- **New file `inc/datamachine-permissions.php`** — a `user_has_cap` filter (`ec_grant_datamachine_view_analytics_cap`) that dynamically resolves `datamachine_view_analytics` to `true` for any user holding the `extra_chill_team` role. The grant can only ever broaden access for a team member; it short-circuits if the cap is already present and never touches non-team users.
- **`extrachill-users.php`** — wired the `require_once` next to the existing bridge requires (`shop-permissions.php`, `brand-socials-permissions.php`).

## Layer purity

Data Machine stays ignorant of Extra Chill. The grant lives entirely in extrachill-users — the one place where the EC `extra_chill_team` concept meets the generic DM permission surface. Same pattern as `inc/brand-socials-permissions.php`, `inc/shop-permissions.php`, and the extrachill-roadie `access_roadie` → `datamachine_can_access_agent` precedent.

**Precedent A (no role-object write):** `datamachine_view_analytics` is a foreign-namespace cap (Data Machine's), so it is resolved dynamically via `user_has_cap` and is deliberately **not** added to `ec_users_get_team_role_caps()`. The EC role stays the source of truth for EC-owned caps only.

The team-role constant `EC_USERS_TEAM_ROLE` (`'extra_chill_team'`, from `inc/team-members/role.php`) is used, with a `defined()` fallback to the literal matching the precedent in `inc/core/abilities/team-experience-stats.php`.

## Acceptance

- `extra_chill_team` members resolve `current_user_can('datamachine_view_analytics')` == true.
- Non-team users unaffected (filter returns `$allcaps` unchanged).
- Grant via `user_has_cap` only — no write to the role object.
- data-machine / data-machine-business untouched.
- Matches existing bridge file conventions (header, rationale docblock).

## Verification

- `php -l inc/datamachine-permissions.php` — clean.
- `php -l extrachill-users.php` — clean.
- phpcs not installed in this worktree (no `vendor/`); file follows the WordPress standard formatting of the sibling bridges.

## Notes

Pairs with **data-machine-business#57** (repointing the GA4 route to the `view_analytics` cap tier) to fully light up GA4 in the Studio Network tab.

Closes #152