### PR TITLE
feat: add auto-subscribe-to-replies notification preference

### DIFF
--- a/inc/core/abilities/notifications.php
+++ b/inc/core/abilities/notifications.php
@@ -221,10 +221,14 @@ function extrachill_users_register_notification_abilities() {
 			'output_schema'       => array(
 				'type'       => 'object',
 				'properties' => array(
-					'user_id'        => array( 'type' => 'integer' ),
-					'emails_enabled' => array(
+					'user_id'               => array( 'type' => 'integer' ),
+					'emails_enabled'        => array(
 						'type'        => 'boolean',
 						'description' => 'True when the user receives unread-notification digest emails.',
+					),
+					'auto_subscribe_replies' => array(
+						'type'        => 'boolean',
+						'description' => 'True when the user is auto-subscribed to replies on content they participate in.',
 					),
 				),
 			),
@@ -256,13 +260,18 @@ function extrachill_users_register_notification_abilities() {
 						'type'        => 'boolean',
 						'description' => 'Set true to receive unread-notification digest emails, false to opt out.',
 					),
+					'auto_subscribe_replies' => array(
+						'type'        => 'boolean',
+						'description' => 'Set true to be auto-subscribed to replies on content you participate in, false to opt out.',
+					),
 				),
 			),
 			'output_schema'       => array(
 				'type'       => 'object',
 				'properties' => array(
-					'user_id'        => array( 'type' => 'integer' ),
-					'emails_enabled' => array( 'type' => 'boolean' ),
+					'user_id'                => array( 'type' => 'integer' ),
+					'emails_enabled'         => array( 'type' => 'boolean' ),
+					'auto_subscribe_replies' => array( 'type' => 'boolean' ),
 				),
 			),
 			'execute_callback'    => 'extrachill_users_ability_update_notification_preferences',
@@ -398,8 +407,9 @@ function extrachill_users_ability_get_notification_preferences() {
 	}
 
 	return array(
-		'user_id'        => $user_id,
-		'emails_enabled' => ec_users_notification_emails_enabled( $user_id ),
+		'user_id'                => $user_id,
+		'emails_enabled'         => ec_users_notification_emails_enabled( $user_id ),
+		'auto_subscribe_replies' => ec_users_auto_subscribe_enabled( $user_id ),
 	);
 }
 
@@ -425,8 +435,14 @@ function extrachill_users_ability_update_notification_preferences( array $input 
 		ec_users_set_notification_emails_disabled( $user_id, ! $emails_enabled );
 	}
 
+	if ( array_key_exists( 'auto_subscribe_replies', $input ) ) {
+		$enabled = filter_var( $input['auto_subscribe_replies'], FILTER_VALIDATE_BOOLEAN );
+		ec_users_set_auto_subscribe_disabled( $user_id, ! $enabled );
+	}
+
 	return array(
-		'user_id'        => $user_id,
-		'emails_enabled' => ec_users_notification_emails_enabled( $user_id ),
+		'user_id'                => $user_id,
+		'emails_enabled'         => ec_users_notification_emails_enabled( $user_id ),
+		'auto_subscribe_replies' => ec_users_auto_subscribe_enabled( $user_id ),
 	);
 }

--- a/inc/notifications/email.php
+++ b/inc/notifications/email.php
@@ -88,6 +88,15 @@ const EC_NOTIFICATIONS_LAST_EMAILED_META = 'ec_notifications_last_emailed';
 const EC_NOTIFICATIONS_EMAILS_DISABLED_META = 'ec_notification_emails_disabled';
 
 /**
+ * User_meta opt-out flag for the auto-subscribe-to-replies preference.
+ *
+ * Truthy value == this user does NOT want to be auto-subscribed to replies on
+ * content they participate in. Absent/falsy == opted-in (default ON), matching
+ * the inversion the digest toggle uses.
+ */
+const EC_AUTO_SUBSCRIBE_REPLIES_DISABLED_META = 'ec_auto_subscribe_replies_disabled';
+
+/**
  * Cron hook for the recurring digest run.
  */
 const EC_NOTIFICATIONS_EMAIL_CRON_HOOK = 'ec_notifications_email_digest';
