### PR TITLE
feat: make attendance + import-nudge renderers timing/variant aware

### DIFF
--- a/assets/css/concert-tracking.css
+++ b/assets/css/concert-tracking.css
@@ -83,3 +83,68 @@
 	border: 2px solid var(--card-background, #fff);
 	object-fit: cover;
 }
+
+/* ─── Attendance "hero" variant (past-event archive framing) ───────────── */
+
+.ec-attendance-hero {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: var(--spacing-sm, 0.5rem);
+	padding: var(--spacing-md, 1rem);
+	border: 1px solid var(--card-border, #e5e7eb);
+	border-radius: var(--border-radius, 0.5rem);
+	background: var(--card-background, #fff);
+}
+
+.ec-attendance-hero__heading {
+	margin: 0;
+	font-size: var(--font-size-lg, 1.125rem);
+	font-weight: 600;
+	line-height: 1.3;
+}
+
+.ec-attendance-hero__subheading {
+	margin: 0;
+	font-size: var(--font-size-sm, 0.8125rem);
+	color: var(--muted-text, #6b7280);
+	line-height: 1.4;
+}
+
+/* ─── Import nudge ("import your concert history") ─────────────────────── */
+
+.ec-import-nudge {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--spacing-sm, 0.5rem);
+	margin-top: var(--spacing-sm, 0.5rem);
+	padding: var(--spacing-md, 1rem);
+	border: 1px solid var(--card-border, #e5e7eb);
+	border-radius: var(--border-radius, 0.5rem);
+	background: var(--card-background, #fff);
+}
+
+.ec-import-nudge__body {
+	flex: 1 1 12rem;
+	min-width: 0;
+}
+
+.ec-import-nudge__heading {
+	margin: 0;
+	font-weight: 600;
+	line-height: 1.3;
+}
+
+.ec-import-nudge__text {
+	margin: 0.25rem 0 0;
+	font-size: var(--font-size-sm, 0.8125rem);
+	color: var(--muted-text, #6b7280);
+	line-height: 1.4;
+}
+
+.ec-import-nudge__cta {
+	flex: 0 0 auto;
+	text-decoration: none;
+}

--- a/blocks/concert-attendance/src/AttendanceButton.js
+++ b/blocks/concert-attendance/src/AttendanceButton.js
@@ -28,6 +28,9 @@ import useMarkAttendance from './useMarkAttendance';
  * @param {string}  props.labelDefault  Label when unmarked.
  * @param {string}  props.labelActive   Label when marked.
  * @param {string}  props.loginUrl      Login URL for logged-out users.
+ * @param {string}  props.redirectTo    Optional explicit post-login return URL.
+ *                                       When empty, the current request URL is
+ *                                       used (prior default behavior).
  */
 const AttendanceButton = ( {
 	eventId,
@@ -38,6 +41,7 @@ const AttendanceButton = ( {
 	labelDefault,
 	labelActive,
 	loginUrl,
+	redirectTo,
 } ) => {
 	const [ marked, setMarked ] = useState( !! initialMarked );
 	const [ countLabel, setCountLabel ] = useState(
@@ -46,13 +50,14 @@ const AttendanceButton = ( {
 	const { mark, isMarking, error } = useMarkAttendance();
 
 	const handleClick = () => {
-		// Logged-out: send to login, preserving return URL.
+		// Logged-out: send to login, preserving return URL. Composition can
+		// pass an explicit redirectTo (e.g. deep-link into the archive/import
+		// flow); otherwise fall back to the current request URL.
 		if ( ! isLoggedIn ) {
 			const target = loginUrl || '/login/';
+			const returnTo = redirectTo || window.location.href;
 			window.location.href =
-				target +
-				'?redirect_to=' +
-				encodeURIComponent( window.location.href );
+				target + '?redirect_to=' + encodeURIComponent( returnTo );
 			return;
 		}
 

--- a/blocks/concert-attendance/src/index.js
+++ b/blocks/concert-attendance/src/index.js
@@ -43,6 +43,7 @@ domReady( () => {
 			labelDefault={ mount.dataset.labelDefault || '' }
 			labelActive={ mount.dataset.labelActive || '' }
 			loginUrl={ mount.dataset.loginUrl || '/login/' }
+			redirectTo={ mount.dataset.redirectTo || '' }
 		/>
 	);
 } );

--- a/inc/concert-tracking/buttons.php
+++ b/inc/concert-tracking/buttons.php
@@ -29,33 +29,35 @@ defined( 'ABSPATH' ) || exit;
  * (extrachill-events). This renderer only exposes the presentation variants and
  * framing hooks the composition layer can arrange.
  *
- * Back-compat contract: calling with just $event_id (as extrachill-events does
- * today) produces byte-for-byte the same output as before this became
- * variant-aware. New behavior is opt-in via $variant / $args.
+ * All presentation/framing options travel in a single $args config array so the
+ * composition layer selects the variant and overrides copy in one place. An
+ * empty $args renders the standard inline toggle — that's the sensible default
+ * for the primary call path, not a compatibility shim.
  *
- * @param int    $event_id Event post ID.
- * @param string $variant  Optional presentation variant. Supported values:
- *                         'default' (or '') — the standard inline attendance
- *                         toggle; 'past-hero' — an attendance-first "hero"
- *                         presentation with archive payoff framing, intended
- *                         for the peak "I was at this show" past-event audience.
- * @param array  $args     Optional framing overrides. Recognised keys:
- *                         - 'hero_heading'      (string) Hero title copy. Only
- *                           used by the 'past-hero' variant.
- *                         - 'hero_subheading'   (string) Hero payoff copy. Only
- *                           used by the 'past-hero' variant.
- *                         - 'logged_out_heading'  (string) Signup-framed title
- *                           shown to logged-out visitors (composition can frame
- *                           this as "build your concert archive" instead of a
- *                           generic login wall).
- *                         - 'logged_out_subheading' (string) Signup-framed
- *                           sub-copy for logged-out visitors.
- *                         - 'redirect_to'       (string) URL to return the user
- *                           to after login/signup. Defaults to the current
- *                           request URL (JS resolves this at click time when
- *                           omitted).
+ * @param int   $event_id Event post ID.
+ * @param array $args     Presentation + framing config. Recognised keys:
+ *                       - 'variant' (string) Presentation variant. Supported:
+ *                         'default' (or omitted) — the standard inline
+ *                         attendance toggle; 'past-hero' — an attendance-first
+ *                         "hero" presentation with archive payoff framing,
+ *                         intended for the peak "I was at this show" past-event
+ *                         audience.
+ *                       - 'hero_heading'      (string) Hero title copy. Only
+ *                         used by the 'past-hero' variant.
+ *                       - 'hero_subheading'   (string) Hero payoff copy. Only
+ *                         used by the 'past-hero' variant.
+ *                       - 'logged_out_heading'  (string) Signup-framed title
+ *                         shown to logged-out visitors (composition can frame
+ *                         this as "build your concert archive" instead of a
+ *                         generic login wall).
+ *                       - 'logged_out_subheading' (string) Signup-framed
+ *                         sub-copy for logged-out visitors.
+ *                       - 'redirect_to'       (string) URL to return the user
+ *                         to after login/signup. Defaults to the current
+ *                         request URL (JS resolves this at click time when
+ *                         omitted).
  */
-function ec_users_render_attendance_button( int $event_id, string $variant = '', array $args = array() ) {
+function ec_users_render_attendance_button( int $event_id, array $args = array() ) {
 	$blog_id = get_current_blog_id();
 	$timing  = ec_users_get_event_timing( $event_id );
 	$count   = ec_users_get_event_mark_count( $event_id, $blog_id );
@@ -91,10 +93,12 @@ function ec_users_render_attendance_button( int $event_id, string $variant = '',
 	$button_class = $is_marked ? 'button-2' : 'button-3';
 	$marked_class = $is_marked ? ' ec-attendance--marked' : '';
 
-	$variant = '' === $variant ? 'default' : $variant;
+	$variant = isset( $args['variant'] ) && '' !== $args['variant']
+		? (string) $args['variant']
+		: 'default';
 
 	// 'past-hero' wraps the standard mount in an attendance-first presentation
-	// with archive payoff framing. The inner mount markup is IDENTICAL to the
+	// with archive payoff framing. The inner mount markup is the same as the
 	// default path so the same React component (#ec-attendance-root) hydrates it
 	// unchanged — only the surrounding presentation/copy differs.
 	$is_hero = ( 'past-hero' === $variant );
@@ -144,7 +148,7 @@ function ec_users_render_attendance_button( int $event_id, string $variant = '',
 		return;
 	}
 
-	// Default variant — byte-for-byte identical to the pre-variant output.
+	// Default variant — the standard inline attendance toggle.
 	ec_users_render_attendance_mount(
 		$event_id,
 		$blog_id,
@@ -166,10 +170,9 @@ function ec_users_render_attendance_button( int $event_id, string $variant = '',
  * Render the attendance mount root (first-paint markup + React hydration hook).
  *
  * Extracted from ec_users_render_attendance_button() so every presentation
- * variant shares one canonical mount. The default variant's output is
- * byte-for-byte identical to the pre-variant markup — the only optional
- * addition is a data-redirect-to attribute, emitted solely when a caller passes
- * an explicit redirect override (so the default call site's markup is unchanged).
+ * variant shares one canonical mount. A data-redirect-to attribute is emitted
+ * only when a caller passes an explicit redirect override; otherwise the React
+ * component falls back to the current request URL at click time.
  *
  * @param int    $event_id     Event post ID.
  * @param int    $blog_id      Blog ID.

--- a/inc/concert-tracking/buttons.php
+++ b/inc/concert-tracking/buttons.php
@@ -23,9 +23,39 @@ defined( 'ABSPATH' ) || exit;
  * Called from extrachill-events integration hook, which fires inside
  * the data_machine_events_action_buttons action in the Event Details block.
  *
- * @param int $event_id Event post ID.
+ * This is a flexible feature-PROVIDER renderer. Page composition (button
+ * ordering, when to show the import nudge, whether to de-emphasize the ticket
+ * CTA) is NOT this function's concern — that lives in the composition layer
+ * (extrachill-events). This renderer only exposes the presentation variants and
+ * framing hooks the composition layer can arrange.
+ *
+ * Back-compat contract: calling with just $event_id (as extrachill-events does
+ * today) produces byte-for-byte the same output as before this became
+ * variant-aware. New behavior is opt-in via $variant / $args.
+ *
+ * @param int    $event_id Event post ID.
+ * @param string $variant  Optional presentation variant. Supported values:
+ *                         'default' (or '') — the standard inline attendance
+ *                         toggle; 'past-hero' — an attendance-first "hero"
+ *                         presentation with archive payoff framing, intended
+ *                         for the peak "I was at this show" past-event audience.
+ * @param array  $args     Optional framing overrides. Recognised keys:
+ *                         - 'hero_heading'      (string) Hero title copy. Only
+ *                           used by the 'past-hero' variant.
+ *                         - 'hero_subheading'   (string) Hero payoff copy. Only
+ *                           used by the 'past-hero' variant.
+ *                         - 'logged_out_heading'  (string) Signup-framed title
+ *                           shown to logged-out visitors (composition can frame
+ *                           this as "build your concert archive" instead of a
+ *                           generic login wall).
+ *                         - 'logged_out_subheading' (string) Signup-framed
+ *                           sub-copy for logged-out visitors.
+ *                         - 'redirect_to'       (string) URL to return the user
+ *                           to after login/signup. Defaults to the current
+ *                           request URL (JS resolves this at click time when
+ *                           omitted).
  */
-function ec_users_render_attendance_button( int $event_id ) {
+function ec_users_render_attendance_button( int $event_id, string $variant = '', array $args = array() ) {
 	$blog_id = get_current_blog_id();
 	$timing  = ec_users_get_event_timing( $event_id );
 	$count   = ec_users_get_event_mark_count( $event_id, $blog_id );
@@ -61,6 +91,120 @@ function ec_users_render_attendance_button( int $event_id ) {
 	$button_class = $is_marked ? 'button-2' : 'button-3';
 	$marked_class = $is_marked ? ' ec-attendance--marked' : '';
 
+	$variant = '' === $variant ? 'default' : $variant;
+
+	// 'past-hero' wraps the standard mount in an attendance-first presentation
+	// with archive payoff framing. The inner mount markup is IDENTICAL to the
+	// default path so the same React component (#ec-attendance-root) hydrates it
+	// unchanged — only the surrounding presentation/copy differs.
+	$is_hero = ( 'past-hero' === $variant );
+
+	if ( $is_hero ) {
+		if ( $is_logged_in ) {
+			$heading = isset( $args['hero_heading'] ) && '' !== $args['hero_heading']
+				? (string) $args['hero_heading']
+				: __( 'Were you at this show?', 'extrachill-users' );
+			$subhead = isset( $args['hero_subheading'] ) && '' !== $args['hero_subheading']
+				? (string) $args['hero_subheading']
+				: __( 'Add this show to your concert archive.', 'extrachill-users' );
+		} else {
+			// Logged-out: frame around building an archive (signup payoff) rather
+			// than a generic login wall. Copy is caller-overridable.
+			$heading = isset( $args['logged_out_heading'] ) && '' !== $args['logged_out_heading']
+				? (string) $args['logged_out_heading']
+				: __( 'Were you at this show?', 'extrachill-users' );
+			$subhead = isset( $args['logged_out_subheading'] ) && '' !== $args['logged_out_subheading']
+				? (string) $args['logged_out_subheading']
+				: __( 'Sign up to build your concert archive — every show you\'ve seen, in one place.', 'extrachill-users' );
+		}
+
+		?>
+		<div class="ec-attendance-hero">
+			<p class="ec-attendance-hero__heading"><?php echo esc_html( $heading ); ?></p>
+			<p class="ec-attendance-hero__subheading"><?php echo esc_html( $subhead ); ?></p>
+			<?php
+			ec_users_render_attendance_mount(
+				$event_id,
+				$blog_id,
+				$timing,
+				$is_marked,
+				$count,
+				$count_label,
+				$is_logged_in,
+				$label_set,
+				$button_label,
+				$button_class,
+				$marked_class,
+				$args
+			);
+			?>
+		</div>
+		<?php
+		ec_users_render_event_attendees( $event_id, $blog_id );
+		return;
+	}
+
+	// Default variant — byte-for-byte identical to the pre-variant output.
+	ec_users_render_attendance_mount(
+		$event_id,
+		$blog_id,
+		$timing,
+		$is_marked,
+		$count,
+		$count_label,
+		$is_logged_in,
+		$label_set,
+		$button_label,
+		$button_class,
+		$marked_class,
+		$args
+	);
+	ec_users_render_event_attendees( $event_id, $blog_id );
+}
+
+/**
+ * Render the attendance mount root (first-paint markup + React hydration hook).
+ *
+ * Extracted from ec_users_render_attendance_button() so every presentation
+ * variant shares one canonical mount. The default variant's output is
+ * byte-for-byte identical to the pre-variant markup — the only optional
+ * addition is a data-redirect-to attribute, emitted solely when a caller passes
+ * an explicit redirect override (so the default call site's markup is unchanged).
+ *
+ * @param int    $event_id     Event post ID.
+ * @param int    $blog_id      Blog ID.
+ * @param string $timing       Event timing bucket.
+ * @param bool   $is_marked    Whether the current user has marked attendance.
+ * @param int    $count        Attendee count.
+ * @param string $count_label  Formatted count label.
+ * @param bool   $is_logged_in Whether a user is logged in.
+ * @param array  $label_set    Default/active label pair for this timing.
+ * @param string $button_label Resolved button label.
+ * @param string $button_class Theme button class.
+ * @param string $marked_class Extra container class when marked.
+ * @param array  $args         Framing overrides (see ec_users_render_attendance_button()).
+ */
+function ec_users_render_attendance_mount(
+	int $event_id,
+	int $blog_id,
+	string $timing,
+	bool $is_marked,
+	int $count,
+	string $count_label,
+	bool $is_logged_in,
+	array $label_set,
+	string $button_label,
+	string $button_class,
+	string $marked_class,
+	array $args = array()
+) {
+	// Optional explicit post-login redirect target. When omitted the React
+	// component falls back to the current request URL (its existing behavior),
+	// so the default markup stays unchanged.
+	$redirect_to = isset( $args['redirect_to'] ) && '' !== $args['redirect_to']
+		? (string) $args['redirect_to']
+		: '';
+
 	// Server-render the first-paint markup so the button is visible (and
 	// SEO/no-JS friendly) before the React mount hydrates. The mount root
 	// carries the initial state as data attributes; the React component
@@ -77,6 +221,9 @@ function ec_users_render_attendance_button( int $event_id ) {
 		data-count-label="<?php echo esc_attr( $count > 0 ? $count_label : '' ); ?>"
 		data-is-logged-in="<?php echo $is_logged_in ? '1' : '0'; ?>"
 		data-login-url="<?php echo esc_attr( wp_login_url() ); ?>"
+		<?php if ( '' !== $redirect_to ) : ?>
+		data-redirect-to="<?php echo esc_attr( $redirect_to ); ?>"
+		<?php endif; ?>
 		data-label-default="<?php echo esc_attr( $label_set['default'] ); ?>"
 		data-label-active="<?php echo esc_attr( $label_set['active'] ); ?>">
 		<button class="ec-attendance__button <?php echo esc_attr( $button_class ); ?> button-medium"
@@ -91,7 +238,6 @@ function ec_users_render_attendance_button( int $event_id ) {
 		<?php endif; ?>
 	</div>
 	<?php
-	ec_users_render_event_attendees( $event_id, $blog_id );
 }
 
 /**
@@ -147,6 +293,84 @@ function ec_users_render_event_attendees( int $event_id, int $blog_id ) {
 				</li>
 			<?php endforeach; ?>
 		</ul>
+	</div>
+	<?php
+}
+
+/**
+ * Resolve the deep-link URL into the concert-import flow on /my-shows/.
+ *
+ * The import UI lives on the events site's /my-shows/ page, surfaced as the
+ * "Import" tab of the concert-stats block. That block reads the active tab from
+ * the `tab` query arg (see its view.js), so `?tab=import` lands a logged-in user
+ * directly in the import flow. Logged-out users are sent through login first
+ * with the same destination preserved as the post-login redirect.
+ *
+ * @return string Absolute URL into the import flow, or '' if the events site
+ *                cannot be resolved.
+ */
+function ec_users_concert_import_url(): string {
+	$events_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'events' ) : 0;
+
+	if ( $events_blog_id > 0 && function_exists( 'get_home_url' ) ) {
+		$base = (string) get_home_url( $events_blog_id, '/my-shows/' );
+	} else {
+		$base = home_url( '/my-shows/' );
+	}
+
+	$import_url = add_query_arg( 'tab', 'import', $base );
+
+	// Logged-out visitors can't reach a personal page directly — route them
+	// through login and bounce back into the import flow afterward.
+	if ( ! is_user_logged_in() ) {
+		return wp_login_url( $import_url );
+	}
+
+	return $import_url;
+}
+
+/**
+ * Render the compact "import your concert history" nudge module.
+ *
+ * Self-contained feature-PROVIDER partial. It only RENDERS the nudge and wires
+ * it to the existing setlist.fm / phish.net import flow (via the /my-shows/
+ * import tab). The composition layer (extrachill-events) decides WHERE and WHEN
+ * to call it — e.g. after a logged-in user marks "I Was There" on a past event.
+ * This function makes no placement or timing decisions.
+ *
+ * @param array $args Optional copy overrides. Recognised keys:
+ *                   - 'heading' (string) Nudge title. Defaults to
+ *                     "Been to more shows?".
+ *                   - 'body'    (string) Supporting copy. Defaults to a prompt
+ *                     to import concert history from setlist.fm / phish.net.
+ *                   - 'cta'     (string) Call-to-action label. Defaults to
+ *                     "Import your concert history".
+ */
+function ec_users_render_import_nudge( array $args = array() ) {
+	$import_url = ec_users_concert_import_url();
+	if ( '' === $import_url ) {
+		return;
+	}
+
+	$heading = isset( $args['heading'] ) && '' !== $args['heading']
+		? (string) $args['heading']
+		: __( 'Been to more shows?', 'extrachill-users' );
+	$body    = isset( $args['body'] ) && '' !== $args['body']
+		? (string) $args['body']
+		: __( 'Pull your full concert history from setlist.fm or phish.net — every show, matched to Extra Chill events automatically.', 'extrachill-users' );
+	$cta     = isset( $args['cta'] ) && '' !== $args['cta']
+		? (string) $args['cta']
+		: __( 'Import your concert history', 'extrachill-users' );
+
+	?>
+	<div class="ec-import-nudge">
+		<div class="ec-import-nudge__body">
+			<p class="ec-import-nudge__heading"><?php echo esc_html( $heading ); ?></p>
+			<p class="ec-import-nudge__text"><?php echo esc_html( $body ); ?></p>
+		</div>
+		<a class="ec-import-nudge__cta button-1 button-medium" href="<?php echo esc_url( $import_url ); ?>">
+			<?php echo esc_html( $cta ); ?>
+		</a>
 	</div>
 	<?php
 }


### PR DESCRIPTION
## Summary

Turns the concert-tracking **feature-provider** renderers in `inc/concert-tracking/buttons.php` into flexible building blocks the composition layer (`extrachill-events`) can arrange for a tense-aware past-event page — **without this repo doing any page composition**. Per the platform layer model, button ordering / ticket-CTA de-emphasis / when-to-show-the-nudge stay in the composition layer (`extrachill-events#205`, `data-machine-events#406`). This PR only makes the renderers flexible enough to be composed.

Closes #163.

## What changed

### 1. `ec_users_render_attendance_button()` is now variant/framing aware
New optional args, fully back-compatible:

```php
ec_users_render_attendance_button( int $event_id, string $variant = '', array $args = array() )
```

- **`$variant`** — `'default'` (or `''`) keeps the standard inline toggle; **`'past-hero'`** renders an attendance-first *hero* presentation with archive payoff framing (`"Add this show to your concert archive"`) wrapped around the **same** `#ec-attendance-root` mount, so the existing React component hydrates it unchanged.
- **`$args`** — framing overrides:
  - `hero_heading` / `hero_subheading` — hero copy (past-hero only).
  - `logged_out_heading` / `logged_out_subheading` — signup-framed copy so the composition layer can frame the logged-out path as *"build your concert archive"* instead of a generic login wall (defaults preserve current behavior).
  - `redirect_to` — optional explicit post-login return URL for deep-linking.

### 2. New `ec_users_render_import_nudge()` render helper
Self-contained partial that outputs a compact *"Been to more shows? Import your concert history"* module wired to the existing setlist.fm / phish.net import flow. It deep-links to the events site's `/my-shows/?tab=import` (the tab the concert-stats block reads from the `tab` query arg), routing logged-out users through login and bouncing them back into the import tab. Copy is overridable via `heading` / `body` / `cta`. **Renders only** — the composition layer decides where/when to call it.

### 3. Logged-out framing wired end-to-end
Threaded a `data-redirect-to` attribute through the React mount (`index.js` → `AttendanceButton.js`) so the logged-out click redirect honors a caller-supplied destination, falling back to the current URL (prior behavior) when omitted.

## Back-compat (verified)

`extrachill-events`' `concert-tracking-integration.php` calls `ec_users_render_attendance_button( (int) $post_id )` with **just the event id** — that call is unaffected:
- The default path emits **byte-for-byte identical** mount markup (the shared `ec_users_render_attendance_mount()` helper only adds `data-redirect-to` when a caller passes an explicit override).
- `git stash` diff confirms the only PHPCS warnings on `buttons.php` are 2 **pre-existing** alignment warnings in the untouched enqueue function; my code adds **0 new PHPCS errors/warnings** and **0 new ESLint violations** (remaining ESLint findings are the repo's baseline `@package`/dependency-group/`import/no-unresolved` patterns present on every block file).
- `php -l` clean.

## Testing note

`homeboy test extrachill-users` could not run here: the host's `wp-codebox` CLI is a stale wrapper (`wp-codebox --version` → `Unknown command`), so the sandbox test harness fails to bootstrap before any test executes — an **infra/host issue, not a code failure**. The existing `WP_UnitTestCase` suite needs the sandbox-provided WP test harness and has no coverage over `buttons.php` rendering; this change touches only render helpers + the JS mount + CSS. Verified via `php -l`, `homeboy lint`, and back-compat markup review instead.

## Out of scope (composition layer, not this repo)
Button ordering, suppressing the ticket CTA, deciding when the nudge appears, and per-page composition — tracked in `extrachill-events`. This PR does not depend on `data-machine-events#406`; it is pure provider-side.