### PR TITLE
Fix transitional ability existence checks

### DIFF
--- a/inc/core/abilities/user-administration.php
+++ b/inc/core/abilities/user-administration.php
@@ -115,7 +115,7 @@ function extrachill_users_register_user_administration_abilities() {
 	);
 
 	foreach ( $abilities as $name => $definition ) {
-		if ( wp_get_ability( $name ) ) {
+		if ( wp_has_ability( $name ) ) {
 			continue;
 		}
 

--- a/tests/unit/UserAdministrationAbilitiesTest.php
+++ b/tests/unit/UserAdministrationAbilitiesTest.php
@@ -68,6 +68,19 @@ class Test_User_Administration_Abilities extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Transition registration supplies an ability when no prior owner exists.
+	 */
+	public function test_registration_registers_absent_ability(): void {
+		wp_unregister_ability( 'extrachill/grant-lifetime-membership' );
+
+		$this->assertFalse( wp_has_ability( 'extrachill/grant-lifetime-membership' ) );
+
+		extrachill_users_register_user_administration_abilities();
+
+		$this->assertTrue( wp_has_ability( 'extrachill/grant-lifetime-membership' ) );
+	}
+
+	/**
 	 * Transition registration never replaces an ability owned by Admin Tools.
 	 */
 	public function test_registration_does_not_replace_existing_owner(): void {


### PR DESCRIPTION
## Summary
- use WordPress 6.9's `wp_has_ability()` API for transitional registration predicates
- preserve existing-owner precedence while allowing absent user-administration abilities to register
- cover absent registration alongside the existing owner-preservation test

## Verification
- `php -l inc/core/abilities/user-administration.php`
- `php -l tests/unit/UserAdministrationAbilitiesTest.php`
- `homeboy review lint extrachill-users --changed-only --summary`
- `git diff --check`

PHPUnit could not start because the local Homeboy WP Codebox integration is missing the `buildWordPressPhpunitRecipe` recipe-builder export. The runner failed before executing tests.

Closes #177