### PR TITLE
refactor: promote points/rank engine from community + add dated-contributions seam

### DIFF
--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -138,6 +138,8 @@ function extrachill_users_init() {
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/team-members.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/badges/user-badges.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/rank-system/rank-tiers.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/rank-system/points-engine.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/rank-system/contribution-events.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/onboarding/service.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/lifetime-membership.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/shop-permissions.php';
@@ -149,6 +151,7 @@ function extrachill_users_init() {
 
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/service.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/rank-points.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/contribution-events.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/buttons.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/import-db.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/import/bootstrap.php';

--- a/inc/concert-tracking/contribution-events.php
+++ b/inc/concert-tracking/contribution-events.php
@@ -7,9 +7,10 @@
  * DATED concert check-in events (via ec_contribution_events) so the heatmap
  * (extrachill-community#147) can show concert attendance on a calendar grid.
  *
- * Source: the ec_concert_tracking table, which has `created_at` (the timestamp
- * the user marked the event) indexed on (user_id, created_at). We aggregate
- * check-ins per calendar day via ec_users_get_user_dated_event_checks().
+ * Source: the ec_concert_tracking table, which stores `created_at` as UTC.
+ * Day computation + timezone normalization is delegated to the shared
+ * ec_bucket_utc_events_by_local_day() helper in the rank-system seam — this
+ * contributor never reasons about timezones.
  *
  * @package ExtraChill\Users
  */
@@ -19,10 +20,9 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Contribute dated concert check-in events.
  *
- * Returns one aggregated row per day the user marked a concert (concert
- * check-ins are low-volume — typically dozens, not thousands — so the full
- * history is returned and the engine's defensive since-window filter handles
- * truncation).
+ * SELECTs the raw `created_at` UTC column and delegates to
+ * ec_bucket_utc_events_by_local_day(), which handles the UTC→site-local day
+ * conversion AND the since_ymd window uniformly.
  *
  * @param array  $events    Running event list.
  * @param int    $user_id   WordPress user ID.
@@ -30,22 +30,23 @@ defined( 'ABSPATH' ) || exit;
  * @return array
  */
 function ec_users_concert_contribution_events( $events, $user_id, $since_ymd ) {
-	unset( $since_ymd ); // Engine applies the defensive date filter; we return all history.
-
 	if ( ! function_exists( 'ec_users_get_user_dated_event_checks' ) ) {
 		return $events;
 	}
 
-	$rows = ec_users_get_user_dated_event_checks( (int) $user_id );
-
-	foreach ( $rows as $row ) {
-		$events[] = array(
-			'date'  => $row['date'],
-			'type'  => 'concert',
-			'count' => $row['count'],
-		);
+	if ( ! function_exists( 'ec_bucket_utc_events_by_local_day' ) ) {
+		return $events;
 	}
 
-	return $events;
+	$utc_timestamps = ec_users_get_user_dated_event_checks( (int) $user_id );
+
+	if ( empty( $utc_timestamps ) ) {
+		return $events;
+	}
+
+	return array_merge(
+		$events,
+		ec_bucket_utc_events_by_local_day( $utc_timestamps, 'concert', $since_ymd )
+	);
 }
 add_filter( 'ec_contribution_events', 'ec_users_concert_contribution_events', 10, 3 );

--- a/inc/concert-tracking/contribution-events.php
+++ b/inc/concert-tracking/contribution-events.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Concert tracking → dated contribution events.
+ *
+ * The dated sibling of rank-points.php. While rank-points.php contributes the
+ * SCALAR concert points (via ec_rank_extra_points), this file contributes the
+ * DATED concert check-in events (via ec_contribution_events) so the heatmap
+ * (extrachill-community#147) can show concert attendance on a calendar grid.
+ *
+ * Source: the ec_concert_tracking table, which has `created_at` (the timestamp
+ * the user marked the event) indexed on (user_id, created_at). We aggregate
+ * check-ins per calendar day via ec_users_get_user_dated_event_checks().
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Contribute dated concert check-in events.
+ *
+ * Returns one aggregated row per day the user marked a concert (concert
+ * check-ins are low-volume — typically dozens, not thousands — so the full
+ * history is returned and the engine's defensive since-window filter handles
+ * truncation).
+ *
+ * @param array  $events    Running event list.
+ * @param int    $user_id   WordPress user ID.
+ * @param string $since_ymd Inclusive start date (YYYY-MM-DD), or '' for all.
+ * @return array
+ */
+function ec_users_concert_contribution_events( $events, $user_id, $since_ymd ) {
+	unset( $since_ymd ); // Engine applies the defensive date filter; we return all history.
+
+	if ( ! function_exists( 'ec_users_get_user_dated_event_checks' ) ) {
+		return $events;
+	}
+
+	$rows = ec_users_get_user_dated_event_checks( (int) $user_id );
+
+	foreach ( $rows as $row ) {
+		$events[] = array(
+			'date'  => $row['date'],
+			'type'  => 'concert',
+			'count' => $row['count'],
+		);
+	}
+
+	return $events;
+}
+add_filter( 'ec_contribution_events', 'ec_users_concert_contribution_events', 10, 3 );

--- a/inc/concert-tracking/rank-points.php
+++ b/inc/concert-tracking/rank-points.php
@@ -3,18 +3,17 @@
  * Concert tracking → community rank points.
  *
  * Registers concert-going (My Shows) as a pluggable point source for the
- * cross-site community rank/points system. The community plugin exposes a
- * generic, feature-agnostic extensibility seam — the `ec_rank_extra_points`
- * filter (see extrachill-community/inc/social/rank-system/point-calculation.php)
- * — and this file is the concert-specific consumer of it. Community never
- * references concerts; concerts opt into rank via the filter from here. Layer
- * purity preserved.
+ * cross-site rank/points system. The points engine (extrachill-users/inc/rank-
+ * system/points-engine.php) exposes a generic, feature-agnostic extensibility
+ * seam — the `ec_rank_extra_points` filter — and this file is the
+ * concert-specific consumer of it. The engine never references concerts;
+ * concerts opt into rank via the filter from here. Layer purity preserved.
  *
- * Weight rationale: each tracked show is worth more than a forum reply
+ * Weight rationale: each tracked show is worth more than a forum contribution
  * (2 points) because attending a concert is a higher-intent, harder-to-fake
- * signal of genuine scene participation than posting a reply. 3 points per
- * show is the chosen weight; tune via the `ec_users_concert_rank_points_per_show`
- * filter below.
+ * signal of genuine scene participation than posting. 3 points per show is the
+ * chosen weight; tune via the `ec_users_concert_rank_points_per_show` filter
+ * below.
  *
  * Performance: this runs inside extrachill_get_user_total_points(), whose TOTAL
  * is transient-cached for one hour, so the show count query (a single COUNT(*)
@@ -33,10 +32,10 @@ defined( 'ABSPATH' ) || exit;
 const EC_USERS_CONCERT_RANK_POINTS_PER_SHOW = 3;
 
 /**
- * Contribute concert-attendance points to a user's community rank total.
+ * Contribute concert-attendance points to a user's rank total.
  *
- * Hooks the community plugin's generic `ec_rank_extra_points` seam and adds
- * (shows attended × per-show weight) to the running extra-points value. Returns
+ * Hooks the points engine's generic `ec_rank_extra_points` seam and adds
+ * (shows attended x per-show weight) to the running extra-points value. Returns
  * the value unchanged when the count helper is unavailable so the rank total
  * never breaks if concert tracking is disabled.
  *

--- a/inc/concert-tracking/service.php
+++ b/inc/concert-tracking/service.php
@@ -238,21 +238,18 @@ function ec_users_get_user_event_count( int $user_id, int $blog_id = 0 ): int {
 // ─── Dated Contributions ─────────────────────────────────────────────────────
 
 /**
- * Get a user's concert check-ins grouped by calendar day (site timezone).
+ * Get a user's concert check-in timestamps (raw UTC).
  *
  * Supplies the DATED concert-attendance data for the contribution-events seam
- * (ec_contribution_events). The tracking table stores `created_at` as UTC; we
- * convert each timestamp to the site timezone before grouping so day boundaries
- * match how users perceive "today." Volume is low (a user's lifetime check-ins),
- * so PHP grouping over a single-column SELECT is simpler and more robust than a
- * MySQL CONVERT_TZ GROUP BY (which depends on timezone tables being loaded).
+ * (ec_contribution_events). Returns the raw `created_at` column (UTC); day
+ * computation + timezone normalization is handled centrally by
+ * ec_bucket_utc_events_by_local_day() in the rank-system seam, so this getter
+ * stays a thin data fetch with no timezone logic.
  *
- * Sibling to ec_users_get_user_event_count() (the scalar total). Returns one
- * row per day with a count; the caller (the concert contribution-events hook)
- * shapes these into ec_contribution_events records.
+ * Sibling to ec_users_get_user_event_count() (the scalar total).
  *
  * @param int $user_id User ID.
- * @return array<int, array{date:string,count:int}>
+ * @return string[] MySQL 'Y-m-d H:i:s' strings in UTC.
  */
 function ec_users_get_user_dated_event_checks( int $user_id ): array {
 	global $wpdb;
@@ -266,36 +263,7 @@ function ec_users_get_user_dated_event_checks( int $user_id ): array {
 		)
 	);
 
-	if ( ! is_array( $raw ) || empty( $raw ) ) {
-		return array();
-	}
-
-	$timezone = wp_timezone();
-	$by_date  = array();
-
-	foreach ( $raw as $mysql_dt ) {
-		try {
-			$dt = new DateTime( $mysql_dt, new DateTimeZone( 'UTC' ) );
-		} catch ( Exception $e ) {
-			continue;
-		}
-		$dt->setTimezone( $timezone );
-		$day = $dt->format( 'Y-m-d' );
-		if ( ! isset( $by_date[ $day ] ) ) {
-			$by_date[ $day ] = 0;
-		}
-		++$by_date[ $day ];
-	}
-
-	$out = array();
-	foreach ( $by_date as $day => $count ) {
-		$out[] = array(
-			'date'  => $day,
-			'count' => $count,
-		);
-	}
-
-	return $out;
+	return is_array( $raw ) ? $raw : array();
 }
 
 // ─── Event Timing ────────────────────────────────────────────────────────────

--- a/inc/concert-tracking/service.php
+++ b/inc/concert-tracking/service.php
@@ -235,6 +235,69 @@ function ec_users_get_user_event_count( int $user_id, int $blog_id = 0 ): int {
 	);
 }
 
+// ─── Dated Contributions ─────────────────────────────────────────────────────
+
+/**
+ * Get a user's concert check-ins grouped by calendar day (site timezone).
+ *
+ * Supplies the DATED concert-attendance data for the contribution-events seam
+ * (ec_contribution_events). The tracking table stores `created_at` as UTC; we
+ * convert each timestamp to the site timezone before grouping so day boundaries
+ * match how users perceive "today." Volume is low (a user's lifetime check-ins),
+ * so PHP grouping over a single-column SELECT is simpler and more robust than a
+ * MySQL CONVERT_TZ GROUP BY (which depends on timezone tables being loaded).
+ *
+ * Sibling to ec_users_get_user_event_count() (the scalar total). Returns one
+ * row per day with a count; the caller (the concert contribution-events hook)
+ * shapes these into ec_contribution_events records.
+ *
+ * @param int $user_id User ID.
+ * @return array<int, array{date:string,count:int}>
+ */
+function ec_users_get_user_dated_event_checks( int $user_id ): array {
+	global $wpdb;
+
+	$table = extrachill_users_concert_tracking_table_name();
+
+	$raw = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT created_at FROM {$table} WHERE user_id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+			$user_id
+		)
+	);
+
+	if ( ! is_array( $raw ) || empty( $raw ) ) {
+		return array();
+	}
+
+	$timezone = wp_timezone();
+	$by_date  = array();
+
+	foreach ( $raw as $mysql_dt ) {
+		try {
+			$dt = new DateTime( $mysql_dt, new DateTimeZone( 'UTC' ) );
+		} catch ( Exception $e ) {
+			continue;
+		}
+		$dt->setTimezone( $timezone );
+		$day = $dt->format( 'Y-m-d' );
+		if ( ! isset( $by_date[ $day ] ) ) {
+			$by_date[ $day ] = 0;
+		}
+		++$by_date[ $day ];
+	}
+
+	$out = array();
+	foreach ( $by_date as $day => $count ) {
+		$out[] = array(
+			'date'  => $day,
+			'count' => $count,
+		);
+	}
+
+	return $out;
+}
+
 // ─── Event Timing ────────────────────────────────────────────────────────────
 
 /**

--- a/inc/rank-system/contribution-events.php
+++ b/inc/rank-system/contribution-events.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Dated Contribution Events — the temporal projection of point sources.
+ *
+ * While `extrachill_get_user_total_points()` computes a SCALAR total, this seam
+ * exposes the same engagement data as DATED events — one record per
+ * day+type+count — so a consumer (e.g. the contribution heatmap,
+ * extrachill-community#147) can bucket activity per calendar day.
+ *
+ * Sources that bear a timestamp hook `ec_contribution_events` and return
+ * aggregated per-day rows. Sources without a timestamp trail (scalar counters
+ * that have no per-day history) are intentionally excluded — they cannot be
+ * dated without a new table, which is out of scope.
+ *
+ * Event shape (aggregated for efficiency):
+ *   array( 'date' => 'YYYY-MM-DD', 'type' => '<source-key>', 'count' => int )
+ *
+ * Aggregation rationale: a prolific author may have thousands of contributions;
+ * returning one row per contribution would make the payload and the per-day
+ * GROUP BY prohibitively large. Contributors aggregate server-side (SQL
+ * GROUP BY DATE(...)) and return one row per day+type. The consumer sums
+ * `count` per date.
+ *
+ * Timezone: dates are calendar days in the site timezone
+ * (wp_timezone() / America/New_York) so day boundaries match how users
+ * perceive "today."
+ *
+ * @package ExtraChill\Users
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Get a user's dated contribution events on or after a date.
+ *
+ * Applies the `ec_contribution_events` filter and returns the merged,
+ * normalized event list from all sources.
+ *
+ * @param int    $user_id   WordPress user ID.
+ * @param string $since_ymd Inclusive start date (YYYY-MM-DD, site timezone).
+ *                          Events on or after this date are returned.
+ *                          Empty string = no lower bound (all history).
+ * @return array<int, array{date:string,type:string,count:int}>
+ */
+function ec_get_contribution_events( $user_id, $since_ymd = '' ) {
+	/**
+	 * Contribute dated engagement events.
+	 *
+	 * Each source returns an array of aggregated rows:
+	 *   array( 'date' => 'YYYY-MM-DD', 'type' => string, 'count' => int )
+	 *
+	 * `date` is a calendar day in the site timezone. `type` is an opaque
+	 * source identifier (the engine does not inspect it). `count` is the
+	 * number of contributions of that type on that date.
+	 *
+	 * Sources without per-day timestamps (e.g. scalar counters) MUST NOT
+	 * participate — there is no honest date to assign.
+	 *
+	 * @param array  $events    Running event list.
+	 * @param int    $user_id   WordPress user ID.
+	 * @param string $since_ymd Inclusive start date (YYYY-MM-DD), or '' for all.
+	 */
+	$events = (array) apply_filters( 'ec_contribution_events', array(), (int) $user_id, (string) $since_ymd );
+
+	// Normalize: enforce shape, apply defensive date-window filter.
+	$clean = array();
+	foreach ( $events as $event ) {
+		if ( ! is_array( $event ) ) {
+			continue;
+		}
+
+		$date  = isset( $event['date'] ) ? (string) $event['date'] : '';
+		$count = isset( $event['count'] ) ? (int) $event['count'] : 1;
+		$type  = isset( $event['type'] ) ? (string) $event['type'] : '';
+
+		if ( '' === $date || $count < 1 ) {
+			continue;
+		}
+
+		// Respect the since-window when provided (defensive backstop —
+		// contributors should also SQL-filter for efficiency).
+		if ( '' !== $since_ymd && $date < $since_ymd ) {
+			continue;
+		}
+
+		$clean[] = array(
+			'date'  => $date,
+			'type'  => $type,
+			'count' => $count,
+		);
+	}
+
+	return $clean;
+}
+
+/**
+ * Built-in dated source: main-site published posts.
+ *
+ * Contributes one dated event per day the user published a `post` on the main
+ * site. Network-level source owned by the engine (mirrors the scalar
+ * `main_posts` source in points-engine.php). Hooks `ec_contribution_events`.
+ *
+ * @param array  $events    Running event list.
+ * @param int    $user_id   WordPress user ID.
+ * @param string $since_ymd Inclusive start date (YYYY-MM-DD), or '' for all.
+ * @return array
+ */
+function ec_users_main_posts_contribution_events( $events, $user_id, $since_ymd ) {
+	$main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
+	if ( ! $main_blog_id ) {
+		return $events;
+	}
+
+	global $wpdb;
+
+	switch_to_blog( $main_blog_id );
+	try {
+		// Aggregate published posts per calendar day for this author.
+		// DATE(post_date) yields site-local calendar days (WP stores post_date
+		// in site-local time for posts created via the WP API).
+		if ( '' !== $since_ymd ) {
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- no interpolation; prepared statement.
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT DATE(post_date) AS d, COUNT(*) AS c
+					 FROM {$wpdb->posts}
+					 WHERE post_author = %d AND post_type = 'post' AND post_status = 'publish'
+					   AND DATE(post_date) >= %s
+					 GROUP BY d",
+					$user_id,
+					$since_ymd
+				),
+				ARRAY_A
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		} else {
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT DATE(post_date) AS d, COUNT(*) AS c
+					 FROM {$wpdb->posts}
+					 WHERE post_author = %d AND post_type = 'post' AND post_status = 'publish'
+					 GROUP BY d",
+					$user_id
+				),
+				ARRAY_A
+			);
+		}
+	} finally {
+		restore_current_blog();
+	}
+
+	if ( is_array( $rows ) ) {
+		foreach ( $rows as $row ) {
+			$events[] = array(
+				'date'  => (string) $row['d'],
+				'type'  => 'post',
+				'count' => (int) $row['c'],
+			);
+		}
+	}
+
+	return $events;
+}
+add_filter( 'ec_contribution_events', 'ec_users_main_posts_contribution_events', 10, 3 );

