### PR TITLE
feat: collect Local Scene during onboarding

### DIFF
--- a/blocks/onboarding/render.php
+++ b/blocks/onboarding/render.php
@@ -37,6 +37,7 @@ $redirect_url     = $stored_redirect ? $stored_redirect : $default_url;
 $from_join        = get_user_meta( $user_id, 'onboarding_from_join', true ) === '1';
 $user             = get_userdata( $user_id );
 $current_username = $user ? $user->user_login : '';
+ec_users_emit_onboarding_event( EC_ANALYTICS_EVENT_ONBOARDING_VIEWED, $user_id );
 ?>
 
 <div class="onboarding-container">
@@ -50,6 +51,7 @@ $current_username = $user ? $user->user_login : '';
 		data-redirect-url="<?php echo esc_attr( $redirect_url ); ?>"
 		data-from-join="<?php echo $from_join ? 'true' : 'false'; ?>"
 		data-rest-url="<?php echo esc_url( rest_url( 'extrachill/v1/' ) ); ?>"
+		data-abilities-url="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>"
 		data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>"
 		data-username="<?php echo esc_attr( $current_username ); ?>"
 	>
@@ -68,6 +70,19 @@ $current_username = $user ? $user->user_login : '';
 					placeholder="<?php esc_attr_e( 'Your username', 'extrachill-users' ); ?>"
 				>
 				<small class="onboarding-field-hint"><?php esc_html_e( 'Letters, numbers, hyphens, and underscores only. 3-60 characters.', 'extrachill-users' ); ?></small>
+			</div>
+
+			<div class="onboarding-field onboarding-local-scene">
+				<label for="onboarding-local-scene"><?php esc_html_e( 'Local Scene (optional)', 'extrachill-users' ); ?></label>
+				<input type="search" id="onboarding-local-scene" autocomplete="off" placeholder="<?php esc_attr_e( 'Search cities and regions', 'extrachill-users' ); ?>" aria-autocomplete="list" aria-controls="onboarding-local-scene-results">
+				<input type="hidden" id="onboarding-local-scene-slug" value="">
+				<div id="onboarding-local-scene-results" class="onboarding-local-scene-results" role="listbox" hidden></div>
+				<small class="onboarding-field-hint"><?php esc_html_e( 'Find people and live music near you. You can change this anytime.', 'extrachill-users' ); ?></small>
+				<fieldset class="onboarding-visibility">
+					<legend><?php esc_html_e( 'Who can see your Local Scene?', 'extrachill-users' ); ?></legend>
+					<label><input type="radio" name="local_scene_visibility" value="public" checked> <?php esc_html_e( 'Public', 'extrachill-users' ); ?></label>
+					<label><input type="radio" name="local_scene_visibility" value="private"> <?php esc_html_e( 'Private', 'extrachill-users' ); ?></label>
+				</fieldset>
 			</div>
 
 			<div class="onboarding-field onboarding-checkboxes">

--- a/blocks/onboarding/style.css
+++ b/blocks/onboarding/style.css
@@ -35,7 +35,8 @@
 	font-weight: 500;
 }
 