@@ -351,6 +360,60 @@ function ec_users_set_notification_emails_disabled( $user_id, $disabled ) {
  */
 function ec_users_notification_emails_enabled( $user_id ) {
 	return ! ec_notifications_email_user_opted_out( $user_id );
+}
+
+/**
+ * Has the user opted out of being auto-subscribed to replies?
+ *
+ * Default is OFF (opted-in). Any truthy value on the opt-out meta == disabled.
+ *
+ * @param int $user_id User ID.
+ * @return bool True if the user should NOT be auto-subscribed to replies.
+ */
+function ec_auto_subscribe_replies_user_opted_out( $user_id ) {
+	return (bool) get_user_meta( (int) $user_id, EC_AUTO_SUBSCRIBE_REPLIES_DISABLED_META, true );
+}
+
+/**
+ * Canonical setter for the auto-subscribe-to-replies opt-out flag.
+ *
+ * THE single source of truth for writing ec_auto_subscribe_replies_disabled.
+ * Mirrors ec_users_set_notification_emails_disabled(): enabling removes the
+ * flag entirely (so the default "opted-in" state is the absence of the meta),
+ * keeping ec_auto_subscribe_replies_user_opted_out() simple.
+ *
+ * @param int  $user_id  User ID.
+ * @param bool $disabled True to DISABLE auto-subscribe, false to enable.
+ * @return bool True on success, false on an invalid user.
+ */
+function ec_users_set_auto_subscribe_disabled( $user_id, $disabled ) {
+	$user_id = (int) $user_id;
+	if ( $user_id <= 0 ) {
+		return false;
+	}
+
+	if ( $disabled ) {
+		update_user_meta( $user_id, EC_AUTO_SUBSCRIBE_REPLIES_DISABLED_META, 1 );
+		return true;
+	}
+
+	// Enabling = remove the flag so the opted-out check is false (default ON).
+	delete_user_meta( $user_id, EC_AUTO_SUBSCRIBE_REPLIES_DISABLED_META );
+	return true;
+}
+
+/**
+ * Whether auto-subscribe-to-replies is ENABLED for a user.
+ *
+ * User-facing sense: true == the user gets auto-subscribed to replies on
+ * content they participate in. Derived from the inverted internal DISABLED
+ * flag. The settings UI binds its toggle to this.
+ *
+ * @param int $user_id User ID.
+ * @return bool
+ */
+function ec_users_auto_subscribe_enabled( $user_id ) {
+	return ! ec_auto_subscribe_replies_user_opted_out( $user_id );
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a **second notification preference** (`auto_subscribe_replies`, default ON) alongside the existing `emails_enabled` digest opt-out, using the **exact same inverted-meta storage pattern** — no new abilities, no new storage mechanism.

Closes #168. This is **Phase 1** of bridging bbPress topic subscriptions into the `extrachill-users` notification system and unblocks the `extrachill-community` producer + settings-tab work.

## What changed

**`inc/notifications/email.php`** — new setter/getter pair mirroring `ec_users_set_notification_emails_disabled()` / `ec_users_notification_emails_enabled()`:
- New const `EC_AUTO_SUBSCRIBE_REPLIES_DISABLED_META = 'ec_auto_subscribe_replies_disabled'` (sibling of the existing `EC_NOTIFICATIONS_EMAILS_DISABLED_META`).
- `ec_auto_subscribe_replies_user_opted_out( $user_id )` — internal opt-out check (mirrors `ec_notifications_email_user_opted_out()`).
- `ec_users_set_auto_subscribe_disabled( $user_id, $disabled )` — **the** canonical setter. `update_user_meta` when disabling, `delete_user_meta` when enabling (so the default "opted-in" state is the absence of the meta).
- `ec_users_auto_subscribe_enabled( $user_id )` — user-facing getter, `! (bool) get_user_meta( ..., true )`.

**`inc/core/abilities/notifications.php`** — extends the two existing self-only abilities (no new abilities created):
- `extrachill/get-notification-preferences`: added `auto_subscribe_replies` (boolean) to `output_schema`; returned it from the callback.
- `extrachill/update-notification-preferences`: added `auto_subscribe_replies` (boolean) to **both** `input_schema` and `output_schema`; handle it right after the existing `emails_enabled` block via the canonical setter:
  ```php
  if ( array_key_exists( 'auto_subscribe_replies', $input ) ) {
      $enabled = filter_var( $input['auto_subscribe_replies'], FILTER_VALIDATE_BOOLEAN );
      ec_users_set_auto_subscribe_disabled( $user_id, ! $enabled );
  }
  ```

## Verification

- `php -l` clean on both edited files.
- Confirmed via grep that both `emails_enabled` and `auto_subscribe_replies` appear in the get output_schema, the update input_schema, and the update output_schema.

## Acceptance (from #168)

- `ec_users_auto_subscribe_enabled( <uid> )` returns `true` for a user with no meta (default ON) — the getter returns `! (bool) get_user_meta( ... )`, which is `! false === true`.
- `get-notification-preferences` now returns both `emails_enabled` and `auto_subscribe_replies`.
- `update-notification-preferences` with `{ "auto_subscribe_replies": false }` persists the disabled flag via the canonical setter.

## Constraints honored

- Conventional commit (`feat:`). CHANGELOG.md untouched, version string untouched (homeboy owns both).
- No new abilities, no new storage mechanism, no new REST surface — extends the existing pair.
- Both abilities remain self-only.
- PR only — not merged, released, or deployed.