### PR TITLE
fix(events): harden attendee strip CSS against .entry-content style leak

### DIFF
--- a/assets/css/concert-tracking.css
+++ b/assets/css/concert-tracking.css
@@ -44,7 +44,13 @@
 	color: var(--muted-text, #6b7280);
 }
 
-.ec-attendance-list__avatars {
+/* Selectors below are intentionally scoped under `.ec-attendance-list` to
+ * raise specificity above the theme's content-context rules. This strip
+ * renders inside `.entry-content` (it's part of the EventDetails block
+ * content), so bare `.ec-attendance-list__item` (0,1,0) loses to
+ * `.entry-content li` (0,1,1) and the avatar overlap / row layout break.
+ * The descendant-scoped form (0,2,0) wins without resorting to !important. */
+.ec-attendance-list .ec-attendance-list__avatars {
 	display: flex;
 	align-items: center;
 	list-style: none;
@@ -52,15 +58,24 @@
 	padding: 0;
 }
 
-.ec-attendance-list__item {
+.ec-attendance-list .ec-attendance-list__item {
 	margin: 0 0 0 -0.5rem;
 }
 
-.ec-attendance-list__item:first-child {
+.ec-attendance-list .ec-attendance-list__item:first-child {
 	margin-left: 0;
 }
 
-.ec-attendance-list__avatar {
+/* Neutralize inherited `.entry-content a` link styling on the avatar anchor. */
+.ec-attendance-list .ec-attendance-list__item a {
+	display: block;
+	line-height: 0;
+	text-decoration: none;
+	color: inherit;
+	border: 0;
+}
+
+.ec-attendance-list .ec-attendance-list__avatar {
 	display: block;
 	width: 32px;
 	height: 32px;


### PR DESCRIPTION
## Summary

Fixes the odd styling on the single-event "Going" attendee avatar strip. The strip renders **inside `.entry-content`** (it's emitted by the EventDetails block content via `data_machine_events_action_buttons`), so the theme's global content rules leaked in and the plugin's CSS wasn't specific enough to win.

- **Avatar overlap was broken:** theme `.entry-content li { margin: var(--spacing-xs) 0 }` (specificity 0,1,1) overrode the plugin's `.ec-attendance-list__item { margin: 0 0 0 -0.5rem }` (0,1,0), killing the negative-margin stacked-avatar overlap and adding 4px vertical margin.
- **Link styling leak:** the avatars are wrapped in `<a href>` to community profiles, so `.entry-content a` color/underline/hover bled onto the anchors.

### Fix
Scope the item / avatar / anchor rules under `.ec-attendance-list` (specificity → 0,2,0) so they beat the theme content rules, plus an anchor reset to neutralize inherited link styling. No theme edits, no `!important` (per theme convention — fight specificity properly).

Verified the leak on a live event with attendees (`events.extrachill.com/events/susto-es-muerto`): the strip sits 4 `<div>` levels inside `.entry-content`.

Closes #154