### PR TITLE
feat: own user administration abilities

### DIFF
--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -103,6 +103,7 @@ function extrachill_users_init() {
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/assets.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/gating.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/feature-rollout-admin.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/artist-access-admin.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/admin-access-control.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/moderation/bootstrap.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/abilities/register.php';

--- a/inc/core/abilities/artist-access.php
+++ b/inc/core/abilities/artist-access.php
@@ -366,7 +366,7 @@ function extrachill_users_send_artist_access_request_email( $user_id, $user, $ac
 		);
 	}
 
-	$admin_tools_url = admin_url( 'tools.php?page=extrachill-admin-tools#artist-access-requests' );
+	$admin_tools_url = network_admin_url( 'admin.php?page=extrachill-artist-access' );
 
 	$subject = sprintf(
 		/* translators: %s: user display name */

--- a/inc/core/abilities/register.php
+++ b/inc/core/abilities/register.php
@@ -69,6 +69,7 @@ require_once __DIR__ . '/onboarding.php';
 require_once __DIR__ . '/moderation.php';
 require_once __DIR__ . '/welcome-email.php';
 require_once __DIR__ . '/artist-access.php';
+require_once __DIR__ . '/user-administration.php';
 require_once __DIR__ . '/user-settings.php';
 require_once __DIR__ . '/user-profile.php';
 require_once __DIR__ . '/subscriptions.php';

--- a/inc/core/abilities/user-administration.php
+++ b/inc/core/abilities/user-administration.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * Network user administration abilities.
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_users_register_user_administration_abilities' );
+
+/**
+ * Register abilities formerly supplied by the Admin Tools umbrella.
+ *
+ * Existing registrations win during the transition so this plugin can be
+ * deployed before Admin Tools is removed without duplicate registrations.
+ */
+function extrachill_users_register_user_administration_abilities() {
+	$abilities = array(
+		'extrachill/grant-lifetime-membership'  => array(
+			'label'            => __( 'Grant Lifetime Membership', 'extrachill-users' ),
+			'description'      => __( 'Grant lifetime ad-free membership to a user by username or email.', 'extrachill-users' ),
+			'input_schema'     => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_identifier' => array(
+						'type'        => 'string',
+						'description' => __( 'Username or email address.', 'extrachill-users' ),
+					),
+				),
+				'required'   => array( 'user_identifier' ),
+			),
+			'output_schema'    => array(
+				'type'        => 'object',
+				'description' => __( 'Grant confirmation with user details.', 'extrachill-users' ),
+			),
+			'execute_callback' => 'extrachill_users_ability_grant_lifetime_membership',
+			'annotations'      => array(
+				'readonly'    => false,
+				'idempotent'  => true,
+				'destructive' => false,
+			),
+		),
+		'extrachill/revoke-lifetime-membership' => array(
+			'label'            => __( 'Revoke Lifetime Membership', 'extrachill-users' ),
+			'description'      => __( 'Revoke lifetime membership from a user.', 'extrachill-users' ),
+			'input_schema'     => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'User ID to revoke membership from.', 'extrachill-users' ),
+					),
+				),
+				'required'   => array( 'user_id' ),
+			),
+			'output_schema'    => array(
+				'type'        => 'object',
+				'description' => __( 'Revoke confirmation.', 'extrachill-users' ),
+			),
+			'execute_callback' => 'extrachill_users_ability_revoke_lifetime_membership',
+			'annotations'      => array(
+				'readonly'    => false,
+				'idempotent'  => true,
+				'destructive' => true,
+			),
+		),
+		'extrachill/sync-team-members'          => array(
+			'label'            => __( 'Sync Team Members', 'extrachill-users' ),
+			'description'      => __( 'Sync team member status for all network users based on current role assignments.', 'extrachill-users' ),
+			'input_schema'     => array(
+				'type'       => 'object',
+				'properties' => array(),
+			),
+			'output_schema'    => array(
+				'type'        => 'object',
+				'description' => __( 'Sync report with updated site counts.', 'extrachill-users' ),
+			),
+			'execute_callback' => 'extrachill_users_ability_sync_team_members',
+			'annotations'      => array(
+				'readonly'    => false,
+				'idempotent'  => true,
+				'destructive' => false,
+			),
+		),
+		'extrachill/manage-team-member'         => array(
+			'label'            => __( 'Manage Team Member', 'extrachill-users' ),
+			'description'      => __( 'Grant or revoke the extra_chill_team WordPress role for a user, network-wide.', 'extrachill-users' ),
+			'input_schema'     => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'User ID to manage.', 'extrachill-users' ),
+					),
+					'action'  => array(
+						'type'        => 'string',
+						'description' => __( 'Action to take: force_add to grant the role, force_remove to revoke it.', 'extrachill-users' ),
+						'enum'        => array( 'force_add', 'force_remove' ),
+					),
+				),
+				'required'   => array( 'user_id', 'action' ),
+			),
+			'output_schema'    => array(
+				'type'        => 'object',
+				'description' => __( 'Updated team member status.', 'extrachill-users' ),
+			),
+			'execute_callback' => 'extrachill_users_ability_manage_team_member',
+			'annotations'      => array(
+				'readonly'    => false,
+				'idempotent'  => true,
+				'destructive' => false,
+			),
+		),
+	);
+
+	foreach ( $abilities as $name => $definition ) {
+		if ( wp_get_ability( $name ) ) {
+			continue;
+		}
+
+		wp_register_ability(
+			$name,
+			array(
+				'label'               => $definition['label'],
+				'description'         => $definition['description'],
+				'category'            => 'extrachill-users',
+				'input_schema'        => $definition['input_schema'],
+				'output_schema'       => $definition['output_schema'],
+				'execute_callback'    => $definition['execute_callback'],
+				'permission_callback' => 'extrachill_users_user_administration_permission',
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => $definition['annotations'],
+				),
+			)
+		);
+	}
+}
+
+/**
+ * Preserve network-admin, CLI, and scheduled automation access.
+ *
+ * @return bool
+ */
+function extrachill_users_user_administration_permission() {
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		return true;
+	}
+
+	if ( class_exists( 'ActionScheduler' ) && did_action( 'action_scheduler_before_execute' ) ) {
+		return true;
+	}
+
+	return current_user_can( 'manage_network_options' );
+}
+
+/**
+ * Grant lifetime membership by username or email.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_grant_lifetime_membership( $input ) {
+	$identifier = isset( $input['user_identifier'] ) ? sanitize_text_field( $input['user_identifier'] ) : '';
+	$user       = is_email( $identifier ) ? get_user_by( 'email', $identifier ) : get_user_by( 'login', $identifier );
+
+	if ( ! $user ) {
+		return new WP_Error( 'user_not_found', 'User not found.', array( 'status' => 404 ) );
+	}
+
+	$existing = get_user_meta( $user->ID, 'extrachill_lifetime_membership', true );
+	if ( empty( $existing ) ) {
+		$result = ec_create_lifetime_membership( $user->user_login );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+	}
+
+	return array(
+		'success'    => true,
+		'message'    => 'Lifetime membership granted.',
+		'user_id'    => $user->ID,
+		'user_login' => $user->user_login,
+		'user_email' => $user->user_email,
+	);
+}
+
+/**
+ * Revoke lifetime membership from a user.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_revoke_lifetime_membership( $input ) {
+	$user_id = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : 0;
+	$user    = $user_id ? get_user_by( 'id', $user_id ) : false;
+
+	if ( ! $user ) {
+		return new WP_Error( 'user_not_found', 'User not found.', array( 'status' => 404 ) );
+	}
+
+	delete_user_meta( $user_id, 'extrachill_lifetime_membership' );
+
+	return array(
+		'success'    => true,
+		'message'    => 'Lifetime membership revoked.',
+		'user_id'    => $user_id,
+		'user_login' => $user->user_login,
+	);
+}
+
+/**
+ * Re-grant current team roles across every network site.
+ *
+ * @return array
+ */
+function extrachill_users_ability_sync_team_members() {
+	$team_user_ids   = extrachill_users_get_current_team_user_ids();
+	$sites_processed = 0;
+
+	foreach ( $team_user_ids as $user_id ) {
+		$sites_processed += count( ec_users_grant_team_role( $user_id ) );
+	}
+
+	return array(
+		'total_team_users' => count( $team_user_ids ),
+		'sites_processed'  => $sites_processed,
+	);
+}
+
+/**
+ * Grant or revoke the team role for one user.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_manage_team_member( $input ) {
+	$user_id = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : 0;
+	$action  = isset( $input['action'] ) ? (string) $input['action'] : '';
+
+	if ( ! $user_id ) {
+		return new WP_Error( 'invalid_user_id', 'A positive user_id is required.', array( 'status' => 400 ) );
+	}
+	if ( ! get_user_by( 'id', $user_id ) ) {
+		return new WP_Error( 'user_not_found', sprintf( 'User %d not found.', $user_id ), array( 'status' => 404 ) );
+	}
+
+	if ( 'force_add' === $action ) {
+		$sites = ec_users_grant_team_role( $user_id );
+		return array(
+			'message'        => sprintf( 'Team role granted on %d site(s).', count( $sites ) ),
+			'user_id'        => $user_id,
+			'is_team_member' => true,
+			'sites_added'    => $sites,
+		);
+	}
+	if ( 'force_remove' === $action ) {
+		$sites = ec_users_revoke_team_role( $user_id );
+		return array(
+			'message'        => sprintf( 'Team role revoked on %d site(s).', count( $sites ) ),
+			'user_id'        => $user_id,
+			'is_team_member' => false,
+			'sites_removed'  => $sites,
+		);
+	}
+
+	return new WP_Error( 'invalid_action', sprintf( 'Unknown action: %s. Expected force_add or force_remove.', $action ), array( 'status' => 400 ) );
+}
+
+/**
+ * Find users holding the team role on any network site.
+ *
+ * @return int[]
+ */
+function extrachill_users_get_current_team_user_ids() {
+	global $wpdb;
+
+	$ids = array();
+	foreach ( ec_users_get_network_site_ids() as $blog_id ) {
+		$caps_key = $wpdb->get_blog_prefix( (int) $blog_id ) . 'capabilities';
+		$user_ids = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- One-off network role synchronization requires an uncached cross-site role lookup.
+			$wpdb->prepare(
+				"SELECT user_id FROM {$wpdb->usermeta} WHERE meta_key = %s AND meta_value LIKE %s",
+				$caps_key,
+				'%' . $wpdb->esc_like( EC_USERS_TEAM_ROLE ) . '%'
+			)
+		);
+		foreach ( (array) $user_ids as $user_id ) {
+			$ids[ (int) $user_id ] = true;
+		}
+	}
+
+	return array_keys( $ids );
+}

