### PR TITLE
feat: add private entity subscriptions

### DIFF
--- a/docs/entity-subscriptions.md
+++ b/docs/entity-subscriptions.md
@@ -1,0 +1,21 @@
+# Entity Subscriptions
+
+Entity subscriptions are private, network-wide update preferences for canonical `festival`, `artist`, `venue`, and `location` taxonomies. They are not followers, newsletter lists, artist-email consent, or bbPress topic subscriptions. The system never returns subscriber counts.
+
+## Consumer abilities
+
+Authenticated users manage only their own records through:
+
+- `extrachill/subscribe`
+- `extrachill/unsubscribe`
+- `extrachill/entity-subscription-status`
+
+`extrachill/resolve-entity-subscription-recipients` is a non-REST ability restricted to network administrators. Runtime producers use the private PHP contract below instead.
+
+Every input includes `entity_type`, `taxonomy`, and `slug`. The default canonical pairs are `festival/festival`, `artist/artist`, `venue/venue`, and `location/location`.
+
+## Producer contract
+
+Main, Wire, Events, and Community producers must register their own stable producer identifier through `extrachill_users_entity_subscription_producer_authorized`. They then call `extrachill_users_entity_subscription_recipients( $producer, $entity_type, $taxonomy, $slug )` and pass the returned IDs to `ec_users_notify()`.
+
+Recipient resolution is a private PHP contract, not a REST ability, and only returns unique user IDs. It is denied until the producer authorizes itself through the filter. Producers must not log, render, or count recipients. For normal bell notifications, use the default `notification` delivery; the notification substrate applies the user's digest-email preference when it sends email. Producers that directly deliver email must pass `email`, which excludes users who disabled notification emails.