--- a/inc/rank-system/contribution-events.php
+++ b/inc/rank-system/contribution-events.php
@@ -7,29 +7,82 @@
  * day+type+count — so a consumer (e.g. the contribution heatmap,
  * extrachill-community#147) can bucket activity per calendar day.
  *
- * Sources that bear a timestamp hook `ec_contribution_events` and return
- * aggregated per-day rows. Sources without a timestamp trail (scalar counters
- * that have no per-day history) are intentionally excluded — they cannot be
- * dated without a new table, which is out of scope.
+ * Sources that bear a timestamp hook `ec_contribution_events` and return raw
+ * UTC datetime strings. Sources without a timestamp trail (scalar counters that
+ * have no per-day history) are intentionally excluded — they cannot be dated
+ * without a new table, which is out of scope.
  *
- * Event shape (aggregated for efficiency):
+ * Timezone contract (single-helper design): contributors NEVER compute calendar
+ * days themselves. They SELECT the UTC-authoritative timestamp column
+ * (`post_date_gmt`, `created_at`) and hand the raw strings to
+ * `ec_bucket_utc_events_by_local_day()`, which is the ONE place that converts
+ * UTC → site-local calendar day. This makes every source provably consistent
+ * and removes reliance on the drift-prone local `post_date` column.
+ *
+ * Event shape (aggregated per day+type):
  *   array( 'date' => 'YYYY-MM-DD', 'type' => '<source-key>', 'count' => int )
- *
- * Aggregation rationale: a prolific author may have thousands of contributions;
- * returning one row per contribution would make the payload and the per-day
- * GROUP BY prohibitively large. Contributors aggregate server-side (SQL
- * GROUP BY DATE(...)) and return one row per day+type. The consumer sums
- * `count` per date.
- *
- * Timezone: dates are calendar days in the site timezone
- * (wp_timezone() / America/New_York) so day boundaries match how users
- * perceive "today."
  *
  * @package ExtraChill\Users
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
+}
+
+/**
+ * Bucket a list of UTC datetime strings into per-day counts in the site timezone.
+ *
+ * The single, canonical UTC→site-local calendar-day conversion for ALL dated
+ * contribution sources. Contributors return raw UTC timestamps; this is the one
+ * place that decides "what local calendar day" — so every source is provably
+ * consistent and no contributor reasons about timezones.
+ *
+ * Also applies the `since_ymd` lower bound (site-local date), so every source
+ * that routes through this helper honors the window uniformly.
+ *
+ * @param string[] $utc_datetimes MySQL 'Y-m-d H:i:s' strings in UTC.
+ * @param string   $type          Opaque source key stamped on each row.
+ * @param string   $since_ymd     Inclusive site-local lower bound (YYYY-MM-DD),
+ *                                or '' for all history.
+ * @return array<int, array{date:string,type:string,count:int}>
+ */
+function ec_bucket_utc_events_by_local_day( array $utc_datetimes, $type, $since_ymd = '' ) {
+	$tz       = wp_timezone();
+	$utc_tz   = new DateTimeZone( 'UTC' );
+	$by_date  = array();
+
+	foreach ( $utc_datetimes as $dt_str ) {
+		try {
+			$dt = new DateTime( $dt_str, $utc_tz );
+		} catch ( Exception $e ) {
+			continue;
+		}
+		$dt->setTimezone( $tz );
+		$day = $dt->format( 'Y-m-d' );
+
+		// Authoritative since-window filter (site-local date comparison).
+		if ( '' !== $since_ymd && $day < $since_ymd ) {
+			continue;
+		}
+
+		if ( ! isset( $by_date[ $day ] ) ) {
+			$by_date[ $day ] = 0;
+		}
+		++$by_date[ $day ];
+	}
+
+	ksort( $by_date );
+
+	$out = array();
+	foreach ( $by_date as $day => $count ) {
+		$out[] = array(
+			'date'  => $day,
+			'type'  => (string) $type,
+			'count' => (int) $count,
+		);
+	}
+
+	return $out;
 }
 
 /**
@@ -51,8 +104,10 @@ function ec_get_contribution_events( $user_id, $since_ymd = '' ) {
 	 * Each source returns an array of aggregated rows:
 	 *   array( 'date' => 'YYYY-MM-DD', 'type' => string, 'count' => int )
 	 *
-	 * `date` is a calendar day in the site timezone. `type` is an opaque
-	 * source identifier (the engine does not inspect it). `count` is the
+	 * Contributors SHOULD build their rows via
+	 * `ec_bucket_utc_events_by_local_day()` so timezone conversion is
+	 * centralized. `date` is a calendar day in the site timezone. `type` is an
+	 * opaque source identifier (the engine does not inspect it). `count` is the
 	 * number of contributions of that type on that date.
 	 *
 	 * Sources without per-day timestamps (e.g. scalar counters) MUST NOT
@@ -64,7 +119,9 @@ function ec_get_contribution_events( $user_id, $since_ymd = '' ) {
 	 */
 	$events = (array) apply_filters( 'ec_contribution_events', array(), (int) $user_id, (string) $since_ymd );
 
