### PR TITLE
fix: avoid newsletter ability collision

### DIFF
--- a/docs/entity-subscriptions.md
+++ b/docs/entity-subscriptions.md
@@ -6,8 +6,8 @@ Entity subscriptions are private, network-wide update preferences for canonical 
 
 Authenticated users manage only their own records through:
 
-- `extrachill/subscribe`
-- `extrachill/unsubscribe`
+- `extrachill/entity-subscribe`
+- `extrachill/entity-unsubscribe`
 - `extrachill/entity-subscription-status`
 
 `extrachill/resolve-entity-subscription-recipients` is a non-REST ability restricted to network administrators. Runtime producers use the private PHP contract below instead.

--- a/inc/core/abilities/entity-subscriptions.php
+++ b/inc/core/abilities/entity-subscriptions.php
@@ -28,8 +28,8 @@ function extrachill_users_register_entity_subscription_abilities(): void {
 
 	foreach (
 		array(
-			'subscribe'                  => 'Subscribe',
-			'unsubscribe'                => 'Unsubscribe',
+			'entity-subscribe'           => 'Subscribe to Entity',
+			'entity-unsubscribe'         => 'Unsubscribe from Entity',
 			'entity-subscription-status' => 'Get Entity Subscription Status',
 		) as $name => $label
 	) {
@@ -129,7 +129,7 @@ function extrachill_users_entity_subscription_ability( array $input, string $ope
  * @param array $input Ability input.
  * @return array|WP_Error
  */
-function extrachill_users_ability_subscribe( array $input ) {
+function extrachill_users_ability_entity_subscribe( array $input ) {
 	return extrachill_users_entity_subscription_ability( $input, 'subscribe' );
 }
 
@@ -139,7 +139,7 @@ function extrachill_users_ability_subscribe( array $input ) {
  * @param array $input Ability input.
  * @return array|WP_Error
  */
-function extrachill_users_ability_unsubscribe( array $input ) {
+function extrachill_users_ability_entity_unsubscribe( array $input ) {
 	return extrachill_users_entity_subscription_ability( $input, 'unsubscribe' );
 }
 

--- a/tests/unit/EntitySubscriptionsTest.php
+++ b/tests/unit/EntitySubscriptionsTest.php
@@ -35,10 +35,26 @@ class Test_Entity_Subscriptions extends WP_UnitTestCase {
 	}
 
 	public function test_abilities_include_private_recipient_resolution(): void {
-		$this->assertNotNull( wp_get_ability( 'extrachill/subscribe' ) );
-		$this->assertNotNull( wp_get_ability( 'extrachill/unsubscribe' ) );
+		$subscribe   = wp_get_ability( 'extrachill/entity-subscribe' );
+		$unsubscribe = wp_get_ability( 'extrachill/entity-unsubscribe' );
+
+		$this->assertNotNull( $subscribe );
+		$this->assertNotNull( $unsubscribe );
 		$this->assertNotNull( wp_get_ability( 'extrachill/entity-subscription-status' ) );
 		$this->assertNotNull( wp_get_ability( 'extrachill/resolve-entity-subscription-recipients' ) );
+
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		$result = $subscribe->execute(
+			array(
+				'entity_type' => 'festival',
+				'taxonomy'    => 'festival',
+				'slug'        => 'bonnaroo',
+			)
+		);
+
+		$this->assertSame( 'bonnaroo', $result['slug'] );
+		$this->assertTrue( $result['subscribed'] );
 	}
 
 	public function test_status_and_unsubscribe_are_self_contained(): void {


### PR DESCRIPTION
## Summary

- rename entity write abilities to `extrachill/entity-subscribe` and `extrachill/entity-unsubscribe`
- preserve `extrachill/subscribe` as the Newsletter-owned Sendy contract
- execute the entity ability in regression coverage so an unrelated registered ability cannot satisfy the test
- update the consumer documentation

Fixes #187.

## Verification

- PHP syntax passes
- `git diff --check`
- changed-file PHPCS passes with no findings

Local PHPStan remains unavailable because the installed PHAR has an oversized manifest.