--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -172,6 +172,9 @@ function extrachill_users_init() {
 	// Header notification bell — renders network-wide via the theme header hook.
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/notifications/bell.php';
 
+	// Private, network-wide entity update subscriptions.
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/entity-subscriptions/service.php';
+
 	// wp-native-auth bridge: layer EC policy (membership, blocking, Turnstile)
 	// onto the generic wp-native-auth filter surface when both plugins are active.
 	if ( defined( 'WP_NATIVE_AUTH_VERSION' ) ) {

--- a/inc/core/abilities/entity-subscriptions.php
+++ b/inc/core/abilities/entity-subscriptions.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Self-only entity subscription abilities.
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_users_register_entity_subscription_abilities' );
+
+/**
+ * Register entity subscription abilities.
+ *
+ * @return void
+ */
+function extrachill_users_register_entity_subscription_abilities(): void {
+
+	$identity_schema = array(
+		'type'       => 'object',
+		'properties' => array(
+			'entity_type' => array( 'type' => 'string' ),
+			'taxonomy'    => array( 'type' => 'string' ),
+			'slug'        => array( 'type' => 'string' ),
+		),
+		'required'   => array( 'entity_type', 'taxonomy', 'slug' ),
+	);
+
+	foreach (
+		array(
+			'subscribe'                  => 'Subscribe',
+			'unsubscribe'                => 'Unsubscribe',
+			'entity-subscription-status' => 'Get Entity Subscription Status',
+		) as $name => $label
+	) {
+		wp_register_ability(
+			'extrachill/' . $name,
+			array(
+				'label'               => __( $label, 'extrachill-users' ), // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
+				'description'         => __( 'Manage your private subscriptions to canonical entity updates.', 'extrachill-users' ),
+				'category'            => 'extrachill-users',
+				'input_schema'        => $identity_schema,
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => 'extrachill_users_ability_' . str_replace( '-', '_', $name ),
+				'permission_callback' => 'is_user_logged_in',
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'   => 'entity-subscription-status' === $name,
+						'idempotent' => true,
+					),
+				),
+			)
+		);
+	}
+
+	// Producer recipient enumeration is never exposed through REST. Producers
+	// use the private service directly, and privileged tooling may use this
+	// ability only when it has a network administrator's authorization.
+	wp_register_ability(
+		'extrachill/resolve-entity-subscription-recipients',
+		array(
+			'label'               => __( 'Resolve Entity Subscription Recipients', 'extrachill-users' ),
+			'description'         => __( 'Resolve private recipient IDs for an authorized entity-update producer.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array_merge(
+				$identity_schema,
+				array(
+					'properties' => array_merge(
+						$identity_schema['properties'],
+						array(
+							'producer' => array( 'type' => 'string' ),
+							'delivery' => array( 'type' => 'string' ),
+						)
+					),
+					'required'   => array_merge( $identity_schema['required'], array( 'producer' ) ),
+				)
+			),
+			'output_schema'       => array( 'type' => 'object' ),
+			'execute_callback'    => 'extrachill_users_ability_entity_subscription_recipients',
+			'permission_callback' => 'extrachill_users_entity_subscription_recipient_ability_permission',
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'   => true,
+					'idempotent' => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Limit recipient enumeration to network administrators.
+ *
+ * @return bool
+ */
+function extrachill_users_entity_subscription_recipient_ability_permission(): bool {
+	return current_user_can( 'manage_network_options' );
+}
+
+/**
+ * Execute a self-only entity subscription operation.
+ *
+ * @param array $input Ability input.
+ * @param string $operation subscribe, unsubscribe, or status.
+ * @return array|WP_Error
+ */
+function extrachill_users_entity_subscription_ability( array $input, string $operation ) {
+
+	$user_id = extrachill_users_resolve_self_user_id();
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
+
+	if ( 'subscribe' === $operation ) {
+		return extrachill_users_subscribe_to_entity( $user_id, $input['entity_type'] ?? '', $input['taxonomy'] ?? '', $input['slug'] ?? '' );
+	}
+	if ( 'unsubscribe' === $operation ) {
+		return extrachill_users_unsubscribe_from_entity( $user_id, $input['entity_type'] ?? '', $input['taxonomy'] ?? '', $input['slug'] ?? '' );
+	}
+
+	return extrachill_users_entity_subscription_status( $user_id, $input['entity_type'] ?? '', $input['taxonomy'] ?? '', $input['slug'] ?? '' );
+}
+
+/**
+ * Subscribe the authenticated user.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_subscribe( array $input ) {
+	return extrachill_users_entity_subscription_ability( $input, 'subscribe' );
+}
+
+/**
+ * Unsubscribe the authenticated user.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_unsubscribe( array $input ) {
+	return extrachill_users_entity_subscription_ability( $input, 'unsubscribe' );
+}
+
+/**
+ * Get the authenticated user's subscription status.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_entity_subscription_status( array $input ) {
+	return extrachill_users_entity_subscription_ability( $input, 'status' );
+}
+
+/**
+ * Resolve recipients through the private producer authorization contract.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_entity_subscription_recipients( array $input ) {
+	$recipients = extrachill_users_entity_subscription_recipients(
+		$input['producer'] ?? '',
+		$input['entity_type'] ?? '',
+		$input['taxonomy'] ?? '',
+		$input['slug'] ?? '',
+		$input['delivery'] ?? 'notification'
+	);
+
+	if ( is_wp_error( $recipients ) ) {
+		return $recipients;
+	}
+
+	return array( 'recipient_ids' => $recipients );
+}

--- a/inc/core/abilities/register.php
+++ b/inc/core/abilities/register.php
@@ -74,6 +74,7 @@ require_once __DIR__ . '/user-settings.php';
 require_once __DIR__ . '/user-event-locations.php';
 require_once __DIR__ . '/user-profile.php';
 require_once __DIR__ . '/subscriptions.php';
+require_once __DIR__ . '/entity-subscriptions.php';
 require_once __DIR__ . '/concert-tracking.php';
 require_once __DIR__ . '/concert-import.php';
 require_once __DIR__ . '/notifications.php';

--- a/inc/core/activation.php
+++ b/inc/core/activation.php
@@ -47,6 +47,10 @@ function extrachill_users_run_activation() {
 		defined( 'EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION' ) ? (string) EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION : '1'
 	);
 
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/entity-subscriptions/db.php';
+	extrachill_users_install_entity_subscriptions_table();
+	update_site_option( 'extrachill_users_entity_subscriptions_schema_version', EXTRACHILL_USERS_ENTITY_SUBSCRIPTIONS_SCHEMA_VERSION );
+
 	extrachill_users_create_login_pages_network();
 
 	// Register extra_chill_team role on every site in the network and

--- a/inc/entity-subscriptions/db.php
+++ b/inc/entity-subscriptions/db.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Network entity subscription storage.
+ *
+ * User meta is network-wide but cannot index recipients by entity without
+ * scanning serialized values. This table is the small reverse-indexing gap.
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+const EXTRACHILL_USERS_ENTITY_SUBSCRIPTIONS_SCHEMA_VERSION = '1';
+
+/**
+ * Get the network entity subscription table name.
+ *
+ * @return string
+ */
+function extrachill_users_entity_subscriptions_table_name(): string {
+
+	global $wpdb;
+
+	return $wpdb->base_prefix . 'ec_entity_subscriptions';
+}
+
+/**
+ * Install the network entity subscription table.
+ *
+ * @return void
+ */
+function extrachill_users_install_entity_subscriptions_table(): void {
+
+	global $wpdb;
+
+	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+	$table_name      = extrachill_users_entity_subscriptions_table_name();
+	$charset_collate = $wpdb->get_charset_collate();
+	$sql             = "CREATE TABLE {$table_name} (
+		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+		user_id bigint(20) unsigned NOT NULL,
+		entity_type varchar(32) NOT NULL,
+		taxonomy varchar(32) NOT NULL,
+		entity_slug varchar(200) NOT NULL,
+		created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY  (id),
+		UNIQUE KEY user_entity (user_id, entity_type, taxonomy, entity_slug),
+		KEY entity_recipients (entity_type, taxonomy, entity_slug, user_id)
+	) {$charset_collate};";
+
+	dbDelta( $sql );
+}

--- a/inc/entity-subscriptions/service.php
+++ b/inc/entity-subscriptions/service.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Network entity subscription service.
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/db.php';
+
+/**
+ * Ensure the network table exists after upgrades.
+ *
+ * @return void
+ */
+function extrachill_users_maybe_install_entity_subscriptions_table(): void {
+
+	if ( EXTRACHILL_USERS_ENTITY_SUBSCRIPTIONS_SCHEMA_VERSION === (string) get_site_option( 'extrachill_users_entity_subscriptions_schema_version', '' ) ) {
+		return;
+	}
+
+	extrachill_users_install_entity_subscriptions_table();
+	update_site_option( 'extrachill_users_entity_subscriptions_schema_version', EXTRACHILL_USERS_ENTITY_SUBSCRIPTIONS_SCHEMA_VERSION );
+}
+add_action( 'init', 'extrachill_users_maybe_install_entity_subscriptions_table' );
+
+/**
+ * Normalize and validate an entity identity.
+ *
+ * The default map defines the network's canonical entity/taxonomy pairs. A
+ * feature may extend it without changing this generic persistence layer.
+ *
+ * @param string $entity_type Entity type.
+ * @param string $taxonomy Taxonomy.
+ * @param string $slug Entity slug.
+ * @return array|WP_Error
+ */
+function extrachill_users_normalize_entity_subscription( $entity_type, $taxonomy, $slug ) {
+
+	$entity_type = sanitize_key( $entity_type );
+	$taxonomy    = sanitize_key( $taxonomy );
+	$slug        = sanitize_title( $slug );
+	$entities    = apply_filters(
+		'extrachill_users_entity_subscription_entities',
+		array(
+			'festival' => 'festival',
+			'artist'   => 'artist',
+			'venue'    => 'venue',
+			'location' => 'location',
+		)
+	);
+
+	if ( '' === $entity_type || '' === $taxonomy || '' === $slug || ! isset( $entities[ $entity_type ] ) || $taxonomy !== $entities[ $entity_type ] ) {
+		return new WP_Error( 'invalid_entity_subscription', __( 'A supported entity type, taxonomy, and slug are required.', 'extrachill-users' ), array( 'status' => 400 ) );
+	}
+
+	return array(
+		'entity_type' => $entity_type,
+		'taxonomy'    => $taxonomy,
+		'slug'        => $slug,
+	);
+}
+
+/**
+ * Subscribe a user to a canonical entity.
+ *
+ * @param int   $user_id User ID.
+ * @param string $entity_type Entity type.
+ * @param string $taxonomy Taxonomy.
+ * @param string $slug Entity slug.
+ * @return array|WP_Error
+ */
+function extrachill_users_subscribe_to_entity( $user_id, $entity_type, $taxonomy, $slug ) {
+
+	global $wpdb;
+
+	$user_id = absint( $user_id );
+	$entity  = extrachill_users_normalize_entity_subscription( $entity_type, $taxonomy, $slug );
+	if ( is_wp_error( $entity ) ) {
+		return $entity;
+	}
+	if ( ! $user_id || ! get_userdata( $user_id ) ) {
+		return new WP_Error( 'user_not_found', __( 'User not found.', 'extrachill-users' ), array( 'status' => 404 ) );
+	}
+
+	$table = extrachill_users_entity_subscriptions_table_name();
+	$wpdb->query(
+		$wpdb->prepare(
+			"INSERT IGNORE INTO {$table} (user_id, entity_type, taxonomy, entity_slug, created_at) VALUES (%d, %s, %s, %s, %s)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- trusted table helper.
+			$user_id,
+			$entity['entity_type'],
+			$entity['taxonomy'],
+			$entity['slug'],
+			current_time( 'mysql', true )
+		)
+	);
+
+	return array_merge( $entity, array( 'subscribed' => true ) );
+}
+
+/**
+ * Unsubscribe a user from a canonical entity.
+ *
+ * @param int $user_id User ID.
+ * @param string $entity_type Entity type.
+ * @param string $taxonomy Taxonomy.
+ * @param string $slug Entity slug.
+ * @return array|WP_Error
+ */
+function extrachill_users_unsubscribe_from_entity( $user_id, $entity_type, $taxonomy, $slug ) {
+
+	global $wpdb;
+
+	$user_id = absint( $user_id );
+	$entity  = extrachill_users_normalize_entity_subscription( $entity_type, $taxonomy, $slug );
+	if ( is_wp_error( $entity ) ) {
+		return $entity;
+	}
+	if ( ! $user_id || ! get_userdata( $user_id ) ) {
+		return new WP_Error( 'user_not_found', __( 'User not found.', 'extrachill-users' ), array( 'status' => 404 ) );
+	}
+
+	$table = extrachill_users_entity_subscriptions_table_name();
+	$wpdb->query(
+		$wpdb->prepare(
+			"DELETE FROM {$table} WHERE user_id = %d AND entity_type = %s AND taxonomy = %s AND entity_slug = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- trusted table helper.
+			$user_id,
+			$entity['entity_type'],
+			$entity['taxonomy'],
+			$entity['slug']
+		)
+	);
+
+	return array_merge( $entity, array( 'subscribed' => false ) );
+}
+
+/**
+ * Get one user's subscription status.
+ *
+ * @param int $user_id User ID.
+ * @param string $entity_type Entity type.
+ * @param string $taxonomy Taxonomy.
+ * @param string $slug Entity slug.
+ * @return array|WP_Error
+ */
+function extrachill_users_entity_subscription_status( $user_id, $entity_type, $taxonomy, $slug ) {
+
+	global $wpdb;
+
+	$user_id = absint( $user_id );
+	$entity  = extrachill_users_normalize_entity_subscription( $entity_type, $taxonomy, $slug );
+	if ( is_wp_error( $entity ) ) {
+		return $entity;
+	}
+
+	$table      = extrachill_users_entity_subscriptions_table_name();
+	$subscribed = $user_id && (bool) $wpdb->get_var(
+		$wpdb->prepare(
+			"SELECT 1 FROM {$table} WHERE user_id = %d AND entity_type = %s AND taxonomy = %s AND entity_slug = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- trusted table helper.
+			$user_id,
+			$entity['entity_type'],
+			$entity['taxonomy'],
+			$entity['slug']
+		)
+	);
+
+	return array_merge( $entity, array( 'subscribed' => $subscribed ) );
+}
+
+/**
+ * Resolve recipients for an authorized producer without exposing an audience.
+ *
+ * Producers must opt in through the authorization filter with their own stable
+ * identifier. The result is intentionally only a de-duplicated ID list.
+ *
+ * @param string $producer Producer identifier.
+ * @param string $entity_type Entity type.
+ * @param string $taxonomy Taxonomy.
+ * @param string $slug Entity slug.
+ * @param string $delivery Delivery channel: notification or email.
+ * @return int[]|WP_Error
+ */
+function extrachill_users_entity_subscription_recipients( $producer, $entity_type, $taxonomy, $slug, $delivery = 'notification' ) {
+
+	global $wpdb;
+
+	$producer = sanitize_key( $producer );
+	$delivery = sanitize_key( $delivery );
+	$entity   = extrachill_users_normalize_entity_subscription( $entity_type, $taxonomy, $slug );
+	if ( is_wp_error( $entity ) ) {
+		return $entity;
+	}
+	if ( '' === $producer || ! apply_filters( 'extrachill_users_entity_subscription_producer_authorized', false, $producer, $entity, $delivery ) ) {
+		return new WP_Error( 'entity_subscription_producer_forbidden', __( 'This producer is not authorized to resolve entity subscription recipients.', 'extrachill-users' ), array( 'status' => 403 ) );
+	}
+	if ( ! in_array( $delivery, array( 'notification', 'email' ), true ) ) {
+		return new WP_Error( 'invalid_entity_subscription_delivery', __( 'Unsupported notification delivery.', 'extrachill-users' ), array( 'status' => 400 ) );
+	}
+
+	$table = extrachill_users_entity_subscriptions_table_name();
+	$ids   = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT user_id FROM {$table} WHERE entity_type = %s AND taxonomy = %s AND entity_slug = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- trusted table helper.
+			$entity['entity_type'],
+			$entity['taxonomy'],
+			$entity['slug']
+		)
+	);
+	$ids   = array_values( array_unique( array_map( 'absint', $ids ) ) );
+
+	if ( 'email' === $delivery && function_exists( 'ec_users_notification_emails_enabled' ) ) {
+		$ids = array_values( array_filter( $ids, 'ec_users_notification_emails_enabled' ) );
+	}
+
+	return $ids;
+}