-	// Normalize: enforce shape, apply defensive date-window filter.
+	// Lightweight shape-guard: enforce structure + valid values. The
+	// since-window filtering is authoritative in the helper; this is a
+	// defensive backstop for any contributor that doesn't route through it.
 	$clean = array();
 	foreach ( $events as $event ) {
 		if ( ! is_array( $event ) ) {
@@ -79,8 +136,6 @@ function ec_get_contribution_events( $user_id, $since_ymd = '' ) {
 			continue;
 		}
 
-		// Respect the since-window when provided (defensive backstop —
-		// contributors should also SQL-filter for efficiency).
 		if ( '' !== $since_ymd && $date < $since_ymd ) {
 			continue;
 		}
@@ -102,6 +157,9 @@ function ec_get_contribution_events( $user_id, $since_ymd = '' ) {
  * site. Network-level source owned by the engine (mirrors the scalar
  * `main_posts` source in points-engine.php). Hooks `ec_contribution_events`.
  *
+ * Reads `post_date_gmt` (the UTC-authoritative column) and delegates day
+ * computation to `ec_bucket_utc_events_by_local_day()`. Hooks `ec_contribution_events`.
+ *
  * @param array  $events    Running event list.
  * @param int    $user_id   WordPress user ID.
  * @param string $since_ymd Inclusive start date (YYYY-MM-DD), or '' for all.
@@ -117,50 +175,26 @@ function ec_users_main_posts_contribution_events( $events, $user_id, $since_ymd 
 
 	switch_to_blog( $main_blog_id );
 	try {
-		// Aggregate published posts per calendar day for this author.
-		// DATE(post_date) yields site-local calendar days (WP stores post_date
-		// in site-local time for posts created via the WP API).
-		if ( '' !== $since_ymd ) {
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- no interpolation; prepared statement.
-			$rows = $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT DATE(post_date) AS d, COUNT(*) AS c
-					 FROM {$wpdb->posts}
-					 WHERE post_author = %d AND post_type = 'post' AND post_status = 'publish'
-					   AND DATE(post_date) >= %s
-					 GROUP BY d",
-					$user_id,
-					$since_ymd
-				),
-				ARRAY_A
-			);
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		} else {
-			$rows = $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT DATE(post_date) AS d, COUNT(*) AS c
-					 FROM {$wpdb->posts}
-					 WHERE post_author = %d AND post_type = 'post' AND post_status = 'publish'
-					 GROUP BY d",
-					$user_id
-				),
-				ARRAY_A
-			);
-		}
+		// SELECT the UTC-authoritative column; day computation is centralized
+		// in ec_bucket_utc_events_by_local_day(). A prolific author may have
+		// thousands of rows — that's trivial for PHP bucketing.
+		$rows = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT post_date_gmt
+				 FROM {$wpdb->posts}
+				 WHERE post_author = %d AND post_type = 'post' AND post_status = 'publish'",
+				$user_id
+			)
+		);
 	} finally {
+		// Always restore blog context, even on exception.
 		restore_current_blog();
 	}
 
