### PR TITLE
feat: list public Local Scene members

### DIFF
--- a/inc/core/abilities/local-scene-members.php
+++ b/inc/core/abilities/local-scene-members.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Local Scene Members Ability
+ *
+ * @package ExtraChill\Users
+ */
+
+declare(strict_types=1);
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_users_register_local_scene_members_ability' );
+
+/**
+ * Register the public Local Scene member directory ability.
+ */
+function extrachill_users_register_local_scene_members_ability(): void {
+	wp_register_ability(
+		'extrachill/local-scene-members',
+		array(
+			'label'               => __( 'List Local Scene members', 'extrachill-users' ),
+			'description'         => __( 'Returns public profile cards for members of a canonical Local Scene.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'slug'     => array( 'type' => 'string' ),
+					'page'     => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+						'default' => 1,
+					),
+					'per_page' => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+						'maximum' => 100,
+						'default' => 25,
+					),
+				),
+				'required'             => array( 'slug' ),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array( 'type' => 'object' ),
+			'permission_callback' => '__return_true',
+			'execute_callback'    => 'extrachill_users_ability_local_scene_members',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * List public members of a canonical Local Scene.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error Member directory response or resolution error.
+ */
+function extrachill_users_ability_local_scene_members( array $input ): array|WP_Error {
+	$slug = sanitize_title( (string) ( $input['slug'] ?? '' ) );
+	if ( '' === $slug ) {
+		return new WP_Error( 'missing_local_scene', __( 'A Local Scene slug is required.', 'extrachill-users' ) );
+	}
+
+	$scene = extrachill_users_resolve_local_scene( $slug );
+	if ( is_wp_error( $scene ) ) {
+		return $scene;
+	}
+
+	$page     = max( 1, (int) ( $input['page'] ?? 1 ) );
+	$per_page = max( 1, min( 100, (int) ( $input['per_page'] ?? 25 ) ) );
+	$query    = new WP_User_Query(
+		array(
+			'number'      => $per_page,
+			'offset'      => ( $page - 1 ) * $per_page,
+			'orderby'     => 'display_name',
+			'order'       => 'ASC',
+			'count_total' => true,
+			'meta_query'  => array(
+				'relation' => 'AND',
+				array(
+					'key'   => EXTRACHILL_USERS_LOCAL_SCENE_META_KEY,
+					'value' => $scene['slug'],
+				),
+				array(
+					'relation' => 'OR',
+					array(
+						'key'     => EXTRACHILL_USERS_LOCAL_SCENE_VISIBILITY_META_KEY,
+						'compare' => 'NOT EXISTS',
+					),
+					array(
+						'key'   => EXTRACHILL_USERS_LOCAL_SCENE_VISIBILITY_META_KEY,
+						'value' => 'public',
+					),
+				),
+			),
+		)
+	);
+
+	$members = array();
+	foreach ( $query->get_results() as $user ) {
+		$user_id     = (int) $user->ID;
+		$points      = (float) get_user_meta( $user_id, 'extrachill_total_points', true );
+		$profile_url = function_exists( 'extrachill_get_user_profile_url' )
+			? extrachill_get_user_profile_url( $user_id, $user->user_email )
+			: get_author_posts_url( $user_id );
+
+		$members[] = array(
+			'user_id'      => $user_id,
+			'display_name' => $user->display_name,
+			'username'     => $user->user_login,
+			'profile_url'  => $profile_url,
+			'avatar_url'   => get_avatar_url( $user_id, array( 'size' => 96 ) ),
+			'custom_title' => (string) get_user_meta( $user_id, 'ec_custom_title', true ),
+			'bio'          => wp_trim_words( wp_strip_all_tags( (string) $user->description ), 30 ),
+			'rank'         => function_exists( 'ec_get_rank_for_points' ) ? ec_get_rank_for_points( $points ) : '',
+		);
+	}
+
+	$total = (int) $query->get_total();
+
+	return array(
+		'scene'      => $scene,
+		'members'    => $members,
+		'pagination' => array(
+			'page'        => $page,
+			'per_page'    => $per_page,
+			'total'       => $total,
+			'total_pages' => (int) ceil( $total / $per_page ),
+		),
+	);
+}

--- a/inc/core/abilities/register.php
+++ b/inc/core/abilities/register.php
@@ -80,6 +80,7 @@ require_once __DIR__ . '/concert-import.php';
 require_once __DIR__ . '/notifications.php';
 require_once __DIR__ . '/users-leaderboard.php';
 require_once __DIR__ . '/users-search.php';
+require_once __DIR__ . '/local-scene-members.php';
 require_once __DIR__ . '/get-user-by-id.php';
 require_once __DIR__ . '/get-user-artists.php';
 require_once __DIR__ . '/get-user-artist-access.php';

--- a/tests/unit/LocalSceneMembersAbilityTest.php
+++ b/tests/unit/LocalSceneMembersAbilityTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Tests for the public Local Scene member directory.
+ *
+ * @package ExtraChill\Users
+ */
+
+class Test_Local_Scene_Members_Ability extends WP_UnitTestCase {
+
+	/** @var int */
+	private $events_blog_id;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->events_blog_id = self::factory()->blog->create();
+		add_filter( 'extrachill_users_events_blog_id', array( $this, 'filter_events_blog_id' ) );
+
+		switch_to_blog( $this->events_blog_id );
+		register_taxonomy( 'location', 'post', array( 'public' => true ) );
+		$region = wp_insert_term( 'USA', 'location' );
+		$state  = wp_insert_term( 'South Carolina', 'location', array( 'parent' => $region['term_id'] ) );
+		wp_insert_term( 'Charleston', 'location', array( 'slug' => 'charleston-sc', 'parent' => $state['term_id'] ) );
+		restore_current_blog();
+	}
+
+	protected function tearDown(): void {
+		remove_filter( 'extrachill_users_events_blog_id', array( $this, 'filter_events_blog_id' ) );
+		parent::tearDown();
+	}
+
+	public function filter_events_blog_id(): int {
+		return $this->events_blog_id;
+	}
+
+	public function test_public_readonly_ability_is_registered(): void {
+		$ability = wp_get_ability( 'extrachill/local-scene-members' );
+
+		$this->assertNotNull( $ability );
+		$this->assertTrue( $ability->get_meta()['annotations']['readonly'] );
+	}
+
+	public function test_privacy_filter_excludes_private_members_from_rows_and_totals(): void {
+		$legacy_public   = $this->create_member( 'Alpha', null );
+		$explicit_public = $this->create_member( 'Bravo', 'public' );
+		$private         = $this->create_member( 'Charlie', 'private' );
+		$this->create_member( 'Different Scene', 'public', 'charleston-tx' );
+
+		$result = extrachill_users_ability_local_scene_members( array( 'slug' => 'charleston-sc' ) );
+		$ids    = wp_list_pluck( $result['members'], 'user_id' );
+
+		$this->assertSame( array( $legacy_public, $explicit_public ), $ids );
+		$this->assertNotContains( $private, $ids );
+		$this->assertSame( 2, $result['pagination']['total'] );
+		$this->assertArrayNotHasKey( 'email', $result['members'][0] );
+		$this->assertSame( 'charleston-sc', $result['scene']['slug'] );
+	}
+
+	public function test_pagination_counts_only_public_matches(): void {
+		$this->create_member( 'Alpha', null );
+		$second = $this->create_member( 'Bravo', 'public' );
+		$this->create_member( 'Charlie', 'private' );
+
+		$result = extrachill_users_ability_local_scene_members(
+			array(
+				'slug'     => 'charleston-sc',
+				'page'     => 2,
+				'per_page' => 1,
+			)
+		);
+
+		$this->assertSame( array( $second ), wp_list_pluck( $result['members'], 'user_id' ) );
+		$this->assertSame( 2, $result['pagination']['total'] );
+		$this->assertSame( 2, $result['pagination']['total_pages'] );
+	}
+
+	private function create_member( string $display_name, ?string $visibility, string $scene = 'charleston-sc' ): int {
+		$user_id = self::factory()->user->create( array( 'display_name' => $display_name ) );
+		update_user_meta( $user_id, EXTRACHILL_USERS_LOCAL_SCENE_META_KEY, $scene );
+		if ( null !== $visibility ) {
+			update_user_meta( $user_id, EXTRACHILL_USERS_LOCAL_SCENE_VISIBILITY_META_KEY, $visibility );
+		}
+		return $user_id;
+	}
+}


### PR DESCRIPTION
Adds a public readonly paginated Local Scene member Ability. Resolves canonical scenes, returns safe profile-card fields, and excludes private users from rows, totals, and pagination. Missing visibility preserves legacy-public semantics. Fixes #190.