--- a/tests/unit/EntitySubscriptionsTest.php
+++ b/tests/unit/EntitySubscriptionsTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Tests for private, network entity subscriptions.
+ *
+ * @package ExtraChill\Users
+ */
+
+class Test_Entity_Subscriptions extends WP_UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		extrachill_users_install_entity_subscriptions_table();
+		add_filter( 'extrachill_users_entity_subscription_producer_authorized', array( $this, 'authorize_test_producer' ), 10, 4 );
+	}
+
+	protected function tearDown(): void {
+		remove_filter( 'extrachill_users_entity_subscription_producer_authorized', array( $this, 'authorize_test_producer' ), 10 );
+		parent::tearDown();
+	}
+
+	public function authorize_test_producer( $authorized, $producer ): bool {
+		return 'test-producer' === $producer;
+	}
+
+	public function test_subscribe_normalizes_and_deduplicates(): void {
+		$user_id = self::factory()->user->create();
+
+		$first  = extrachill_users_subscribe_to_entity( $user_id, 'Festival', 'festival', 'Big Fest 2026' );
+		$second = extrachill_users_subscribe_to_entity( $user_id, 'festival', 'festival', 'big-fest-2026' );
+
+		$this->assertTrue( $first['subscribed'] );
+		$this->assertSame( 'big-fest-2026', $first['slug'] );
+		$this->assertTrue( $second['subscribed'] );
+		$this->assertSame( array( $user_id ), extrachill_users_entity_subscription_recipients( 'test-producer', 'festival', 'festival', 'big-fest-2026' ) );
+	}
+
+	public function test_abilities_include_private_recipient_resolution(): void {
+		$this->assertNotNull( wp_get_ability( 'extrachill/subscribe' ) );
+		$this->assertNotNull( wp_get_ability( 'extrachill/unsubscribe' ) );
+		$this->assertNotNull( wp_get_ability( 'extrachill/entity-subscription-status' ) );
+		$this->assertNotNull( wp_get_ability( 'extrachill/resolve-entity-subscription-recipients' ) );
+	}
+
+	public function test_status_and_unsubscribe_are_self_contained(): void {
+		$user_id = self::factory()->user->create();
+		extrachill_users_subscribe_to_entity( $user_id, 'venue', 'venue', 'the-royal-american' );
+
+		$this->assertTrue( extrachill_users_entity_subscription_status( $user_id, 'venue', 'venue', 'the-royal-american' )['subscribed'] );
+		$this->assertFalse( extrachill_users_unsubscribe_from_entity( $user_id, 'venue', 'venue', 'the-royal-american' )['subscribed'] );
+		$this->assertFalse( extrachill_users_entity_subscription_status( $user_id, 'venue', 'venue', 'the-royal-american' )['subscribed'] );
+	}
+
+	public function test_invalid_entity_pair_is_rejected(): void {
+		$user_id = self::factory()->user->create();
+		$result  = extrachill_users_subscribe_to_entity( $user_id, 'festival', 'artist', 'big-fest' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_entity_subscription', $result->get_error_code() );
+	}
+
+	public function test_recipient_resolution_requires_producer_authorization(): void {
+		$user_id = self::factory()->user->create();
+		extrachill_users_subscribe_to_entity( $user_id, 'location', 'location', 'charleston-sc' );
+
+		$denied = extrachill_users_entity_subscription_recipients( 'untrusted', 'location', 'location', 'charleston-sc' );
+		$this->assertWPError( $denied );
+		$this->assertSame( 'entity_subscription_producer_forbidden', $denied->get_error_code() );
+	}
+
+	public function test_direct_email_recipient_resolution_respects_digest_preference(): void {
+		$enabled_user  = self::factory()->user->create();
+		$disabled_user = self::factory()->user->create();
+		extrachill_users_subscribe_to_entity( $enabled_user, 'artist', 'artist', 'phish' );
+		extrachill_users_subscribe_to_entity( $disabled_user, 'artist', 'artist', 'phish' );
+		ec_users_set_notification_emails_disabled( $disabled_user, true );
+
+		$this->assertSame( array( $enabled_user, $disabled_user ), extrachill_users_entity_subscription_recipients( 'test-producer', 'artist', 'artist', 'phish' ) );
+		$this->assertSame( array( $enabled_user ), extrachill_users_entity_subscription_recipients( 'test-producer', 'artist', 'artist', 'phish', 'email' ) );
+	}
+}