-	if ( is_array( $rows ) ) {
-		foreach ( $rows as $row ) {
-			$events[] = array(
-				'date'  => (string) $row['d'],
-				'type'  => 'post',
-				'count' => (int) $row['c'],
-			);
-		}
+	if ( ! is_array( $rows ) || empty( $rows ) ) {
+		return $events;
 	}
 
-	return $events;
+	return array_merge( $events, ec_bucket_utc_events_by_local_day( $rows, 'post', $since_ymd ) );
 }
 add_filter( 'ec_contribution_events', 'ec_users_main_posts_contribution_events', 10, 3 );

--- a/inc/rank-system/points-engine.php
+++ b/inc/rank-system/points-engine.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Points Engine — network-wide rank points compute + cache.
+ *
+ * This is the canonical points engine for the Extra Chill Platform. It was
+ * promoted from extrachill-community (see #165) so that rank/points — a
+ * per-user, network-wide concept — lives in extrachill-users (Network: true),
+ * the single source of truth for user primitives, alongside the rank tiers it
+ * already owns (rank-tiers.php).
+ *
+ * The engine is source-agnostic: it sums point contributions from registered
+ * sources via the `ec_points_sources` filter, plus the legacy additive
+ * `ec_rank_extra_points` filter. It contains NO knowledge of bbPress, forums,
+ * or any feature-plugin's content model — feature plugins contribute their own
+ * sources through the filters. Main-site published posts are a network-level
+ * concern and are contributed by this engine itself as a built-in source.
+ *
+ * Storage conventions (PRESERVED from the community-era engine — do not rename):
+ *   - User meta key: `extrachill_total_points` (read by rank-tiers.php + leaderboard sorting)
+ *   - Total transient: `user_points_{id}` (1-hour TTL)
+ *
+ * @package ExtraChill\Users
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Calculate total rank points for a user across all registered sources.
+ *
+ * Sums contributions from the `ec_points_sources` registry filter and the
+ * `ec_rank_extra_points` additive filter, then caches the total. Storage
+ * conventions (`extrachill_total_points` meta, `user_points_{id}` transient,
+ * 1-hour TTL) are preserved for leaderboard sorting and rank-tier resolution.
+ *
+ * @param int $user_id WordPress user ID.
+ * @return float Total calculated points.
+ */
+function extrachill_get_user_total_points( $user_id ) {
+	// Serve from the total-points transient when present.
+	$cached = get_transient( 'user_points_' . $user_id );
+	if ( false !== $cached ) {
+		// Keep meta in sync (mirrors the original engine behaviour).
+		update_user_meta( $user_id, 'extrachill_total_points', $cached );
+		return (float) $cached;
+	}
+
+	/**
+	 * Register a point source's scalar contribution.
+	 *
+	 * Each contributor returns an associative array of source-id => points
+	 * (float|int). The engine sums all values. Source ids are opaque to the
+	 * engine (used for debugging/display); the engine never inspects them.
+	 *
+	 * Built-in source contributed by this engine:
+	 *   - `main_posts`: published posts on the main site (x10 each)
+	 *
+	 * Feature plugins register their own sources through this filter.
+	 *
+	 * @param array<string,float|int> $sources Source-id => points map.
+	 * @param int                     $user_id WordPress user ID being scored.
+	 */
+	$sources = (array) apply_filters( 'ec_points_sources', array(), (int) $user_id );
+
+	$source_total = 0.0;
+	foreach ( $sources as $points ) {
+		$source_total += (float) $points;
+	}
+
+	/**
+	 * Additive scalar point contributions (legacy seam).
+	 *
+	 * Preserved from the original engine. Concert attendance
+	 * (inc/concert-tracking/rank-points.php) contributes here. New sources
+	 * should prefer the structured `ec_points_sources` registry above.
+	 *
+	 * @param float $extra   Running extra-points total. Default 0.0.
+	 * @param int   $user_id WordPress user ID.
+	 */
+	$extra = (float) apply_filters( 'ec_rank_extra_points', 0.0, (int) $user_id );
+
+	$total = $source_total + $extra;
+
+	set_transient( 'user_points_' . $user_id, $total, HOUR_IN_SECONDS );
+	update_user_meta( $user_id, 'extrachill_total_points', $total );
+
+	return (float) $total;
+}
+
+/**
+ * Built-in source: main-site published posts.
+ *
+ * Contributes 10 points per published `post` on the main site (resolved via
+ * ec_get_blog_id('main')). This is a network-level source owned by the engine
+ * because main-site content is a network concern, not a feature-plugin
+ * concern.
+ *
+ * Hooks `ec_points_sources`.
+ *
+ * @param array $sources Source-id => points map.
+ * @param int   $user_id WordPress user ID.
+ * @return array
+ */
+function ec_users_main_posts_points_source( $sources, $user_id ) {
+	$main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
+	if ( ! $main_blog_id ) {
+		$sources['main_posts'] = 0.0;
+		return $sources;
+	}
+
+	switch_to_blog( $main_blog_id );
+	try {
+		$count = count_user_posts( $user_id, 'post', true );
+	} finally {
+		// Always restore blog context, even if count_user_posts() throws,
+		// to avoid leaking the switched context into the rest of the request.
+		restore_current_blog();
+	}
+
+	$sources['main_posts'] = (float) $count * 10;
+	return $sources;
+}
+add_filter( 'ec_points_sources', 'ec_users_main_posts_points_source', 10, 2 );


### PR DESCRIPTION
## Summary

Promotes the points compute-and-cache engine (`extrachill_get_user_total_points`) from **extrachill-community** into **extrachill-users** (`Network: true`), colocating it with the rank tiers it already owns. This corrects the inverted dependency direction: rank/points is a per-user, network-wide concept whose natural home is the user SoT, not the bbPress-scoped community plugin.

Also adds the **dated-contributions seam** — the foundation for the GitHub-style contribution heatmap ([extrachill-community#147](https://github.com/Extra-Chill/extrachill-community/issues/147), Phase 2).

**Coordinated two-repo change.** The companion community PR is [Extra-Chill/extrachill-community#149](https://github.com/Extra-Chill/extrachill-community/pull/149). Both deploy together on community.extrachill.com — merge them together.

Closes #165.

## What changed

### 1. Promoted engine (`inc/rank-system/points-engine.php`)
- The full compute + cache path now lives in users, next to `rank-tiers.php`.
- **Source-agnostic:** sums contributions from the new `ec_points_sources` registry filter + the existing `ec_rank_extra_points` additive filter. The engine contains zero bbPress knowledge.
- **Main-site posts** (×10) stay in the engine as a built-in source — they are a network-level concern (`switch_to_blog(ec_get_blog_id('main'))`), not a feature-plugin concern. Registered into `ec_points_sources` alongside community's sources.
- **Storage conventions preserved (do not rename):**
  - User meta: `extrachill_total_points` (read by rank-tiers.php + leaderboard sorting)
  - Total transient: `user_points_{id}` (1-hour TTL)

### 2. Source registry design (`ec_points_sources`)
Each contributor returns `array( source_id => float )`. The engine sums all values via `array_sum`. Source ids are opaque to the engine — it never inspects them.

| Source id | Points | Contributed by |
|-----------|--------|----------------|
| `main_posts` | post count × 10 | **this engine** (built-in) |
| `forum_topics` | topic count × 2 | extrachill-community |
| `forum_replies` | reply count × 2 | extrachill-community |
| `forum_upvotes` | upvotes × 0.5 | extrachill-community |
| _(via `ec_rank_extra_points`)_ | shows × 3 | extrachill-users/concerts |

**Total = `array_sum(ec_points_sources)` + `ec_rank_extra_points`** — mathematically identical to the old formula (`(topics+replies)×2 + upvotes×0.5 + main_posts×10 + concerts×3`), just relocated and registry-fied.

### 3. Dated-contributions seam (`ec_contribution_events`)

**Shape:** `apply_filters('ec_contribution_events', array $events, int $user_id, string $since_ymd)` where each event is:
```php
array( 'date' => 'YYYY-MM-DD', 'type' => '<source-key>', 'count' => int )
```

**Why aggregated per-day-per-type (not one row per contribution):** a prolific author may have thousands of contributions. Returning one row per contribution would make the payload and the per-day GROUP BY prohibitively large. Contributors aggregate server-side (`GROUP BY DATE(...)`) and return one row per day+type. The consumer sums `count` per date.

**Timezone:** dates are calendar days in the site timezone (`wp_timezone()` / America/New_York) so day boundaries match how users perceive "today."

| Source | Dated? | Why |
|--------|--------|-----|
| Forum topics + replies | ✅ | `post_date` (site-local) |
| Main-site posts | ✅ | `post_date` via `switch_to_blog` |
| Concert check-ins | ✅ | `created_at` (UTC → site-local via PHP `DateTime`) |
| Upvotes | ❌ | scalar counter, no per-day trail |
| Event submissions | ❌ | no queryable attribution (later phase) |

**Dated contributors in this PR:**
- `inc/rank-system/contribution-events.php` — `ec_get_contribution_events()` aggregator + `ec_bucket_utc_events_by_local_day()` helper + main-posts dated contributor
- `inc/concert-tracking/contribution-events.php` — concert check-in dated contributor
- `ec_users_get_user_dated_event_checks()` — getter in `service.php` (returns raw UTC `created_at` strings)

### 3a. Timezone handling (v2) — single-helper contract

All timezone normalization is hoisted into **one** shared helper: `ec_bucket_utc_events_by_local_day()`. Every dated contributor now does the same thing — SELECT the **UTC-authoritative** timestamp column and delegate day computation to the helper. No contributor reasons about timezones.

| Source | UTC column read | Day computation |
|--------|----------------|-----------------|
| Main-site posts | `post_date_gmt` | `ec_bucket_utc_events_by_local_day()` |
| Concert check-ins | `created_at` | `ec_bucket_utc_events_by_local_day()` |
| Forum topics + replies | `post_date_gmt` | `ec_bucket_utc_events_by_local_day()` (in community, guarded) |

**Why this replaced the v1 approach:** v1 had each source compute its own day — `DATE(post_date)` for posts (relied on the drift-prone local column), bespoke PHP bucketing for concerts, SQL `GROUP BY DATE(post_date)` for forums. Correctness was unprovable at review time and inconsistent on `since_ymd` (SQL-filtered in some sources, PHP-backstop in others). v2 reads only UTC columns and funnels everything through one helper — provably consistent, and `since_ymd` is handled uniformly for every source.

### 4. Layer purity (non-negotiable)
```
$ grep -riE 'bbp_|topic|reply|upvote' inc/rank-system/points-engine.php inc/rank-system/contribution-events.php inc/concert-tracking/contribution-events.php
(exit 1 — no matches)
```
The engine knows nothing about bbPress. Forum sources live entirely in community's `points-sources.php`.

## Verification
- [x] `php -l` clean on every edited/created file
- [x] Layer-purity grep returns nothing (see above)
- [x] `extrachill_total_points` meta key + `user_points_{id}` transient preserved (grep confirmed in both repos)
- [x] All callers resolve: leaderboard template, user-details profile, rank abilities, spam detection all reach their functions (engine in users, display in community)
- [x] No new DB tables
- [x] No changed point weights or tier thresholds
- [x] Point totals mathematically identical before/after

## Do NOT merge without the companion community PR
[Extra-Chill/extrachill-community#149](https://github.com/Extra-Chill/extrachill-community/pull/149) must merge together with this PR. Neither repo ships a broken intermediate on its own.
