### PR TITLE
feat: ec_get_network_bot_user_id() helper + create-user role/unclaimed inputs (#207)

### DIFF
--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -109,6 +109,7 @@ function extrachill_users_init() {
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/online-users.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/last-login.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/user-creation.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/network-bot-user.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/registration-emails.php';
 
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/auth/login.php';

--- a/inc/core/abilities/create-user.php
+++ b/inc/core/abilities/create-user.php
@@ -54,6 +54,14 @@ function extrachill_users_register_create_user_ability() {
 						'type'        => 'string',
 						'description' => __( 'Method label (e.g. standard, google).', 'extrachill-users' ),
 					),
+					'role'                => array(
+						'type'        => 'string',
+						'description' => __( 'Role to assign on the community blog (e.g. subscriber). Defaults to the blog default_role when empty.', 'extrachill-users' ),
+					),
+					'unclaimed'           => array(
+						'type'        => 'boolean',
+						'description' => __( 'Mark the account unclaimed (ec_unclaimed=1) so it cannot be logged into until the user sets their password. Used by attribution-on-submission flows that create an account on a user\'s behalf.', 'extrachill-users' ),
+					),
 					'referrer'            => array(
 						'type'        => 'string',
 						'description' => __( 'External referrer URL captured at registration (last-touch attribution). Optional.', 'extrachill-users' ),
@@ -142,6 +150,8 @@ function extrachill_users_ability_create_user( $input ) {
 	$registration_page   = isset( $input['registration_page'] ) ? $input['registration_page'] : '';
 	$registration_source = isset( $input['registration_source'] ) ? $input['registration_source'] : '';
 	$registration_method = isset( $input['registration_method'] ) ? $input['registration_method'] : '';
+	$role                = isset( $input['role'] ) ? sanitize_text_field( (string) $input['role'] ) : '';
+	$unclaimed           = ! empty( $input['unclaimed'] );
 	$referrer            = isset( $input['referrer'] ) ? esc_url_raw( (string) $input['referrer'] ) : '';
 	$utm                 = extrachill_users_sanitize_utm( isset( $input['utm'] ) ? $input['utm'] : array() );
 
@@ -172,6 +182,24 @@ function extrachill_users_ability_create_user( $input ) {
 
 		if ( ! empty( $registration_method ) ) {
 			update_user_meta( $user_id, 'registration_method', sanitize_text_field( (string) $registration_method ) );
+		}
+
+		// Explicit role override. wp_create_user() assigns the blog default_role
+		// (subscriber on the community blog); callers that need a specific role —
+		// e.g. event-submission attribution creating a locked subscriber account —
+		// pass `role` to pin it. Runs in the switched (community) context so the
+		// role lands on the right blog's capabilities meta.
+		if ( ! empty( $role ) ) {
+			$user = new WP_User( $user_id );
+			$user->set_role( $role );
+		}
+
+		// Unclaimed flag: accounts created on a user's behalf (e.g. an anonymous
+		// event submitter) are subscriber-role and flagged ec_unclaimed=1 until
+		// the user sets their password via the claim link, so the account can't
+		// be logged into before the rightful owner claims it.
+		if ( $unclaimed ) {
+			update_user_meta( $user_id, 'ec_unclaimed', 1 );
 		}
 
 		// Source attribution (last-touch): persist the external referrer and any

--- a/inc/core/network-bot-user.php
+++ b/inc/core/network-bot-user.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Network Bot User
+ *
+ * Config-driven source of truth for the platform "bot" account — the user that
+ * genuine Data Machine automation (scheduled scrapes, non-submission pipelines)
+ * is attributed to so authorship stays honest at the source.
+ *
+ * This helper exists so the bot id is config-over-code: callers resolve it
+ * through {@see ec_get_network_bot_user_id()} (or its filter) instead of
+ * scattering a magic `32` literal across plugins (layer purity / config over
+ * code per the site RULES).
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Default user ID of the network automation bot account.
+ *
+ * "Extra Chill" (login "Extra Chill Staff"), historically uid 32. Exposed as a
+ * constant so the default is itself not a bare literal at call sites.
+ */
+if ( ! defined( 'EXTRACHILL_NETWORK_BOT_USER_ID_DEFAULT' ) ) {
+	define( 'EXTRACHILL_NETWORK_BOT_USER_ID_DEFAULT', 32 );
+}
+
+/**
+ * Get the network bot user ID — the honest author for automation.
+ *
+ * The value is filterable via `extrachill_network_bot_user_id` so deployments
+ * can override it without editing code, and so tests can stub it. The default
+ * is {@see EXTRACHILL_NETWORK_BOT_USER_ID_DEFAULT} (32).
+ *
+ * Consumers (event/wire upsert author resolution, authorship backfills, points
+ * engines) should call this rather than hardcoding the id, so a future bot-id
+ * change is a single config/filter edit instead of a plugin-wide find/replace.
+ *
+ * @return int The bot user ID (filtered). 0 if filtered to an empty/falsey value.
+ */
+function ec_get_network_bot_user_id() {
+	/**
+	 * Filter the network automation bot user ID.
+	 *
+	 * @param int $bot_user_id Default bot user ID (32).
+	 */
+	return (int) apply_filters( 'extrachill_network_bot_user_id', EXTRACHILL_NETWORK_BOT_USER_ID_DEFAULT );
+}


### PR DESCRIPTION
Part of **honest content authorship at the source** — extrachill-events#207 (Phase 2 foundation + Phase 1 account-creation glue).

## What this adds

### `ec_get_network_bot_user_id()` — config-driven bot account id
New `inc/core/network-bot-user.php`. The single source of truth for the platform automation bot account ("Extra Chill", uid 32), filterable via `extrachill_network_bot_user_id` (default `EXTRACHILL_NETWORK_BOT_USER_ID_DEFAULT` = 32). Consumers (event/wire author resolution, authorship backfill) call this instead of scattering a magic `32` literal across plugins — **config over code / layer purity** per the site RULES.

### `extrachill/create-user` ability — `role` + `unclaimed` inputs
Two optional inputs so attribution-on-submission flows (Phase 1) can create a locked subscriber account on a user's behalf:
- `role` — explicitly pins the community-blog role (used to force `subscriber`).
- `unclaimed` (bool) — sets `ec_unclaimed=1` user meta. Combined with the random password the caller generates, the account can't be logged into until the user claims it via the set-password link. The flag is forward-looking metadata for future login-blocking / cleanup enforcement.

## Why here
This is the foundation layer: the bot-id helper and the account-creation primitive both belong in extrachill-users. The two sibling PRs consume them:
- **data-machine-events** → `resolvePostAuthor()` automation default via `ec_get_network_bot_user_id()`.
- **extrachill-events** → Phase 1 anonymous-submitter account creation via the ability; Phase 3 backfill via the helper.

## Verified
- `php -l` clean on all touched files.
- Helper resolves to 32 live; backfill dry-run (extrachill-events PR) consumes it end-to-end.
- Additive only — no existing callers change.

## Cross-linked PRs
- data-machine-events: _linked below_
- extrachill-events: _linked below_

Conventional commits. No CHANGELOG / version bumps (homeboy owns those).