### PR DESCRIPTION
## Summary
- Add a network-wide, uniquely indexed entity-subscription store for festival, artist, venue, and location taxonomy slugs.
- Provide self-only subscribe, unsubscribe, and status abilities plus non-REST, network-admin-gated recipient resolution backed by a private producer authorization filter.
- Document the Main, Wire, Events, and Community producer contract and add focused persistence, deduplication, authorization, and email-preference tests.

## Design
- WordPress core user meta is network-wide and can store serialized arrays, but cannot efficiently reverse-resolve recipients by entity. The base-prefix table fills only that indexing gap.
- Recipient IDs are never available through public REST and no counts, follower terminology, newsletter integration, or bbPress coupling were added.
- Producers authorize their stable identifier through `extrachill_users_entity_subscription_producer_authorized`, resolve recipient IDs through the private service, and send standard bell notifications through `ec_users_notify()`.

## Verification
- `php -l` passed for all changed PHP files.
- Scoped PHPCS passed for the new service, schema, ability, and test files.
- `homeboy review extrachill-users test` could not start PHPUnit because the local WP Codebox recipe builder module is unavailable.
- Scoped PHPStan could not start because the local Homeboy PHPStan PHAR exceeds PHP's 100 MB manifest limit.
- Full lint remains blocked by pre-existing repository findings outside this change.

## Producer Follow-ups
- Main festival pillars, Wire, Events, and Community should each register their own producer identifier via the authorization filter and invoke the documented private recipient resolver when they publish a relevant update.

Closes #182