### PR TITLE
feat: send team welcome + set-password email on first role grant (#159)

### DIFF
--- a/inc/auth/password-reset.php
+++ b/inc/auth/password-reset.php
@@ -389,3 +389,129 @@ function ec_send_password_reset_email( $user, $reset_key ) {
 
 	return true;
 }
+
+/**
+ * Send the "Welcome to the Extra Chill team" onboarding email.
+ *
+ * Sent when a user is granted the team role for the first time and has
+ * never logged in (extrachill-users#159). New team members get a working
+ * way into their account — a set-password link — instead of hitting the
+ * "I don't know my login" wall and registering a duplicate account.
+ *
+ * This is a dedicated welcome email rather than a bare password reset: it
+ * names the user, tells them they're on the team, states the username that
+ * holds their access (so they don't re-register under a new identity), and
+ * points them at Studio once they're in. It reuses the exact same branded
+ * send path as {@see ec_send_password_reset_email()} —
+ * `get_password_reset_key()` for the link + `extrachill_send_registration_email()`
+ * for delivery — so the CTA lands on the canonical
+ * community.extrachill.com/reset-password/ page, not raw wp-login.php.
+ *
+ * Like the reset email, this runs the send through
+ * `extrachill_send_registration_email()` so the underlying
+ * `datamachine/send-email` ability executes inside an authenticated
+ * context (the grant itself is the authorization decision; see #110).
+ *
+ * @param WP_User $user      User object being welcomed to the team.
+ * @param string  $reset_key Password reset key minted via get_password_reset_key().
+ * @return bool Whether the email was sent successfully.
+ */
+function ec_send_team_welcome_email( $user, $reset_key ) {
+	$reset_url = add_query_arg(
+		array(
+			'action' => 'reset',
+			'key'    => $reset_key,
+			'login'  => rawurlencode( $user->user_login ),
+		),
+		ec_get_site_url( 'community' ) . '/reset-password/'
+	);
+
+	$studio_url = function_exists( 'ec_get_site_url' )
+		? ec_get_site_url( 'studio' )
+		: 'https://studio.extrachill.com';
+
+	$subject = __( 'Welcome to the Extra Chill team', 'extrachill-users' );
+
+	$body_html  = '<p>' . esc_html__( "You've been added to the Extra Chill team — welcome aboard!", 'extrachill-users' ) . '</p>';
+	$body_html .= '<p>' . esc_html__( 'Your team account is ready, but you need to set a password before you can log in. Click the button below to choose your password and get started.', 'extrachill-users' ) . '</p>';
+	$body_html .= '<p><strong>' . esc_html__( 'Your username:', 'extrachill-users' ) . '</strong> ' . esc_html( $user->user_login ) . '<br>';
+	$body_html .= esc_html__( 'This is the account that holds your team access — log in with this username (or your email), not a new account.', 'extrachill-users' ) . '</p>';
+	$body_html .= '<p>' . sprintf(
+		/* translators: %s: Extra Chill Studio URL. */
+		esc_html__( 'Once you\'re in, head to %s to start working.', 'extrachill-users' ),
+		'<a href="' . esc_url( $studio_url ) . '">' . esc_html( $studio_url ) . '</a>'
+	) . '</p>';
+	$body_html .= '<p>' . esc_html__( 'This link will expire in 24 hours. If it does, you can request a new one any time from the reset-password page.', 'extrachill-users' ) . '</p>';
+	$body_html .= '<p>' . esc_html__( 'Much love,', 'extrachill-users' ) . '<br>' . esc_html__( 'Extra Chill', 'extrachill-users' ) . '</p>';
+
+	$result = extrachill_send_registration_email(
+		array(
+			'to'         => $user->user_email,
+			'subject'    => $subject,
+			'template'   => 'extrachill/minimal',
+			'from_name'  => 'Extra Chill',
+			'from_email' => get_option( 'admin_email' ),
+			'context'    => array(
+				'subject_html'   => esc_html( $subject ),
+				'body_html'      => $body_html,
+				'recipient_name' => $user->display_name,
+				'cta_url'        => $reset_url,
+				'cta_label'      => __( 'Set Your Password', 'extrachill-users' ),
+				'preheader'      => __( "You're on the Extra Chill team — set your password to log in.", 'extrachill-users' ),
+			),
+		)
+	);
+
+	// Same defensive envelope handling as the reset email: the ability
+	// returns WP_Error on permission/validation failure, not the array
+	// envelope. Never index blindly (#110).
+	if ( ! is_array( $result ) || empty( $result['success'] ) ) {
+		extrachill_log_email_failure( 'team_welcome', $user->ID, $user->user_email, $subject, $result );
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Send the team welcome email to a user who was just granted the team role.
+ *
+ * Gates the send on "user has never logged in" — a logged-in user has a
+ * non-empty `session_tokens` user meta array, so an empty value means the
+ * account has never been used. This makes re-grants and grants to active
+ * members no-ops, satisfying the idempotency requirement in #159: existing
+ * team members are never re-emailed.
+ *
+ * Mints the set-password key here (not in the caller) so the grant path in
+ * role.php stays a thin orchestration call.
+ *
+ * @param int $user_id User ID that was just granted the team role.
+ * @return bool True if a welcome email was sent, false if skipped or failed.
+ */
+function ec_maybe_send_team_welcome_email( $user_id ) {
+	$user_id = (int) $user_id;
+	if ( $user_id <= 0 ) {
+		return false;
+	}
+
+	// Never-logged-in gate: a non-empty session_tokens array means the
+	// account has an active or prior session, so the member already has a
+	// working login and must not be emailed.
+	$session_tokens = get_user_meta( $user_id, 'session_tokens', true );
+	if ( ! empty( $session_tokens ) ) {
+		return false;
+	}
+
+	$user = get_userdata( $user_id );
+	if ( ! $user || ! $user->exists() ) {
+		return false;
+	}
+
+	$reset_key = get_password_reset_key( $user );
+	if ( is_wp_error( $reset_key ) ) {
+		extrachill_log_email_failure( 'team_welcome', $user_id, $user->user_email, __( 'Welcome to the Extra Chill team', 'extrachill-users' ), $reset_key );
+		return false;
+	}
+
+	return ec_send_team_welcome_email( $user, $reset_key );
+}

--- a/inc/team-members/role.php
+++ b/inc/team-members/role.php
@@ -176,10 +176,19 @@ function ec_users_get_network_site_ids() {
  * multisite cap layer, and giving them an extra role on every
  * subsite is noise.
  *
- * @param int $user_id User ID.
+ * When the role is newly granted to a user who has never logged in, a
+ * one-time "Welcome to the Extra Chill team" email with a set-password
+ * link is sent so the member gets a working login instead of registering
+ * a duplicate account (extrachill-users#159). Pass $notify = false to
+ * suppress the email — used by the one-shot legacy-meta migration, which
+ * re-grants existing members who are not being newly onboarded.
+ *
+ * @param int  $user_id User ID.
+ * @param bool $notify  Whether to send the team welcome email when the role
+ *                      is newly granted to a never-logged-in user. Default true.
  * @return int[] Blog IDs the role was newly added to (already-present sites omitted).
  */
-function ec_users_grant_team_role( $user_id ) {
+function ec_users_grant_team_role( $user_id, $notify = true ) {
 	$user_id = (int) $user_id;
 	if ( $user_id <= 0 ) {
 		return array();
@@ -226,6 +235,16 @@ function ec_users_grant_team_role( $user_id ) {
 			$user_id,
 			array( 'blog_ids' => $added )
 		);
+	}
+
+	// Deliver a working credential to brand-new team members. Only fires
+	// when the role was newly added on at least one site (so re-grants are
+	// no-ops) and the recipient has never logged in (gated inside
+	// ec_maybe_send_team_welcome_email via session_tokens). At most one
+	// email per grant, never per blog. Suppressed during the legacy-meta
+	// migration ($notify = false). See extrachill-users#159.
+	if ( $notify && ! empty( $added ) && function_exists( 'ec_maybe_send_team_welcome_email' ) ) {
+		ec_maybe_send_team_welcome_email( $user_id );
 	}
 
 	return $added;
@@ -331,7 +350,10 @@ function ec_users_migrate_team_meta_to_role() {
 				: ( '1' === (string) $flag ) );
 
 		if ( $should_have ) {
-			$added = ec_users_grant_team_role( $user_id );
+			// Suppress the welcome email: migration re-grants existing
+			// members carried over from the legacy meta system, not new
+			// onboardings. Emailing them would be spam (#159).
+			$added = ec_users_grant_team_role( $user_id, false );
 			if ( ! empty( $added ) ) {
 				++$summary['granted'];
 			}


### PR DESCRIPTION
## Summary

Team accounts are **created for** a person by an admin (`ec_users_grant_team_role()` grants `extra_chill_team`) — the person doesn't create their own. But that grant is a pure role write: it emits a `team_member_added` analytics event and **never delivers the person a working credential** for the account that was made for them. The result (#159): a new member hits the "I don't know my login" wall on an account they never set up, sees no set-password prompt, and — having no way into that account — self-registers a fresh public account on a different email that has none of the team caps.

This wires a one-time **"Welcome to the Extra Chill team"** email — containing a **set-password link** — into the grant path, so a new member can get into the team account that was created for them. That removes the *need* to self-register a workaround account; it does not (and cannot) *prevent* someone from registering a second account on a different email — duplicate detection / linking / merge is a separate concern owned by #142. Closes #159.

**Forward-looking only — the two evidence cases were already resolved out-of-band.** Tucker McManus and Steve Hughes (the #159 cases) were each handled manually before this PR: accounts consolidated and a password-reset link sent by hand, so both already have working access. This change is purely forward-looking — it does **not** retroactively email existing members (the legacy-meta migration path passes `$notify = false`, and the session-token gate skips anyone who has ever logged in). Nobody is left broken by merging this; it just ensures the *next* person added to the team gets a credential automatically instead of someone having to notice they're stuck and run a CLI reset.

## What changed

- **`inc/auth/password-reset.php`**
  - `ec_send_team_welcome_email( $user, $reset_key )` — new branded onboarding email. Same send path as the existing reset email (`extrachill_send_registration_email()` + `extrachill/minimal` template), so the CTA lands on the canonical `community.extrachill.com/reset-password/` link. Copy names the user, states they're on the team, **states their username**, points them at `studio.extrachill.com`, and notes the 24h expiry.
  - `ec_maybe_send_team_welcome_email( $user_id )` — gate + key mint helper. Skips if the user has any `session_tokens` (i.e. has ever logged in), mints the set-password key via `get_password_reset_key()`, then sends.
- **`inc/team-members/role.php`**
  - `ec_users_grant_team_role()` gains a `$notify = true` param and calls `ec_maybe_send_team_welcome_email()` in the existing **newly-added** branch (`! empty( $added )`), so the email fires at most **once per grant**, never per blog.
  - The one-shot legacy-meta migration passes `$notify = false` — those are carried-over existing members, not new onboardings, so they're never emailed.

## Approach chosen: dedicated welcome email vs. reusing the reset email

I went with a **dedicated `ec_send_team_welcome_email()`** rather than reusing `ec_send_password_reset_email()` verbatim. The issue explicitly allows either and prefers a welcome email for onboarding — a "someone requested a password reset" email reads wrong for a first-time team welcome, and the issue's acceptance criteria require the email to *name the team membership* and *state the username* (the bare reset email does neither). The new function still routes through the **exact same** authenticated send path (`extrachill_send_registration_email()`), template (`extrachill/minimal`), and link-builder (`ec_get_site_url('community') . '/reset-password/'`) as the reset email, so no new infrastructure is introduced and the canonical-link guarantee holds.

## How the "never logged in" gating works

A logged-in user has a non-empty `session_tokens` user meta array (WP writes it on auth). `ec_maybe_send_team_welcome_email()` reads `get_user_meta( $user_id, 'session_tokens', true )` and bails if it's non-empty. Combined with the `! empty( $added )` branch (re-grants produce an empty `$added`), this satisfies the idempotency requirement: re-granting, or granting to an already-active member, sends nothing. `session_tokens` is global (non-blog-scoped) user meta, so the read is correct after the per-blog `switch_to_blog` loop restores the current blog.

## Acceptance criteria

- [x] Granting team role to a never-logged-in user → exactly one welcome-with-set-password email.
- [x] Email uses the canonical `community.extrachill.com/reset-password/` link (not raw wp-login.php).
- [x] Email states the user's username.
- [x] Re-granting / granting to an already-active member does **not** re-send (session-gated + only-on-newly-added).
- [x] No new tables/substrates — reuses `get_password_reset_key()` + the existing EC email send path.

## Verification

- `php -l` clean on both files.
- `phpcs --standard=WordPress` on both files: the only findings are **pre-existing** (lines outside this change); my additions introduce zero new phpcs errors.
- `phpstan` (level 5, repo config): zero new findings from my code — all reported errors are the pre-existing "WP core symbol not stubbed" baseline class, unchanged by this PR.
- `homeboy test` could not run in this environment (wp-codebox harness binary failed to start before any tests executed) — an infra limitation, not a test failure. Grant flow re-read end-to-end manually to confirm the hook placement and gating.

Closes #159