### PR TITLE
fix: own event market resolution

### DIFF
--- a/inc/core/abilities/register.php
+++ b/inc/core/abilities/register.php
@@ -71,6 +71,7 @@ require_once __DIR__ . '/welcome-email.php';
 require_once __DIR__ . '/artist-access.php';
 require_once __DIR__ . '/user-administration.php';
 require_once __DIR__ . '/user-settings.php';
+require_once __DIR__ . '/user-event-locations.php';
 require_once __DIR__ . '/user-profile.php';
 require_once __DIR__ . '/subscriptions.php';
 require_once __DIR__ . '/concert-tracking.php';

--- a/inc/core/abilities/user-event-locations.php
+++ b/inc/core/abilities/user-event-locations.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * User Event Location Ability
+ *
+ * Provides canonical market discovery for the network-wide user preference.
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_users_register_event_locations_ability' );
+
+/**
+ * Register the public user event location discovery Ability.
+ */
+function extrachill_users_register_event_locations_ability() {
+	$location_schema         = array(
+		'type'       => 'object',
+		'properties' => array(
+			'term_id'     => array( 'type' => 'integer' ),
+			'name'        => array( 'type' => 'string' ),
+			'slug'        => array( 'type' => 'string' ),
+			'url'         => array( 'type' => 'string' ),
+			'coordinates' => array(
+				'type'       => array( 'object', 'null' ),
+				'properties' => array(
+					'lat' => array( 'type' => 'number' ),
+					'lon' => array( 'type' => 'number' ),
+				),
+			),
+			'hierarchy'   => array(
+				'type'       => 'object',
+				'properties' => array(
+					'region' => array( 'type' => 'string' ),
+					'state'  => array( 'type' => 'string' ),
+					'label'  => array( 'type' => 'string' ),
+				),
+			),
+		),
+	);
+	$resolved_schema         = $location_schema;
+	$resolved_schema['type'] = array( 'object', 'null' );
+
+	wp_register_ability(
+		'extrachill/user-event-locations',
+		array(
+			'label'               => __( 'User Event Locations', 'extrachill-users' ),
+			'description'         => __( 'Search or resolve canonical event markets for the user default event location preference.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'required'   => array( 'mode' ),
+				'properties' => array(
+					'mode'   => array(
+						'type' => 'string',
+						'enum' => array( 'search', 'resolve' ),
+					),
+					'search' => array( 'type' => 'string' ),
+					'slug'   => array( 'type' => 'string' ),
+					'limit'  => array(
+						'type'    => 'integer',
+						'default' => 10,
+						'minimum' => 1,
+						'maximum' => 20,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'locations' => array(
+						'type'  => 'array',
+						'items' => $location_schema,
+					),
+					'location'  => $resolved_schema,
+				),
+			),
+			'execute_callback'    => 'extrachill_users_ability_event_locations',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'   => true,
+					'idempotent' => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Search or resolve selectable cities on the authoritative Events site.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error Location response or error.
+ */
+function extrachill_users_ability_event_locations( array $input ) {
+	$mode           = sanitize_key( $input['mode'] ?? '' );
+	$events_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'events' ) : 0;
+	$events_blog_id = (int) apply_filters( 'extrachill_users_events_blog_id', $events_blog_id );
+
+	if ( $events_blog_id <= 0 || ( is_multisite() && ! get_site( $events_blog_id ) ) ) {
+		return new WP_Error( 'events_site_unavailable', __( 'The canonical Events site is unavailable.', 'extrachill-users' ), array( 'status' => 500 ) );
+	}
+
+	$switched = get_current_blog_id() !== $events_blog_id;
+	if ( $switched && ! switch_to_blog( $events_blog_id ) ) {
+		return new WP_Error( 'events_site_unavailable', __( 'The canonical Events site is unavailable.', 'extrachill-users' ), array( 'status' => 500 ) );
+	}
+
+	try {
+		if ( ! taxonomy_exists( 'location' ) ) {
+			return new WP_Error( 'location_taxonomy_unavailable', __( 'The canonical location taxonomy is unavailable.', 'extrachill-users' ), array( 'status' => 500 ) );
+		}
+
+		if ( 'search' === $mode ) {
+			$search = trim( sanitize_text_field( $input['search'] ?? '' ) );
+			if ( '' === $search ) {
+				return array(
+					'locations' => array(),
+					'location'  => null,
+				);
+			}
+
+			$terms = get_terms(
+				array(
+					'taxonomy'   => 'location',
+					'hide_empty' => false,
+					'search'     => $search,
+					'number'     => 100,
+				)
+			);
+			if ( is_wp_error( $terms ) ) {
+				return new WP_Error( 'location_search_failed', $terms->get_error_message(), array( 'status' => 500 ) );
+			}
+
+			$locations = array();
+			$limit     = min( 20, max( 1, (int) ( $input['limit'] ?? 10 ) ) );
+			foreach ( $terms as $term ) {
+				$location = extrachill_users_prepare_event_location( $term );
+				if ( null === $location ) {
+					continue;
+				}
+				$locations[] = $location;
+				if ( count( $locations ) >= $limit ) {
+					break;
+				}
+			}
+
+			return array(
+				'locations' => $locations,
+				'location'  => null,
+			);
+		}
+
+		if ( 'resolve' !== $mode ) {
+			return new WP_Error( 'invalid_location_mode', __( 'mode must be search or resolve.', 'extrachill-users' ), array( 'status' => 400 ) );
+		}
+
+		$slug = sanitize_title( $input['slug'] ?? '' );
+		if ( '' === $slug ) {
+			return new WP_Error( 'invalid_location_slug', __( 'A location slug is required for resolve mode.', 'extrachill-users' ), array( 'status' => 400 ) );
+		}
+
+		$term     = get_term_by( 'slug', $slug, 'location' );
+		$location = $term && ! is_wp_error( $term ) ? extrachill_users_prepare_event_location( $term ) : null;
+		if ( null === $location ) {
+			return new WP_Error( 'location_not_found', __( 'No selectable canonical event location matched that slug.', 'extrachill-users' ), array( 'status' => 404 ) );
+		}
+
+		return array(
+			'locations' => array(),
+			'location'  => $location,
+		);
+	} finally {
+		if ( $switched ) {
+			restore_current_blog();
+		}
+	}
+}
+
+/**
+ * Format a selectable city term for preference consumers.
+ *
+ * @param WP_Term $term Location term.
+ * @return array|null Formatted location, or null when not selectable.
+ */
+function extrachill_users_prepare_event_location( WP_Term $term ) {
+	$ancestor_ids = get_ancestors( $term->term_id, 'location', 'taxonomy' );
+	if ( count( $ancestor_ids ) < 2 ) {
+		return null;
+	}
+
+	$ancestors = array();
+	foreach ( array_reverse( $ancestor_ids ) as $ancestor_id ) {
+		$ancestor = get_term( $ancestor_id, 'location' );
+		if ( $ancestor && ! is_wp_error( $ancestor ) ) {
+			$ancestors[] = $ancestor;
+		}
+	}
+	if ( count( $ancestors ) < 2 ) {
+		return null;
+	}
+
+	$url         = get_term_link( $term );
+	$state       = $ancestors[ count( $ancestors ) - 1 ]->name;
+	$coordinates = extrachill_users_get_event_location_coordinates( (int) $term->term_id );
+
+	return array(
+		'term_id'     => (int) $term->term_id,
+		'name'        => $term->name,
+		'slug'        => $term->slug,
+		'url'         => is_wp_error( $url ) ? '' : $url,
+		'coordinates' => $coordinates,
+		'hierarchy'   => array(
+			'region' => $ancestors[0]->name,
+			'state'  => $state,
+			'label'  => sprintf( '%s, %s', $term->name, $state ),
+		),
+	);
+}
+
+/**
+ * Parse coordinates stored on an Events location term.
+ *
+ * @param int $term_id Location term ID.
+ * @return array|null Parsed coordinates.
+ */
+function extrachill_users_get_event_location_coordinates( int $term_id ) {
+	$value = get_term_meta( $term_id, '_location_coordinates', true );
+	if ( ! is_string( $value ) || false === strpos( $value, ',' ) ) {
+		return null;
+	}
+
+	$parts = explode( ',', $value, 2 );
+	$lat   = (float) trim( $parts[0] );
+	$lon   = (float) trim( $parts[1] );
+	if ( 0.0 === $lat && 0.0 === $lon ) {
+		return null;
+	}
+
+	return array(
+		'lat' => $lat,
+		'lon' => $lon,
+	);
+}

--- a/inc/core/abilities/user-settings.php
+++ b/inc/core/abilities/user-settings.php
@@ -293,22 +293,13 @@ function extrachill_users_ability_update_settings( $input ) {
 }
 
 /**
- * Resolve a canonical location through the Events domain's public Ability.
+ * Resolve a canonical event location through the Users-owned preference helper.
  *
  * @param string $slug Location term slug.
  * @return array|WP_Error Resolved location or dependency/validation error.
  */
 function extrachill_users_resolve_default_event_location( string $slug ) {
-	$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/events-locations' ) : null;
-	if ( ! $ability ) {
-		return new WP_Error(
-			'events_locations_unavailable',
-			__( 'Canonical event locations are currently unavailable.', 'extrachill-users' ),
-			array( 'status' => 503 )
-		);
-	}
-
-	$result = $ability->execute(
+	$result = extrachill_users_ability_event_locations(
 		array(
 			'mode' => 'resolve',
 			'slug' => $slug,
@@ -321,7 +312,7 @@ function extrachill_users_resolve_default_event_location( string $slug ) {
 
 	if ( ! is_array( $result ) || ! isset( $result['location'] ) || ! is_array( $result['location'] ) ) {
 		return new WP_Error(
-			'events_locations_invalid_response',
+			'user_event_locations_invalid_response',
 			__( 'Canonical event locations returned an invalid response.', 'extrachill-users' ),
 			array( 'status' => 502 )
 		);

--- a/tests/unit/UserSettingsDefaultEventLocationTest.php
+++ b/tests/unit/UserSettingsDefaultEventLocationTest.php
@@ -1,93 +1,145 @@
 <?php
 /**
- * Tests for the private default event location setting.
+ * Tests for canonical event market discovery and the private user preference.
  *
  * @package ExtraChill\Users
  */
 
 /**
- * Verify account settings delegate canonical event location resolution.
+ * Verify Users owns canonical event market resolution across the network.
  */
 class Test_User_Settings_Default_Event_Location extends WP_UnitTestCase {
 
 	/**
-	 * Register a controllable canonical location Ability.
+	 * Events fixture blog ID.
+	 *
+	 * @var int
+	 */
+	private $events_blog_id;
+
+	/**
+	 * Community fixture blog ID.
+	 *
+	 * @var int
+	 */
+	private $community_blog_id;
+
+	/**
+	 * Create the authoritative taxonomy fixture.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
 
-		$GLOBALS['ec_users_test_location_result'] = null;
-		if ( ! wp_get_ability( 'extrachill/events-locations' ) ) {
-			wp_register_ability(
-				'extrachill/events-locations',
-				array(
-					'label'               => 'Test Event Locations',
-					'description'         => 'Test resolver.',
-					'category'            => 'extrachill-users',
-					'input_schema'        => array( 'type' => 'object' ),
-					'output_schema'       => array( 'type' => 'object' ),
-					'permission_callback' => '__return_true',
-					'execute_callback'    => static function ( $input ) {
-						$GLOBALS['ec_users_test_location_input'] = $input;
-						return $GLOBALS['ec_users_test_location_result'];
-					},
-				)
-			);
+		$this->events_blog_id    = self::factory()->blog->create();
+		$this->community_blog_id = self::factory()->blog->create();
+		add_filter( 'extrachill_users_events_blog_id', array( $this, 'filter_events_blog_id' ) );
+		register_taxonomy( 'location', 'post', array( 'public' => true ) );
+
+		switch_to_blog( $this->events_blog_id );
+		$region = wp_insert_term( 'USA', 'location' );
+		$sc     = wp_insert_term( 'South Carolina', 'location', array( 'parent' => $region['term_id'] ) );
+		$texas  = wp_insert_term( 'Texas', 'location', array( 'parent' => $region['term_id'] ) );
+		$city   = wp_insert_term(
+			'Charleston',
+			'location',
+			array(
+				'slug'   => 'charleston-sc',
+				'parent' => $sc['term_id'],
+			)
+		);
+		wp_insert_term(
+			'Charleston',
+			'location',
+			array(
+				'slug'   => 'charleston-tx',
+				'parent' => $texas['term_id'],
+			)
+		);
+		update_term_meta( $city['term_id'], '_location_coordinates', '32.7765,-79.9311' );
+		restore_current_blog();
+	}
+
+	/**
+	 * Restore filters and taxonomy registration.
+	 */
+	protected function tearDown(): void {
+		remove_filter( 'extrachill_users_events_blog_id', array( $this, 'filter_events_blog_id' ) );
+		unregister_taxonomy( 'location' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Point the resolver at the fixture Events site.
+	 *
+	 * @return int Events blog ID.
+	 */
+	public function filter_events_blog_id(): int {
+		return $this->events_blog_id;
+	}
+
+	/**
+	 * The public Ability remains registered on main and Community requests.
+	 */
+	public function test_ability_is_registered_on_main_and_community(): void {
+		$this->assertNotNull( wp_get_ability( 'extrachill/user-event-locations' ) );
+
+		switch_to_blog( $this->community_blog_id );
+		try {
+			$this->assertNotNull( wp_get_ability( 'extrachill/user-event-locations' ) );
+		} finally {
+			restore_current_blog();
 		}
 	}
 
 	/**
-	 * A canonical result is returned unchanged and an empty string clears it.
+	 * Search returns selectable duplicate city names with distinct labels.
 	 */
-	public function test_update_delegates_resolution_and_clears_default_location(): void {
-		$user_id = self::factory()->user->create();
-		wp_set_current_user( $user_id );
-		$location                                 = array(
-			'term_id'     => 1618,
-			'name'        => 'Charleston',
-			'slug'        => 'charleston',
-			'archive_url' => 'https://events.example/location/charleston/',
-			'coordinates' => array(
-				'lat' => 32.7765,
-				'lon' => -79.9311,
-			),
-			'hierarchy'   => array(
-				'region' => 'United States',
-				'state'  => 'South Carolina',
-				'label'  => 'Charleston, South Carolina',
-			),
-		);
-		$GLOBALS['ec_users_test_location_result'] = array(
-			'locations' => array(),
-			'location'  => $location,
-		);
-
-		$updated = extrachill_users_ability_update_settings( array( 'default_event_location' => 'Charleston' ) );
-
-		$this->assertSame(
+	public function test_search_returns_hierarchy_labels_and_restores_context(): void {
+		$original_blog_id = get_current_blog_id();
+		$result           = extrachill_users_ability_event_locations(
 			array(
-				'mode' => 'resolve',
-				'slug' => 'charleston',
-			),
-			$GLOBALS['ec_users_test_location_input']
+				'mode'   => 'search',
+				'search' => 'Charleston',
+			)
 		);
-		$this->assertSame( $location, $updated['default_event_location'] );
-		$this->assertSame( 'charleston', get_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, true ) );
 
-		$cleared = extrachill_users_ability_update_settings( array( 'default_event_location' => '' ) );
-		$this->assertNull( $cleared['default_event_location'] );
-		$this->assertSame( '', get_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, true ) );
+		$this->assertSame( $original_blog_id, get_current_blog_id() );
+		$this->assertCount( 2, $result['locations'] );
+		$this->assertSame( 'Charleston, South Carolina', $result['locations'][0]['hierarchy']['label'] );
+		$this->assertSame( 'Charleston, Texas', $result['locations'][1]['hierarchy']['label'] );
+		$this->assertArrayHasKey( 'url', $result['locations'][0] );
 	}
 
 	/**
-	 * Validation errors from the Events domain prevent persistence.
+	 * Resolve returns the stable public shape and canonical coordinates.
 	 */
-	public function test_update_propagates_location_validation_errors(): void {
+	public function test_resolve_returns_canonical_location_shape(): void {
+		$result   = extrachill_users_ability_event_locations(
+			array(
+				'mode' => 'resolve',
+				'slug' => 'charleston-sc',
+			)
+		);
+		$location = $result['location'];
+
+		$this->assertSame( array(), $result['locations'] );
+		$this->assertSame( 'charleston-sc', $location['slug'] );
+		$this->assertSame( 'Charleston', $location['name'] );
+		$this->assertIsInt( $location['term_id'] );
+		$this->assertSame( 32.7765, $location['coordinates']['lat'] );
+		$this->assertSame( 'USA', $location['hierarchy']['region'] );
+		$this->assertSame( 'South Carolina', $location['hierarchy']['state'] );
+		$this->assertNotSame( '', $location['url'] );
+	}
+
+	/**
+	 * Non-city terms and unknown slugs are rejected.
+	 */
+	public function test_invalid_write_returns_error_without_persisting(): void {
 		$user_id = self::factory()->user->create();
 		wp_set_current_user( $user_id );
-		$GLOBALS['ec_users_test_location_result'] = new WP_Error( 'location_not_found', 'Not found.', array( 'status' => 404 ) );
 
-		$result = extrachill_users_ability_update_settings( array( 'default_event_location' => 'nowhere' ) );
+		$result = extrachill_users_ability_update_settings( array( 'default_event_location' => 'south-carolina' ) );
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'location_not_found', $result->get_error_code() );
@@ -95,35 +147,48 @@ class Test_User_Settings_Default_Event_Location extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Stored settings fail open when canonical resolution fails.
+	 * A canonical write resolves on read and an empty string clears it.
 	 */
-	public function test_read_returns_null_when_resolution_fails(): void {
+	public function test_resolved_settings_read_and_clear(): void {
 		$user_id = self::factory()->user->create();
 		wp_set_current_user( $user_id );
-		update_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, 'charleston' );
-		$GLOBALS['ec_users_test_location_result'] = new WP_Error( 'events_site_unavailable', 'Unavailable.', array( 'status' => 500 ) );
+
+		$updated = extrachill_users_ability_update_settings( array( 'default_event_location' => 'Charleston SC' ) );
+		$this->assertSame( 'charleston-sc', $updated['default_event_location']['slug'] );
+		$this->assertSame( 'charleston-sc', get_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, true ) );
 
 		$settings = extrachill_users_ability_get_settings();
+		$this->assertSame( 'Charleston, South Carolina', $settings['default_event_location']['hierarchy']['label'] );
 
-		$this->assertNull( $settings['default_event_location'] );
-		$this->assertSame( 'charleston', get_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, true ) );
+		$cleared = extrachill_users_ability_update_settings( array( 'default_event_location' => '' ) );
+		$this->assertNull( $cleared['default_event_location'] );
+		$this->assertSame( '', get_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, true ) );
 	}
 
 	/**
-	 * A missing Events Ability fails open for reads and clearly rejects writes.
+	 * Missing Events infrastructure fails reads open and writes explicitly.
 	 */
-	public function test_missing_ability_returns_null_on_read_and_error_on_update(): void {
+	public function test_unavailable_site_and_taxonomy_restore_context_and_fail_safely(): void {
 		$user_id = self::factory()->user->create();
 		wp_set_current_user( $user_id );
-		update_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, 'charleston' );
-		wp_unregister_ability( 'extrachill/events-locations' );
+		update_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, 'charleston-sc' );
+		$original_blog_id = get_current_blog_id();
 
-		$settings = extrachill_users_ability_get_settings();
-		$updated  = extrachill_users_ability_update_settings( array( 'default_event_location' => 'savannah' ) );
+		add_filter( 'extrachill_users_events_blog_id', '__return_zero', 20 );
+		$site_error = extrachill_users_ability_update_settings( array( 'default_event_location' => 'charleston-tx' ) );
+		remove_filter( 'extrachill_users_events_blog_id', '__return_zero', 20 );
+		$this->assertWPError( $site_error );
+		$this->assertSame( 'events_site_unavailable', $site_error->get_error_code() );
 
+		unregister_taxonomy( 'location' );
+		$settings       = extrachill_users_ability_get_settings();
+		$taxonomy_error = extrachill_users_ability_update_settings( array( 'default_event_location' => 'charleston-tx' ) );
 		$this->assertNull( $settings['default_event_location'] );
-		$this->assertWPError( $updated );
-		$this->assertSame( 'events_locations_unavailable', $updated->get_error_code() );
-		$this->assertSame( 'charleston', get_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, true ) );
+		$this->assertWPError( $taxonomy_error );
+		$this->assertSame( 'location_taxonomy_unavailable', $taxonomy_error->get_error_code() );
+		$this->assertSame( $original_blog_id, get_current_blog_id() );
+		$this->assertSame( 'charleston-sc', get_user_meta( $user_id, EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY, true ) );
+
+		register_taxonomy( 'location', 'post', array( 'public' => true ) );
 	}
 }


### PR DESCRIPTION
## Summary
- add the public, read-only `extrachill/user-event-locations` Ability for searching and resolving canonical selectable event markets
- move default event location validation and resolved settings reads entirely into Users
- query the authoritative Events blog under a guarded multisite switch and always restore the caller's blog context

## Root cause and ownership
Users v0.29.0 delegated its network-wide account preference to `extrachill/events-locations`. That Ability belongs to `extrachill-events`, which is intentionally active only on the Events site, so it does not exist during main or Community requests. Network-activating Events would violate the activation boundary.

Users owns the network-wide `default_event_location` preference, so it now owns the preference-facing discovery and validation contract. This is deliberately scoped to account preference markets rather than introducing a generic events API or server-side HTTP dependency.

## Ability contract
`extrachill/user-event-locations` accepts:
- `mode: search` with `search` and optional `limit` (1-20)
- `mode: resolve` with a canonical `slug`

It returns the stable `{ locations, location }` response. Each location includes `term_id`, `name`, `slug`, `url`, nullable `coordinates`, and `hierarchy` data with `region`, `state`, and a disambiguating `label`.

Only canonical selectable city/deeper terms are returned. Unknown or non-selectable slugs produce explicit validation errors. Missing Events site/taxonomy infrastructure produces explicit errors for writes, while settings reads fail safely to `null`. Empty strings continue to clear the preference. Public free-text `local_city` remains separate.

## Multisite behavior
Every search and resolve deliberately switches to the authoritative Events blog, validates its `location` taxonomy, and restores the original context in `finally`, including error paths. The Ability is registered by network-active Users and is therefore available from main and Community. Community's market search migration targets `extrachill/user-event-locations`; Events and Blog can continue consuming resolved `get-user-settings` output.

## Tests and verification
- focused tests cover main/Community registration, search, resolve, duplicate city hierarchy labels, coordinates and response shape, context restoration, unavailable Events site/taxonomy, invalid writes, clearing, and resolved reads
- changed-file PHPCS passes
- changed-file PHP syntax checks pass
- practical WP-CLI search from main passes with canonical Charleston results
- practical WP-CLI resolve from Community passes and confirms blog context restores from blog 2 to blog 2
- full PHPUnit gate was attempted but the host runner stopped before test execution because its WP Codebox recipe-builder module is unavailable
- repository-wide lint was attempted; it reports existing unrelated PHP/JS findings, while changed-file PHPCS is clean

Closes #180