--- a/inc/core/artist-access-admin.php
+++ b/inc/core/artist-access-admin.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Focused network administration for artist access requests.
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'network_admin_menu', 'extrachill_users_add_artist_access_menu' );
+add_action( 'network_admin_edit_extrachill_artist_access', 'extrachill_users_handle_artist_access_action' );
+
+/**
+ * Add the owner-native artist access page.
+ */
+function extrachill_users_add_artist_access_menu() {
+	$parent = defined( 'EXTRACHILL_NETWORK_MENU_SLUG' ) ? EXTRACHILL_NETWORK_MENU_SLUG : 'settings.php';
+
+	add_submenu_page(
+		$parent,
+		__( 'Artist Access', 'extrachill-users' ),
+		__( 'Artist Access', 'extrachill-users' ),
+		'manage_network_options',
+		'extrachill-artist-access',
+		'extrachill_users_render_artist_access_page'
+	);
+}
+
+/**
+ * Process an approval or rejection from the network-admin page.
+ */
+function extrachill_users_handle_artist_access_action() {
+	if ( ! current_user_can( 'manage_network_options' ) ) {
+		wp_die( esc_html__( 'You do not have permission to manage artist access.', 'extrachill-users' ) );
+	}
+
+	check_admin_referer( 'extrachill_artist_access_action' );
+
+	$user_id = isset( $_POST['user_id'] ) ? absint( $_POST['user_id'] ) : 0;
+	$action  = isset( $_POST['request_action'] ) ? sanitize_key( wp_unslash( $_POST['request_action'] ) ) : '';
+	$type    = isset( $_POST['type'] ) ? sanitize_key( wp_unslash( $_POST['type'] ) ) : '';
+	$ability = wp_get_ability( 'approve' === $action ? 'extrachill/approve-artist-access' : 'extrachill/reject-artist-access' );
+	$result  = $ability ? $ability->execute(
+		'approve' === $action ? array(
+			'user_id' => $user_id,
+			'type'    => $type,
+		) : array( 'user_id' => $user_id )
+	) : new WP_Error( 'ability_not_found', 'Artist access ability is unavailable.' );
+
+	$redirect = add_query_arg(
+		array(
+			'page'   => 'extrachill-artist-access',
+			'status' => is_wp_error( $result ) ? 'error' : 'updated',
+		),
+		network_admin_url( 'admin.php' )
+	);
+	wp_safe_redirect( $redirect );
+	exit;
+}
+
+/**
+ * Render pending artist access requests.
+ */
+function extrachill_users_render_artist_access_page() {
+	if ( ! current_user_can( 'manage_network_options' ) ) {
+		wp_die( esc_html__( 'You do not have permission to manage artist access.', 'extrachill-users' ) );
+	}
+
+	$ability  = wp_get_ability( 'extrachill/list-artist-access-requests' );
+	$result   = $ability ? $ability->execute( array() ) : array( 'requests' => array() );
+	$requests = ! is_wp_error( $result ) && isset( $result['requests'] ) ? $result['requests'] : array();
+	?>
+	<div class="wrap">
+		<h1><?php esc_html_e( 'Artist Access Requests', 'extrachill-users' ); ?></h1>
+		<?php if ( isset( $_GET['status'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display-only redirect flag. ?>
+			<div class="notice notice-<?php echo 'updated' === $_GET['status'] ? 'success' : 'error'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display-only redirect flag. ?> is-dismissible"><p><?php esc_html_e( 'Artist access request processed.', 'extrachill-users' ); ?></p></div>
+		<?php endif; ?>
+		<?php if ( empty( $requests ) ) : ?>
+			<p><?php esc_html_e( 'No pending artist access requests.', 'extrachill-users' ); ?></p>
+		<?php else : ?>
+			<table class="widefat striped">
+				<thead><tr><th><?php esc_html_e( 'User', 'extrachill-users' ); ?></th><th><?php esc_html_e( 'Email', 'extrachill-users' ); ?></th><th><?php esc_html_e( 'Type', 'extrachill-users' ); ?></th><th><?php esc_html_e( 'Actions', 'extrachill-users' ); ?></th></tr></thead>
+				<tbody>
+				<?php foreach ( $requests as $request ) : ?>
+					<tr>
+						<td><?php echo esc_html( $request['user_login'] ); ?></td>
+						<td><?php echo esc_html( $request['user_email'] ); ?></td>
+						<td><?php echo esc_html( $request['type'] ); ?></td>
+						<td>
+							<form method="post" action="<?php echo esc_url( network_admin_url( 'edit.php?action=extrachill_artist_access' ) ); ?>" style="display:inline">
+								<?php wp_nonce_field( 'extrachill_artist_access_action' ); ?>
+								<input type="hidden" name="user_id" value="<?php echo esc_attr( $request['user_id'] ); ?>">
+								<input type="hidden" name="type" value="<?php echo esc_attr( $request['type'] ); ?>">
+								<button class="button button-primary" name="request_action" value="approve"><?php esc_html_e( 'Approve', 'extrachill-users' ); ?></button>
+								<button class="button" name="request_action" value="reject"><?php esc_html_e( 'Reject', 'extrachill-users' ); ?></button>
+							</form>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+				</tbody>
+			</table>
+		<?php endif; ?>
+	</div>
+	<?php
+}

--- a/inc/core/artist-access-admin.php
+++ b/inc/core/artist-access-admin.php
@@ -39,6 +39,10 @@ function extrachill_users_handle_artist_access_action() {
 	$user_id = isset( $_POST['user_id'] ) ? absint( $_POST['user_id'] ) : 0;
 	$action  = isset( $_POST['request_action'] ) ? sanitize_key( wp_unslash( $_POST['request_action'] ) ) : '';
 	$type    = isset( $_POST['type'] ) ? sanitize_key( wp_unslash( $_POST['type'] ) ) : '';
+	if ( ! in_array( $action, array( 'approve', 'reject' ), true ) ) {
+		wp_die( esc_html__( 'Invalid artist access action.', 'extrachill-users' ) );
+	}
+
 	$ability = wp_get_ability( 'approve' === $action ? 'extrachill/approve-artist-access' : 'extrachill/reject-artist-access' );
 	$result  = $ability ? $ability->execute(
 		'approve' === $action ? array(
@@ -69,11 +73,12 @@ function extrachill_users_render_artist_access_page() {
 	$ability  = wp_get_ability( 'extrachill/list-artist-access-requests' );
 	$result   = $ability ? $ability->execute( array() ) : array( 'requests' => array() );
 	$requests = ! is_wp_error( $result ) && isset( $result['requests'] ) ? $result['requests'] : array();
+	$status   = isset( $_GET['status'] ) ? sanitize_key( wp_unslash( $_GET['status'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display-only redirect flag.
 	?>
 	<div class="wrap">
 		<h1><?php esc_html_e( 'Artist Access Requests', 'extrachill-users' ); ?></h1>
-		<?php if ( isset( $_GET['status'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display-only redirect flag. ?>
-			<div class="notice notice-<?php echo 'updated' === $_GET['status'] ? 'success' : 'error'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display-only redirect flag. ?> is-dismissible"><p><?php esc_html_e( 'Artist access request processed.', 'extrachill-users' ); ?></p></div>
+		<?php if ( $status ) : ?>
+			<div class="notice notice-<?php echo 'updated' === $status ? 'success' : 'error'; ?> is-dismissible"><p><?php esc_html_e( 'Artist access request processed.', 'extrachill-users' ); ?></p></div>
 		<?php endif; ?>
 		<?php if ( empty( $requests ) ) : ?>
 			<p><?php esc_html_e( 'No pending artist access requests.', 'extrachill-users' ); ?></p>

--- a/tests/unit/UserAdministrationAbilitiesTest.php
+++ b/tests/unit/UserAdministrationAbilitiesTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Tests for owner-native user administration abilities.
+ *
+ * @package ExtraChill\Users
+ */
+
+/**
+ * Verify the abilities retain their user-domain contracts.
+ */
+class Test_User_Administration_Abilities extends WP_UnitTestCase {
+
+	/**
+	 * Load the directly exercised user-domain primitives.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		require_once dirname( __DIR__, 2 ) . '/inc/team-members/role.php';
+		require_once dirname( __DIR__, 2 ) . '/inc/lifetime-membership.php';
+		require_once dirname( __DIR__, 2 ) . '/inc/core/abilities/user-administration.php';
+	}
+
+	/**
+	 * Grant and revoke use the canonical membership meta and stable response keys.
+	 */
+	public function test_grant_and_revoke_lifetime_membership_preserve_response_shape(): void {
+		$user_id = self::factory()->user->create(
+			array(
+				'user_login' => 'lifetime-test',
+				'user_email' => 'lifetime@example.com',
+			)
+		);
+
+		$granted = extrachill_users_ability_grant_lifetime_membership( array( 'user_identifier' => 'lifetime@example.com' ) );
+		$this->assertTrue( $granted['success'] );
+		$this->assertSame( $user_id, $granted['user_id'] );
+		$this->assertNotEmpty( get_user_meta( $user_id, 'extrachill_lifetime_membership', true ) );
+
+		$revoked = extrachill_users_ability_revoke_lifetime_membership( array( 'user_id' => $user_id ) );
+		$this->assertTrue( $revoked['success'] );
+		$this->assertSame( $user_id, $revoked['user_id'] );
+		$this->assertEmpty( get_user_meta( $user_id, 'extrachill_lifetime_membership', true ) );
+	}
+
+	/**
+	 * Team management delegates to the existing network role primitives.
+	 */
+	public function test_manage_team_member_uses_role_primitives(): void {
+		$user_id = self::factory()->user->create();
+
+		$granted = extrachill_users_ability_manage_team_member(
+			array(
+				'user_id' => $user_id,
+				'action'  => 'force_add',
+			)
+		);
+		$this->assertTrue( $granted['is_team_member'] );
+		$this->assertContains( EC_USERS_TEAM_ROLE, ( new WP_User( $user_id ) )->roles );
+
+		$revoked = extrachill_users_ability_manage_team_member(
+			array(
+				'user_id' => $user_id,
+				'action'  => 'force_remove',
+			)
+		);
+		$this->assertFalse( $revoked['is_team_member'] );
+		$this->assertNotContains( EC_USERS_TEAM_ROLE, ( new WP_User( $user_id ) )->roles );
+	}
+
+	/**
+	 * Transition registration never replaces an ability owned by Admin Tools.
+	 */
+	public function test_registration_does_not_replace_existing_owner(): void {
+		$existing = wp_get_ability( 'extrachill/manage-team-member' );
+		extrachill_users_register_user_administration_abilities();
+		$this->assertSame( $existing, wp_get_ability( 'extrachill/manage-team-member' ) );
+	}
+}


### PR DESCRIPTION
## Summary
- move lifetime membership and team administration abilities into their user-domain owner
- add focused artist-access network administration and update notification links
- preserve legacy ability names with rollout-safe conditional registration
- reject invalid artist-access actions rather than treating them as rejections

## Rollout
Land before Extra-Chill/extrachill-admin-tools#18. Existing Admin Tools registrations win while both plugins are active; Users takes ownership after Admin Tools retirement. API compatibility work is tracked in Extra-Chill/extrachill-api#102.

## Verification
- PHP syntax checks pass for changed PHP and tests
- git diff checks pass
- Homeboy full lint remains blocked by existing repository-wide findings

Closes #173
Part of Extra-Chill/extrachill-admin-tools#16.