-.onboarding-field input[type="text"] {
+.onboarding-field input[type="text"],
+.onboarding-field input[type="search"] {
 	width: 100%;
 	padding: 0.75rem;
 	border: 1px solid var(--border-color);
@@ -43,11 +44,20 @@
 	font-size: 1rem;
 }
 
-.onboarding-field input[type="text"]:focus {
+.onboarding-field input[type="text"]:focus,
+.onboarding-field input[type="search"]:focus {
 	outline: none;
 	border-color: var(--focus-border-color);
 	box-shadow: var(--focus-box-shadow);
 }
+
+.onboarding-local-scene { position: relative; }
+.onboarding-local-scene-results { position: absolute; z-index: 10; width: 100%; max-height: 12rem; overflow-y: auto; background: var(--card-background); border: 1px solid var(--border-color); border-radius: 4px; }
+.onboarding-local-scene-option { display: block; width: 100%; padding: 0.75rem; border: 0; border-bottom: 1px solid var(--border-color); background: transparent; color: inherit; text-align: left; cursor: pointer; }
+.onboarding-local-scene-option:hover, .onboarding-local-scene-option:focus { background: var(--notice-bg); }
+.onboarding-visibility { display: flex; flex-wrap: wrap; gap: 0.5rem 1rem; margin: 0.75rem 0 0; padding: 0; border: 0; }
+.onboarding-visibility legend { width: 100%; margin-bottom: 0.35rem; font-size: 0.875rem; font-weight: 500; }
+.onboarding-visibility label { display: inline-flex; align-items: center; gap: 0.3rem; margin: 0; font-weight: normal; }
 
 .onboarding-field-hint {
 	display: block;

--- a/blocks/onboarding/view.js
+++ b/blocks/onboarding/view.js
@@ -20,6 +20,7 @@
         }
 
         const restUrl = container.dataset.restUrl || '';
+        const abilitiesUrl = container.dataset.abilitiesUrl || '';
         const nonce = container.dataset.nonce || '';
         const redirectUrl = container.dataset.redirectUrl || '/';
         const fromJoin = container.dataset.fromJoin === 'true';
@@ -28,6 +29,61 @@
         const artistCheckbox = document.getElementById('user_is_artist');
         const professionalCheckbox = document.getElementById('user_is_professional');
         const submitButton = document.getElementById('onboarding-submit');
+        const sceneInput = document.getElementById('onboarding-local-scene');
+        const sceneSlugInput = document.getElementById('onboarding-local-scene-slug');
+        const sceneResults = document.getElementById('onboarding-local-scene-results');
+        let searchTimer;
+        let searchRequest = 0;
+
+        if (sceneInput && sceneSlugInput && sceneResults) {
+            sceneInput.addEventListener('input', function () {
+                sceneSlugInput.value = '';
+                window.clearTimeout(searchTimer);
+                const search = sceneInput.value.trim();
+                if (!search) {
+                    sceneResults.hidden = true;
+                    sceneResults.replaceChildren();
+                    return;
+                }
+
+                const request = ++searchRequest;
+                searchTimer = window.setTimeout(function () {
+                    fetch(abilitiesUrl + 'extrachill%2Fuser-event-locations/run', {
+                        method: 'POST',
+                        credentials: 'same-origin',
+                        headers: { 'Content-Type': 'application/json', 'X-WP-Nonce': nonce },
+                        body: JSON.stringify({ input: { mode: 'search', search, limit: 10 } })
+                    })
+                        .then(function (response) {
+                            if (!response.ok) throw new Error('Local Scene search is temporarily unavailable.');
+                            return response.json();
+                        })
+                        .then(function (response) {
+                            if (request !== searchRequest) return;
+                            const data = response && response.result ? response.result : response;
+                            const locations = data && Array.isArray(data.locations) ? data.locations : [];
+                            sceneResults.replaceChildren();
+                            locations.forEach(function (location) {
+                                const option = document.createElement('button');
+                                option.type = 'button';
+                                option.className = 'onboarding-local-scene-option';
+                                option.setAttribute('role', 'option');
+                                option.textContent = location.hierarchy && location.hierarchy.label ? location.hierarchy.label : location.name;
+                                option.addEventListener('click', function () {
+                                    sceneInput.value = option.textContent;
+                                    sceneSlugInput.value = location.slug;
+                                    sceneResults.hidden = true;
+                                });
+                                sceneResults.appendChild(option);
+                            });
+                            sceneResults.hidden = locations.length === 0;
+                        })
+                        .catch(function (err) {
+                            if (request === searchRequest) utils.renderNotice(container, 'error', err.message);
+                        });
+                }, 250);
+            });
+        }
 
         form.addEventListener('submit', function (event) {
             event.preventDefault();
@@ -36,6 +92,9 @@
             const username = usernameInput ? usernameInput.value.trim() : '';
             const isArtist = artistCheckbox ? artistCheckbox.checked : false;
             const isProfessional = professionalCheckbox ? professionalCheckbox.checked : false;
+            const localScene = sceneSlugInput ? sceneSlugInput.value : '';
+            const visibilityInput = form.querySelector('input[name="local_scene_visibility"]:checked');
+            const localSceneVisibility = visibilityInput ? visibilityInput.value : 'public';
 
             if (!username) {
                 utils.renderNotice(container, 'error', 'Please enter a username.');
@@ -57,6 +116,12 @@
                 return;
             }
 
+            if (sceneInput && sceneInput.value.trim() && !localScene) {
+                utils.renderNotice(container, 'error', 'Choose a Local Scene from the search results, or clear the field to skip it.');
+                sceneInput.focus();
+                return;
+            }
+
             if (fromJoin && !isArtist && !isProfessional) {
                 utils.renderNotice(container, 'error', 'Please select "I am a musician" or "I work in the music industry" to continue.');
                 return;
@@ -73,11 +138,12 @@
                     'Content-Type': 'application/json',
                     'X-WP-Nonce': nonce
                 },
-                body: JSON.stringify({
+                body: JSON.stringify(Object.assign({
                     username,
                     user_is_artist: isArtist,
-                    user_is_professional: isProfessional
-                })
+                    user_is_professional: isProfessional,
+                    local_scene_visibility: localSceneVisibility
+                }, localScene ? { local_scene: localScene } : {}))
             })
                 .then(function (response) {
                     return response.json().then(function (data) {

--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -143,6 +143,7 @@ function extrachill_users_init() {
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/rank-system/rank-tiers.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/rank-system/points-engine.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/rank-system/contribution-events.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/onboarding/analytics.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/onboarding/service.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/lifetime-membership.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/shop-permissions.php';

--- a/inc/core/abilities/onboarding.php
+++ b/inc/core/abilities/onboarding.php
@@ -30,21 +30,30 @@ function extrachill_users_register_onboarding_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'user_id'              => array(
+					'user_id'                => array(
 						'type'        => 'integer',
 						'description' => __( 'User ID to complete onboarding for.', 'extrachill-users' ),
 					),
-					'username'             => array(
+					'username'               => array(
 						'type'        => 'string',
 						'description' => __( 'Chosen username.', 'extrachill-users' ),
 					),
-					'user_is_artist'       => array(
+					'user_is_artist'         => array(
 						'type'        => 'boolean',
 						'description' => __( 'Whether user is a musician.', 'extrachill-users' ),
 					),
-					'user_is_professional' => array(
+					'user_is_professional'   => array(
 						'type'        => 'boolean',
 						'description' => __( 'Whether user works in the music industry.', 'extrachill-users' ),
+					),
+					'local_scene'            => array(
+						'type'        => 'string',
+						'description' => __( 'Optional canonical Local Scene slug.', 'extrachill-users' ),
+					),
+					'local_scene_visibility' => array(
+						'type'    => 'string',
+						'enum'    => array( 'public', 'private' ),
+						'default' => 'public',
 					),
 				),
 				'required'   => array( 'user_id', 'username' ),
@@ -161,14 +170,16 @@ function extrachill_users_ability_complete_onboarding( $input ) {
 	$username             = isset( $input['username'] ) ? sanitize_user( $input['username'], true ) : '';
 	$user_is_artist       = ! empty( $input['user_is_artist'] );
 	$user_is_professional = ! empty( $input['user_is_professional'] );
+	$local_scene          = isset( $input['local_scene'] ) ? sanitize_title( (string) $input['local_scene'] ) : '';
+	$visibility           = isset( $input['local_scene_visibility'] ) ? sanitize_key( (string) $input['local_scene_visibility'] ) : 'public';
 
 	$user = get_userdata( $user_id );
 	if ( ! $user ) {
-		return new WP_Error( 'invalid_user', __( 'Invalid user.', 'extrachill-users' ) );
+		return ec_users_onboarding_error( 'invalid_user', __( 'Invalid user.', 'extrachill-users' ), $user_id );
 	}
 
 	if ( function_exists( 'ec_is_onboarding_complete' ) && ec_is_onboarding_complete( $user_id ) ) {
-		return new WP_Error( 'already_completed', __( 'Onboarding already completed.', 'extrachill-users' ) );
+		return ec_users_onboarding_error( 'already_completed', __( 'Onboarding already completed.', 'extrachill-users' ), $user_id );
 	}
 
 	// Validate username via ability.
@@ -182,17 +193,30 @@ function extrachill_users_ability_complete_onboarding( $input ) {
 		);
 
 		if ( is_wp_error( $valid ) ) {
-			return $valid;
+			return ec_users_onboarding_error( $valid->get_error_code(), $valid->get_error_message(), $user_id );
 		}
 	}
 
 	// Join flow requires artist or professional flag.
 	$from_join = function_exists( 'ec_is_onboarding_from_join' ) && ec_is_onboarding_from_join( $user_id );
 	if ( $from_join && ! $user_is_artist && ! $user_is_professional ) {
-		return new WP_Error(
+		return ec_users_onboarding_error(
 			'artist_or_professional_required',
-			__( 'Please select "I am a musician" or "I work in the music industry" to continue.', 'extrachill-users' )
+			__( 'Please select "I am a musician" or "I work in the music industry" to continue.', 'extrachill-users' ),
+			$user_id
 		);
+	}
+
+	if ( '' !== $local_scene ) {
+		$scene_result = extrachill_users_resolve_local_scene( $local_scene );
+		if ( is_wp_error( $scene_result ) ) {
+			return ec_users_onboarding_error( $scene_result->get_error_code(), $scene_result->get_error_message(), $user_id );
+		}
+		$local_scene = $scene_result['slug'];
+	}
+
+	if ( ! in_array( $visibility, array( 'public', 'private' ), true ) ) {
+		return ec_users_onboarding_error( 'invalid_local_scene_visibility', __( 'Local Scene visibility must be public or private.', 'extrachill-users' ), $user_id );
 	}
 
 	// Update username in database.
@@ -211,8 +235,13 @@ function extrachill_users_ability_complete_onboarding( $input ) {
 	);
 
 	if ( false === $result ) {
-		return new WP_Error( 'update_failed', __( 'Failed to update username.', 'extrachill-users' ) );
+		return ec_users_onboarding_error( 'update_failed', __( 'Failed to update username.', 'extrachill-users' ), $user_id );
 	}
+
+	if ( '' !== $local_scene ) {
+		extrachill_users_set_local_scene( $user_id, $local_scene );
+	}
+	extrachill_users_set_local_scene_visibility( $user_id, $visibility );
 
 	// Set flags and mark complete.
 	update_user_meta( $user_id, 'user_is_artist', $user_is_artist ? '1' : '0' );
@@ -233,6 +262,17 @@ function extrachill_users_ability_complete_onboarding( $input ) {
 	 * @param array $input   Onboarding data.
 	 */
 	do_action( 'ec_onboarding_completed', $user_id, $input );
+
+	$event_data = array(
+		'has_local_scene' => '' !== $local_scene,
+		'is_artist'       => $user_is_artist,
+		'is_professional' => $user_is_professional,
+		'from_join'       => $from_join,
+	);
+	ec_users_emit_onboarding_event( EC_ANALYTICS_EVENT_ONBOARDING_COMPLETED, $user_id, $event_data );
+	if ( get_user_meta( $user_id, 'onboarding_reminder_sent_at', true ) ) {
+		ec_users_emit_onboarding_event( EC_ANALYTICS_EVENT_ONBOARDING_REMINDER_RECOVERED, $user_id, $event_data );
+	}
 
 	// Send welcome email via ability.
 	$email_ability = wp_get_ability( 'extrachill/send-welcome-email' );
@@ -297,9 +337,11 @@ function extrachill_users_ability_get_onboarding_status( $input ) {
 		'completed' => $completed,
 		'from_join' => '1' === get_user_meta( $user_id, 'onboarding_from_join', true ),
 		'fields'    => array(
-			'username'             => $user->user_login,
-			'user_is_artist'       => '1' === get_user_meta( $user_id, 'user_is_artist', true ),
-			'user_is_professional' => '1' === get_user_meta( $user_id, 'user_is_professional', true ),
+			'username'               => $user->user_login,
+			'user_is_artist'         => '1' === get_user_meta( $user_id, 'user_is_artist', true ),
+			'user_is_professional'   => '1' === get_user_meta( $user_id, 'user_is_professional', true ),
+			'local_scene'            => extrachill_users_get_local_scene( $user_id ),
+			'local_scene_visibility' => extrachill_users_get_local_scene_visibility( $user_id ),
 		),
 	);
 }

--- a/inc/core/abilities/user-settings.php
+++ b/inc/core/abilities/user-settings.php
@@ -267,11 +267,11 @@ function extrachill_users_ability_update_settings( $input ) {
 
 	if ( array_key_exists( 'local_scene_visibility', $input ) ) {
 		$visibility = sanitize_key( (string) $input['local_scene_visibility'] );
-		if ( ! in_array( $visibility, array( 'public', 'private' ), true ) ) {
-			return new WP_Error( 'invalid_local_scene_visibility', __( 'Local Scene visibility must be public or private.', 'extrachill-users' ), array( 'status' => 400 ) );
+		$result     = extrachill_users_set_local_scene_visibility( $user_id, $visibility );
+		if ( is_wp_error( $result ) ) {
+			return $result;
 		}
-		if ( extrachill_users_get_local_scene_visibility( $user_id ) !== $visibility || ! metadata_exists( 'user', $user_id, EXTRACHILL_USERS_LOCAL_SCENE_VISIBILITY_META_KEY ) ) {
-			update_user_meta( $user_id, EXTRACHILL_USERS_LOCAL_SCENE_VISIBILITY_META_KEY, $visibility );
+		if ( $result ) {
 			$changed = true;
 		}
 	}
@@ -382,6 +382,27 @@ function extrachill_users_set_local_scene( int $user_id, string $value ) {
  */
 function extrachill_users_get_local_scene_visibility( int $user_id ): string {
 	return 'private' === get_user_meta( $user_id, EXTRACHILL_USERS_LOCAL_SCENE_VISIBILITY_META_KEY, true ) ? 'private' : 'public';
+}
+
+/**
+ * Persist Local Scene profile visibility using the canonical meta semantics.
+ *
+ * @param int    $user_id User ID.
+ * @param string $visibility Public or private.
+ * @return bool|WP_Error Whether storage changed, or an error.
+ */
+function extrachill_users_set_local_scene_visibility( int $user_id, string $visibility ) {
+	$visibility = sanitize_key( $visibility );
+	if ( ! in_array( $visibility, array( 'public', 'private' ), true ) ) {
+		return new WP_Error( 'invalid_local_scene_visibility', __( 'Local Scene visibility must be public or private.', 'extrachill-users' ), array( 'status' => 400 ) );
+	}
+
+	if ( extrachill_users_get_local_scene_visibility( $user_id ) === $visibility && metadata_exists( 'user', $user_id, EXTRACHILL_USERS_LOCAL_SCENE_VISIBILITY_META_KEY ) ) {
+		return false;
+	}
+
+	update_user_meta( $user_id, EXTRACHILL_USERS_LOCAL_SCENE_VISIBILITY_META_KEY, $visibility );
+	return true;
 }
 
 /**

--- a/inc/core/abilities/welcome-email.php
+++ b/inc/core/abilities/welcome-email.php
@@ -76,8 +76,12 @@ function extrachill_users_ability_send_welcome_email( $input ) {
 	$user_id    = absint( $input['user_id'] );
 	$email_type = $input['email_type'];
 
-	$already_sent = get_user_meta( $user_id, 'welcome_email_sent', true );
-	if ( '1' === $already_sent ) {
+	$variant_meta = 'onboarding_complete' === $email_type ? 'welcome_email_complete_sent' : 'welcome_email_incomplete_sent';
+	$already_sent = get_user_meta( $user_id, $variant_meta, true );
+	$legacy_sent  = '1' === get_user_meta( $user_id, 'welcome_email_sent', true );
+	$was_reminder = (bool) get_user_meta( $user_id, 'onboarding_reminder_sent_at', true );
+
+	if ( '1' === $already_sent || ( $legacy_sent && ! ( 'onboarding_complete' === $email_type && $was_reminder ) ) ) {
 		return false;
 	}
 
@@ -96,6 +100,11 @@ function extrachill_users_ability_send_welcome_email( $input ) {
 
 	if ( $result ) {
 		update_user_meta( $user_id, 'welcome_email_sent', '1' );
+		update_user_meta( $user_id, $variant_meta, '1' );
+		if ( 'onboarding_incomplete' === $email_type ) {
+			update_user_meta( $user_id, 'onboarding_reminder_sent_at', time() );
+			ec_users_emit_onboarding_event( EC_ANALYTICS_EVENT_ONBOARDING_REMINDER_SENT, $user_id );
+		}
 	}
 
 	return $result;

--- a/inc/onboarding/analytics.php
+++ b/inc/onboarding/analytics.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Privacy-safe onboarding analytics helpers.
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Emit a privacy-safe onboarding event through the canonical Ability.
+ *
+ * @param string $event_type Canonical analytics event constant.
+ * @param int    $user_id User ID.
+ * @param array  $extra Additional bounded event fields.
+ * @return int Event ID, or zero when analytics is unavailable.
+ */
+function ec_users_emit_onboarding_event( string $event_type, int $user_id, array $extra = array() ): int {
+	$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/track-analytics-event' ) : null;
+	if ( ! $ability ) {
+		return 0;
+	}
+
+	$result = $ability->execute(
+		array(
+			'event_type' => $event_type,
+			'event_data' => array_merge( ec_users_get_onboarding_attribution( $user_id ), $extra ),
+		)
+	);
+
+	return is_int( $result ) ? $result : 0;
+}
+
+/**
+ * Get bounded registration attribution for onboarding events.
+ *
+ * @param int $user_id User ID.
+ * @return array Attribution fields.
+ */
+function ec_users_get_onboarding_attribution( int $user_id ): array {
+	$source = sanitize_key( (string) get_user_meta( $user_id, 'registration_source', true ) );
+	$method = sanitize_key( (string) get_user_meta( $user_id, 'registration_method', true ) );
+
+	return array(
+		'user_id' => $user_id,
+		'source'  => $source ? $source : 'unknown',
+		'method'  => $method ? $method : 'unknown',
+		'surface' => ec_is_onboarding_from_join( $user_id ) ? 'join' : 'registration',
+	);
+}
+
+/**
+ * Emit a safe failure code and return the corresponding error.
+ *
+ * @param string $code Stable error code.
+ * @param string $message User-facing message.
+ * @param int    $user_id User ID.
+ * @return WP_Error Onboarding error.
+ */
+function ec_users_onboarding_error( string $code, string $message, int $user_id ): WP_Error {
+	ec_users_emit_onboarding_event(
+		EC_ANALYTICS_EVENT_ONBOARDING_SUBMISSION_FAILED,
+		$user_id,
+		array( 'error_code' => sanitize_key( $code ) )
+	);
+
+	return new WP_Error( $code, $message );
+}

--- a/inc/onboarding/service.php
+++ b/inc/onboarding/service.php
@@ -153,9 +153,11 @@ function ec_get_onboarding_status( $user_id ) {
 		'completed' => $completed,
 		'from_join' => $from_join,
 		'fields'    => array(
-			'username'             => $user->user_login,
-			'user_is_artist'       => '1' === get_user_meta( $user_id, 'user_is_artist', true ),
-			'user_is_professional' => '1' === get_user_meta( $user_id, 'user_is_professional', true ),
+			'username'               => $user->user_login,
+			'user_is_artist'         => '1' === get_user_meta( $user_id, 'user_is_artist', true ),
+			'user_is_professional'   => '1' === get_user_meta( $user_id, 'user_is_professional', true ),
+			'local_scene'            => extrachill_users_get_local_scene( $user_id ),
+			'local_scene_visibility' => extrachill_users_get_local_scene_visibility( $user_id ),
 		),
 	);
 }
@@ -178,10 +180,12 @@ function ec_complete_onboarding( $user_id, $data ) {
 
 	return $ability->execute(
 		array(
-			'user_id'              => absint( $user_id ),
-			'username'             => isset( $data['username'] ) ? $data['username'] : '',
-			'user_is_artist'       => ! empty( $data['user_is_artist'] ),
-			'user_is_professional' => ! empty( $data['user_is_professional'] ),
+			'user_id'                => absint( $user_id ),
+			'username'               => isset( $data['username'] ) ? $data['username'] : '',
+			'user_is_artist'         => ! empty( $data['user_is_artist'] ),
+			'user_is_professional'   => ! empty( $data['user_is_professional'] ),
+			'local_scene_visibility' => isset( $data['local_scene_visibility'] ) ? $data['local_scene_visibility'] : 'public',
+			'local_scene'            => isset( $data['local_scene'] ) ? $data['local_scene'] : '',
 		)
 	);
 }

--- a/tests/unit/UserSettingsDefaultEventLocationTest.php
+++ b/tests/unit/UserSettingsDefaultEventLocationTest.php
@@ -133,6 +133,51 @@ class Test_User_Settings_Default_Event_Location extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Onboarding persists the canonical scene and explicit visibility.
+	 */
+	public function test_onboarding_persists_private_local_scene_before_completion(): void {
+		$user_id = self::factory()->user->create( array( 'user_login' => 'sceneuser' ) );
+		update_user_meta( $user_id, 'onboarding_completed', '0' );
+
+		$result = extrachill_users_ability_complete_onboarding(
+			array(
+				'user_id'                => $user_id,
+				'username'               => 'sceneuser',
+				'user_is_artist'         => false,
+				'user_is_professional'   => false,
+				'local_scene'            => 'charleston-sc',
+				'local_scene_visibility' => 'private',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( '1', get_user_meta( $user_id, 'onboarding_completed', true ) );
+		$this->assertSame( 'charleston-sc', get_user_meta( $user_id, EXTRACHILL_USERS_LOCAL_SCENE_META_KEY, true ) );
+		$this->assertSame( 'private', extrachill_users_get_local_scene_visibility( $user_id ) );
+	}
+
+	/**
+	 * A rejected scene must not mark onboarding complete.
+	 */
+	public function test_onboarding_local_scene_failure_prevents_completion(): void {
+		$user_id = self::factory()->user->create( array( 'user_login' => 'invalidsceneuser' ) );
+		update_user_meta( $user_id, 'onboarding_completed', '0' );
+
+		$result = extrachill_users_ability_complete_onboarding(
+			array(
+				'user_id'                => $user_id,
+				'username'               => 'invalidsceneuser',
+				'local_scene'            => 'not-a-scene',
+				'local_scene_visibility' => 'public',
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( '0', get_user_meta( $user_id, 'onboarding_completed', true ) );
+		$this->assertFalse( metadata_exists( 'user', $user_id, EXTRACHILL_USERS_LOCAL_SCENE_VISIBILITY_META_KEY ) );
+	}
+
+	/**
 	 * Non-city terms and unknown slugs are rejected.
 	 */
 	public function test_invalid_write_returns_error_without_persisting(): void {
@@ -203,7 +248,15 @@ class Test_User_Settings_Default_Event_Location extends WP_UnitTestCase {
 
 		$dry_run = extrachill_users_migrate_legacy_local_scenes( false, array( $matched, $ambiguous, $unmatched, $already ) );
 
-		$this->assertSame( array( 'matched' => 1, 'ambiguous' => 1, 'unmatched' => 1, 'already-set' => 1 ), $dry_run['totals'] );
+		$this->assertSame(
+			array(
+				'matched'     => 1,
+				'ambiguous'   => 1,
+				'unmatched'   => 1,
+				'already-set' => 1,
+			),
+			$dry_run['totals']
+		);
 		$this->assertFalse( metadata_exists( 'user', $matched, EXTRACHILL_USERS_LOCAL_SCENE_META_KEY ) );
 
 		$applied = extrachill_users_migrate_legacy_local_scenes( true, array( $matched, $ambiguous, $unmatched, $already ) );


### PR DESCRIPTION
Adds an optional canonical Local Scene search and explicit public/private choice to the existing single-screen onboarding flow. Persists through Users-owned helpers, emits privacy-safe funnel events, preserves legacy-client defaults, and separates reminder/completion email state so recovered users receive the correct welcome email. Fixes #192. Fixes #194.