### PR TITLE
feat: add default event location preference

### DIFF
--- a/inc/core/abilities/user-settings.php
+++ b/inc/core/abilities/user-settings.php
@@ -293,63 +293,41 @@ function extrachill_users_ability_update_settings( $input ) {
 }
 
 /**
- * Resolve a canonical city-level location in the events site's taxonomy.
+ * Resolve a canonical location through the Events domain's public Ability.
  *
  * @param string $slug Location term slug.
- * @return array|WP_Error Resolved location or validation error.
+ * @return array|WP_Error Resolved location or dependency/validation error.
  */
 function extrachill_users_resolve_default_event_location( string $slug ) {
-	$events_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'events' ) : 0;
-	$events_blog_id = (int) apply_filters( 'extrachill_users_events_blog_id', $events_blog_id );
-	if ( $events_blog_id <= 0 || ! function_exists( 'switch_to_blog' ) ) {
+	$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/events-locations' ) : null;
+	if ( ! $ability ) {
 		return new WP_Error(
-			'events_site_unavailable',
-			__( 'The events site is unavailable.', 'extrachill-users' ),
-			array( 'status' => 500 )
+			'events_locations_unavailable',
+			__( 'Canonical event locations are currently unavailable.', 'extrachill-users' ),
+			array( 'status' => 503 )
 		);
 	}
 
-	$switched = get_current_blog_id() !== $events_blog_id;
-	if ( $switched ) {
-		switch_to_blog( $events_blog_id );
+	$result = $ability->execute(
+		array(
+			'mode' => 'resolve',
+			'slug' => $slug,
+		)
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	try {
-		$term = get_term_by( 'slug', $slug, 'location' );
-		if ( ! $term || is_wp_error( $term ) || count( get_ancestors( $term->term_id, 'location', 'taxonomy' ) ) < 2 ) {
-			return new WP_Error(
-				'invalid_default_event_location',
-				__( 'Choose a canonical city-level event location.', 'extrachill-users' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		$term_link = get_term_link( $term );
-		$resolved  = array(
-			'slug'        => $term->slug,
-			'name'        => $term->name,
-			'term_id'     => (int) $term->term_id,
-			'url'         => is_wp_error( $term_link ) ? '' : $term_link,
-			'coordinates' => null,
+	if ( ! is_array( $result ) || ! isset( $result['location'] ) || ! is_array( $result['location'] ) ) {
+		return new WP_Error(
+			'events_locations_invalid_response',
+			__( 'Canonical event locations returned an invalid response.', 'extrachill-users' ),
+			array( 'status' => 502 )
 		);
-
-		$coordinates = get_term_meta( $term->term_id, '_location_coordinates', true );
-		if ( is_string( $coordinates ) && str_contains( $coordinates, ',' ) ) {
-			$parts = array_map( 'trim', explode( ',', $coordinates, 2 ) );
-			if ( is_numeric( $parts[0] ) && is_numeric( $parts[1] ) ) {
-				$resolved['coordinates'] = array(
-					'lat' => (float) $parts[0],
-					'lon' => (float) $parts[1],
-				);
-			}
-		}
-
-		return $resolved;
-	} finally {
-		if ( $switched ) {
-			restore_current_blog();
-		}
 	}
+
+	return $result['location'];
 }
 
 /**

--- a/inc/core/abilities/user-settings.php
+++ b/inc/core/abilities/user-settings.php
@@ -12,6 +12,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+const EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY = '_extrachill_default_event_location';
+
 add_action( 'wp_abilities_api_init', 'extrachill_users_register_settings_abilities' );
 
 /**
@@ -24,7 +26,7 @@ function extrachill_users_register_settings_abilities() {
 		'extrachill/get-user-settings',
 		array(
 			'label'               => __( 'Get User Settings', 'extrachill-users' ),
-			'description'         => __( 'Retrieve account settings for a user: name, display name, email, pending email.', 'extrachill-users' ),
+			'description'         => __( 'Retrieve private account settings for the authenticated user.', 'extrachill-users' ),
 			'category'            => 'extrachill-users',
 			'input_schema'        => array(
 				'type'       => 'object',
@@ -54,9 +56,13 @@ function extrachill_users_register_settings_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'first_name'   => array( 'type' => 'string' ),
-					'last_name'    => array( 'type' => 'string' ),
-					'display_name' => array( 'type' => 'string' ),
+					'first_name'             => array( 'type' => 'string' ),
+					'last_name'              => array( 'type' => 'string' ),
+					'display_name'           => array( 'type' => 'string' ),
+					'default_event_location' => array(
+						'type'        => 'string',
+						'description' => __( 'Canonical events location slug. Pass an empty string to clear it.', 'extrachill-users' ),
+					),
 				),
 			),
 			'output_schema'       => array( 'type' => 'object' ),
@@ -168,21 +174,31 @@ function extrachill_users_ability_get_settings() {
 	$display_name_options = array_unique( array_filter( array_map( 'trim', $display_name_options ) ) );
 
 	// Pending email change — WordPress core uses '_new_email' meta key.
-	// (The old community settings page incorrectly read '_new_user_email'.)
+	// The old community settings page incorrectly read '_new_user_email'.
 	$pending_email      = null;
 	$pending_email_data = get_user_meta( $user_id, '_new_email', true );
 	if ( $pending_email_data && isset( $pending_email_data['newemail'] ) ) {
 		$pending_email = $pending_email_data['newemail'];
 	}
 
+	$default_event_location_slug = (string) get_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, true );
+	$default_event_location      = null;
+	if ( '' !== $default_event_location_slug ) {
+		$default_event_location = extrachill_users_resolve_default_event_location( $default_event_location_slug );
+		if ( is_wp_error( $default_event_location ) ) {
+			$default_event_location = null;
+		}
+	}
+
 	return array(
-		'user_id'              => $user_id,
-		'first_name'           => $user->first_name,
-		'last_name'            => $user->last_name,
-		'display_name'         => $user->display_name,
-		'display_name_options' => array_values( $display_name_options ),
-		'email'                => $user->user_email,
-		'pending_email'        => $pending_email,
+		'user_id'                => $user_id,
+		'first_name'             => $user->first_name,
+		'last_name'              => $user->last_name,
+		'display_name'           => $user->display_name,
+		'display_name_options'   => array_values( $display_name_options ),
+		'email'                  => $user->user_email,
+		'pending_email'          => $pending_email,
+		'default_event_location' => $default_event_location,
 	);
 }
 
@@ -204,8 +220,9 @@ function extrachill_users_ability_update_settings( $input ) {
 		return new WP_Error( 'user_not_found', 'User not found.' );
 	}
 
-	$update_args = array( 'ID' => $user_id );
-	$changed     = false;
+	$update_args            = array( 'ID' => $user_id );
+	$changed                = false;
+	$location_input_present = array_key_exists( 'default_event_location', $input );
 
 	if ( isset( $input['first_name'] ) ) {
 		$first_name = sanitize_text_field( $input['first_name'] );
@@ -231,7 +248,33 @@ function extrachill_users_ability_update_settings( $input ) {
 		}
 	}
 
+	if ( $location_input_present ) {
+		$location_slug = sanitize_title( (string) $input['default_event_location'] );
+		$current_slug  = (string) get_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, true );
+
+		if ( '' === $location_slug ) {
+			if ( '' !== $current_slug ) {
+				delete_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY );
+				$changed = true;
+			}
+		} else {
+			$location = extrachill_users_resolve_default_event_location( $location_slug );
+			if ( is_wp_error( $location ) ) {
+				return $location;
+			}
+
+			if ( $location_slug !== $current_slug ) {
+				update_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, $location_slug );
+				$changed = true;
+			}
+		}
+	}
+
 	if ( ! $changed ) {
+		if ( $location_input_present ) {
+			return extrachill_users_ability_get_settings();
+		}
+
 		return array(
 			'success' => true,
 			'message' => 'No changes detected.',
@@ -247,6 +290,66 @@ function extrachill_users_ability_update_settings( $input ) {
 
 	// Return fresh settings data (resolves the same authenticated user).
 	return extrachill_users_ability_get_settings();
+}
+
+/**
+ * Resolve a canonical city-level location in the events site's taxonomy.
+ *
+ * @param string $slug Location term slug.
+ * @return array|WP_Error Resolved location or validation error.
+ */
+function extrachill_users_resolve_default_event_location( string $slug ) {
+	$events_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'events' ) : 0;
+	$events_blog_id = (int) apply_filters( 'extrachill_users_events_blog_id', $events_blog_id );
+	if ( $events_blog_id <= 0 || ! function_exists( 'switch_to_blog' ) ) {
+		return new WP_Error(
+			'events_site_unavailable',
+			__( 'The events site is unavailable.', 'extrachill-users' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	$switched = get_current_blog_id() !== $events_blog_id;
+	if ( $switched ) {
+		switch_to_blog( $events_blog_id );
+	}
+
+	try {
+		$term = get_term_by( 'slug', $slug, 'location' );
+		if ( ! $term || is_wp_error( $term ) || count( get_ancestors( $term->term_id, 'location', 'taxonomy' ) ) < 2 ) {
+			return new WP_Error(
+				'invalid_default_event_location',
+				__( 'Choose a canonical city-level event location.', 'extrachill-users' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$term_link = get_term_link( $term );
+		$resolved  = array(
+			'slug'        => $term->slug,
+			'name'        => $term->name,
+			'term_id'     => (int) $term->term_id,
+			'url'         => is_wp_error( $term_link ) ? '' : $term_link,
+			'coordinates' => null,
+		);
+
+		$coordinates = get_term_meta( $term->term_id, '_location_coordinates', true );
+		if ( is_string( $coordinates ) && str_contains( $coordinates, ',' ) ) {
+			$parts = array_map( 'trim', explode( ',', $coordinates, 2 ) );
+			if ( is_numeric( $parts[0] ) && is_numeric( $parts[1] ) ) {
+				$resolved['coordinates'] = array(
+					'lat' => (float) $parts[0],
+					'lon' => (float) $parts[1],
+				);
+			}
+		}
+
+		return $resolved;
+	} finally {
+		if ( $switched ) {
+			restore_current_blog();
+		}
+	}
 }
 
 /**

--- a/tests/unit/UserSettingsDefaultEventLocationTest.php
+++ b/tests/unit/UserSettingsDefaultEventLocationTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Tests for the private default event location setting.
+ *
+ * @package ExtraChill\Users
+ */
+
+/**
+ * Verify account settings persist and resolve canonical event locations.
+ */
+class Test_User_Settings_Default_Event_Location extends WP_UnitTestCase {
+
+	/**
+	 * Events site blog ID.
+	 *
+	 * @var int
+	 */
+	private int $events_blog_id;
+
+	/**
+	 * Create a hierarchical event location fixture.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->events_blog_id                    = self::factory()->blog->create();
+		$GLOBALS['ec_users_test_events_blog_id'] = $this->events_blog_id;
+		add_filter(
+			'extrachill_users_events_blog_id',
+			static function () {
+				return $GLOBALS['ec_users_test_events_blog_id'];
+			}
+		);
+
+		if ( ! function_exists( 'ec_get_blog_id' ) ) {
+			/**
+			 * Resolve the test events site.
+			 *
+			 * @param string $site Site key.
+			 * @return int Blog ID.
+			 */
+			function ec_get_blog_id( $site ) {
+				return 'events' === $site ? $GLOBALS['ec_users_test_events_blog_id'] : 0;
+			}
+		}
+
+		switch_to_blog( $this->events_blog_id );
+		register_taxonomy( 'location', 'post', array( 'hierarchical' => true ) );
+		$country = wp_insert_term( 'United States', 'location', array( 'slug' => 'usa' ) );
+		$state   = wp_insert_term(
+			'South Carolina',
+			'location',
+			array(
+				'slug'   => 'south-carolina',
+				'parent' => $country['term_id'],
+			)
+		);
+		$city    = wp_insert_term(
+			'Charleston',
+			'location',
+			array(
+				'slug'   => 'charleston',
+				'parent' => $state['term_id'],
+			)
+		);
+		update_term_meta( $city['term_id'], '_location_coordinates', '32.7765,-79.9311' );
+		restore_current_blog();
+	}
+
+	/**
+	 * A city slug resolves on write and an empty string clears it.
+	 */
+	public function test_update_resolves_and_clears_private_default_location(): void {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		$original_blog_id = get_current_blog_id();
+
+		$updated = extrachill_users_ability_update_settings( array( 'default_event_location' => 'charleston' ) );
+
+		$this->assertSame( $original_blog_id, get_current_blog_id() );
+		$this->assertSame( 'charleston', $updated['default_event_location']['slug'] );
+		$this->assertSame( 32.7765, $updated['default_event_location']['coordinates']['lat'] );
+		$this->assertSame( 'charleston', get_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, true ) );
+
+		$cleared = extrachill_users_ability_update_settings( array( 'default_event_location' => '' ) );
+		$this->assertNull( $cleared['default_event_location'] );
+		$this->assertSame( '', get_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, true ) );
+	}
+
+	/**
+	 * Country subdivisions and unknown slugs are not valid city defaults.
+	 */
+	public function test_update_rejects_non_city_and_unknown_locations(): void {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+
+		$state = extrachill_users_ability_update_settings( array( 'default_event_location' => 'south-carolina' ) );
+		$this->assertWPError( $state );
+		$this->assertSame( 'invalid_default_event_location', $state->get_error_code() );
+
+		$unknown = extrachill_users_ability_update_settings( array( 'default_event_location' => 'nowhere' ) );
+		$this->assertWPError( $unknown );
+		$this->assertSame( 'invalid_default_event_location', $unknown->get_error_code() );
+	}
+}

--- a/tests/unit/UserSettingsDefaultEventLocationTest.php
+++ b/tests/unit/UserSettingsDefaultEventLocationTest.php
@@ -6,80 +6,72 @@
  */
 
 /**
- * Verify account settings persist and resolve canonical event locations.
+ * Verify account settings delegate canonical event location resolution.
  */
 class Test_User_Settings_Default_Event_Location extends WP_UnitTestCase {
 
 	/**
-	 * Events site blog ID.
-	 *
-	 * @var int
-	 */
-	private int $events_blog_id;
-
-	/**
-	 * Create a hierarchical event location fixture.
+	 * Register a controllable canonical location Ability.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->events_blog_id                    = self::factory()->blog->create();
-		$GLOBALS['ec_users_test_events_blog_id'] = $this->events_blog_id;
-		add_filter(
-			'extrachill_users_events_blog_id',
-			static function () {
-				return $GLOBALS['ec_users_test_events_blog_id'];
-			}
-		);
-
-		if ( ! function_exists( 'ec_get_blog_id' ) ) {
-			/**
-			 * Resolve the test events site.
-			 *
-			 * @param string $site Site key.
-			 * @return int Blog ID.
-			 */
-			function ec_get_blog_id( $site ) {
-				return 'events' === $site ? $GLOBALS['ec_users_test_events_blog_id'] : 0;
-			}
+		$GLOBALS['ec_users_test_location_result'] = null;
+		if ( ! wp_get_ability( 'extrachill/events-locations' ) ) {
+			wp_register_ability(
+				'extrachill/events-locations',
+				array(
+					'label'               => 'Test Event Locations',
+					'description'         => 'Test resolver.',
+					'category'            => 'extrachill-users',
+					'input_schema'        => array( 'type' => 'object' ),
+					'output_schema'       => array( 'type' => 'object' ),
+					'permission_callback' => '__return_true',
+					'execute_callback'    => static function ( $input ) {
+						$GLOBALS['ec_users_test_location_input'] = $input;
+						return $GLOBALS['ec_users_test_location_result'];
+					},
+				)
+			);
 		}
-
-		switch_to_blog( $this->events_blog_id );
-		register_taxonomy( 'location', 'post', array( 'hierarchical' => true ) );
-		$country = wp_insert_term( 'United States', 'location', array( 'slug' => 'usa' ) );
-		$state   = wp_insert_term(
-			'South Carolina',
-			'location',
-			array(
-				'slug'   => 'south-carolina',
-				'parent' => $country['term_id'],
-			)
-		);
-		$city    = wp_insert_term(
-			'Charleston',
-			'location',
-			array(
-				'slug'   => 'charleston',
-				'parent' => $state['term_id'],
-			)
-		);
-		update_term_meta( $city['term_id'], '_location_coordinates', '32.7765,-79.9311' );
-		restore_current_blog();
 	}
 
 	/**
-	 * A city slug resolves on write and an empty string clears it.
+	 * A canonical result is returned unchanged and an empty string clears it.
 	 */
-	public function test_update_resolves_and_clears_private_default_location(): void {
+	public function test_update_delegates_resolution_and_clears_default_location(): void {
 		$user_id = self::factory()->user->create();
 		wp_set_current_user( $user_id );
-		$original_blog_id = get_current_blog_id();
+		$location                                 = array(
+			'term_id'     => 1618,
+			'name'        => 'Charleston',
+			'slug'        => 'charleston',
+			'archive_url' => 'https://events.example/location/charleston/',
+			'coordinates' => array(
+				'lat' => 32.7765,
+				'lon' => -79.9311,
+			),
+			'hierarchy'   => array(
+				'region' => 'United States',
+				'state'  => 'South Carolina',
+				'label'  => 'Charleston, South Carolina',
+			),
+		);
+		$GLOBALS['ec_users_test_location_result'] = array(
+			'locations' => array(),
+			'location'  => $location,
+		);
 
-		$updated = extrachill_users_ability_update_settings( array( 'default_event_location' => 'charleston' ) );
+		$updated = extrachill_users_ability_update_settings( array( 'default_event_location' => 'Charleston' ) );
 
-		$this->assertSame( $original_blog_id, get_current_blog_id() );
-		$this->assertSame( 'charleston', $updated['default_event_location']['slug'] );
-		$this->assertSame( 32.7765, $updated['default_event_location']['coordinates']['lat'] );
+		$this->assertSame(
+			array(
+				'mode' => 'resolve',
+				'slug' => 'charleston',
+			),
+			$GLOBALS['ec_users_test_location_input']
+		);
+		$this->assertSame( $location, $updated['default_event_location'] );
 		$this->assertSame( 'charleston', get_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, true ) );
 
 		$cleared = extrachill_users_ability_update_settings( array( 'default_event_location' => '' ) );
@@ -88,18 +80,50 @@ class Test_User_Settings_Default_Event_Location extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Country subdivisions and unknown slugs are not valid city defaults.
+	 * Validation errors from the Events domain prevent persistence.
 	 */
-	public function test_update_rejects_non_city_and_unknown_locations(): void {
+	public function test_update_propagates_location_validation_errors(): void {
 		$user_id = self::factory()->user->create();
 		wp_set_current_user( $user_id );
+		$GLOBALS['ec_users_test_location_result'] = new WP_Error( 'location_not_found', 'Not found.', array( 'status' => 404 ) );
 
-		$state = extrachill_users_ability_update_settings( array( 'default_event_location' => 'south-carolina' ) );
-		$this->assertWPError( $state );
-		$this->assertSame( 'invalid_default_event_location', $state->get_error_code() );
+		$result = extrachill_users_ability_update_settings( array( 'default_event_location' => 'nowhere' ) );
 
-		$unknown = extrachill_users_ability_update_settings( array( 'default_event_location' => 'nowhere' ) );
-		$this->assertWPError( $unknown );
-		$this->assertSame( 'invalid_default_event_location', $unknown->get_error_code() );
+		$this->assertWPError( $result );
+		$this->assertSame( 'location_not_found', $result->get_error_code() );
+		$this->assertSame( '', get_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, true ) );
+	}
+
+	/**
+	 * Stored settings fail open when canonical resolution fails.
+	 */
+	public function test_read_returns_null_when_resolution_fails(): void {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		update_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, 'charleston' );
+		$GLOBALS['ec_users_test_location_result'] = new WP_Error( 'events_site_unavailable', 'Unavailable.', array( 'status' => 500 ) );
+
+		$settings = extrachill_users_ability_get_settings();
+
+		$this->assertNull( $settings['default_event_location'] );
+		$this->assertSame( 'charleston', get_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, true ) );
+	}
+
+	/**
+	 * A missing Events Ability fails open for reads and clearly rejects writes.
+	 */
+	public function test_missing_ability_returns_null_on_read_and_error_on_update(): void {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		update_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, 'charleston' );
+		wp_unregister_ability( 'extrachill/events-locations' );
+
+		$settings = extrachill_users_ability_get_settings();
+		$updated  = extrachill_users_ability_update_settings( array( 'default_event_location' => 'savannah' ) );
+
+		$this->assertNull( $settings['default_event_location'] );
+		$this->assertWPError( $updated );
+		$this->assertSame( 'events_locations_unavailable', $updated->get_error_code() );
+		$this->assertSame( 'charleston', get_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, true ) );
 	}
 }


### PR DESCRIPTION
## Summary
- extend the self-only account settings abilities with a private, optional canonical event location slug
- delegate all validation and resolved output to the Events-owned public `extrachill/events-locations` Ability
- fail open to `null` when reading an unavailable/stale dependency while rejecting invalid or unavailable writes clearly

## Architecture / Ownership
`extrachill-users` owns only private account persistence because this is user preference state. The canonical slug is stored in `_extrachill_default_event_location`, independently from the public free-text `local_city`; the two are never synchronized.

`extrachill-events` owns canonical location semantics through the merged `extrachill/events-locations` Ability from Extra-Chill/extrachill-events#234. Users performs no blog switching, taxonomy queries, hierarchy checks, term-link construction, coordinate parsing, or event-domain formatting. Generic `data-machine-events` remains unchanged and user-agnostic.

## API Shape
`extrachill/update-user-settings` accepts:

```json
{
  "default_event_location": "charleston"
}
```

Users normalizes the requested slug and calls:

```json
{
  "mode": "resolve",
  "slug": "charleston"
}
```

Both `extrachill/get-user-settings` and a successful update return the Events Ability's `location` object unchanged:

```json
{
  "default_event_location": {
    "term_id": 1618,
    "name": "Charleston",
    "slug": "charleston",
    "archive_url": "https://events.extrachill.com/location/charleston/",
    "coordinates": {
      "lat": 32.7765,
      "lon": -79.9311
    },
    "hierarchy": {
      "region": "United States",
      "state": "South Carolina",
      "label": "Charleston, South Carolina"
    }
  }
}
```

`default_event_location` is `null` when no preference is stored or when a stored slug cannot currently be resolved.

## Validation / Dependency Behavior
- requested non-empty updates execute `extrachill/events-locations` in `resolve` mode before persistence
- Events-owned validation errors such as `location_not_found` propagate unchanged and prevent the new slug from being stored
- a missing Ability returns `events_locations_unavailable` with status 503 on write
- malformed successful responses return `events_locations_invalid_response` with status 502 on write
- reads fail open: any missing dependency, resolution error, or malformed response produces `default_event_location: null` while preserving the stored slug for later recovery
- all cross-site taxonomy and coordinate behavior is encapsulated by `extrachill-events`

## Clearing
Passing an empty string explicitly deletes the preference without requiring the Events Ability and returns `default_event_location: null`. Omitting the property leaves the preference unchanged.

## Consumer Assumptions
- Community can use `extrachill/events-locations` search mode for the selector and submit its selected slug through `extrachill/update-user-settings`.
- Events should apply the returned account default only when no explicit URL/archive or browser location choice exists.
- Blog/homepage and Near Me consumers can use the resolved object without taxonomy access or direct user-meta reads.

## Tests
- focused coverage verifies Ability input, unchanged canonical output, slug persistence, clearing, propagated validation errors, failed-write non-persistence, read-null behavior, and missing-Ability behavior
- changed-file WordPress PHPCS passes
- PHP lint and `git diff --check` pass
- the configured Homeboy PHPUnit gate remains unable to bootstrap because this host lacks a compatible WP Codebox recipe-builder export (`buildWordPressPhpunitRecipe`); no PHPUnit assertions executed or failed locally

Closes #176