### PR TITLE
fix: require onboarding before profile writes

### DIFF
--- a/inc/core/abilities/user-profile.php
+++ b/inc/core/abilities/user-profile.php
@@ -141,6 +141,24 @@ function extrachill_users_get_link_types() {
 }
 
 /**
+ * Require the authenticated user to finish the onboarding lifecycle.
+ *
+ * @param int $user_id User ID.
+ * @return true|WP_Error True when eligible, otherwise an onboarding error.
+ */
+function extrachill_users_require_completed_onboarding( $user_id ) {
+	if ( ec_is_onboarding_complete( $user_id ) ) {
+		return true;
+	}
+
+	return new WP_Error(
+		'onboarding_incomplete',
+		__( 'Complete onboarding before updating your public profile.', 'extrachill-users' ),
+		array( 'status' => 403 )
+	);
+}
+
+/**
  * Get user profile data.
  *
  * @param array $input Input with 'user_id'.
@@ -237,6 +255,11 @@ function extrachill_users_ability_update_profile( $input ) {
 		return $user_id;
 	}
 
+	$onboarding = extrachill_users_require_completed_onboarding( $user_id );
+	if ( is_wp_error( $onboarding ) ) {
+		return $onboarding;
+	}
+
 	$user = get_user_by( 'ID', $user_id );
 	if ( ! $user ) {
 		return new WP_Error( 'user_not_found', 'User not found.' );
@@ -296,6 +319,11 @@ function extrachill_users_ability_update_links( $input ) {
 	$user_id = extrachill_users_resolve_self_user_id();
 	if ( is_wp_error( $user_id ) ) {
 		return $user_id;
+	}
+
+	$onboarding = extrachill_users_require_completed_onboarding( $user_id );
+	if ( is_wp_error( $onboarding ) ) {
+		return $onboarding;
 	}
 
 	$links = isset( $input['links'] ) ? $input['links'] : array();

--- a/tests/unit/UserProfileOnboardingGateTest.php
+++ b/tests/unit/UserProfileOnboardingGateTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Tests for the public profile onboarding gate.
+ *
+ * @package ExtraChill\Users
+ */
+
+/**
+ * Verify profile writes use the canonical onboarding lifecycle state.
+ */
+class Test_User_Profile_Onboarding_Gate extends WP_UnitTestCase {
+
+	/**
+	 * Reset the authenticated user between tests.
+	 */
+	protected function tearDown(): void {
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	/**
+	 * Create and authenticate a test user.
+	 *
+	 * @return int User ID.
+	 */
+	private function create_authenticated_user(): int {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+
+		return $user_id;
+	}
+
+	/**
+	 * Incomplete users cannot publish profile fields or links.
+	 */
+	public function test_incomplete_user_cannot_update_public_profile(): void {
+		$user_id = $this->create_authenticated_user();
+		update_user_meta( $user_id, 'onboarding_completed', '0' );
+
+		$profile_result = extrachill_users_ability_update_profile(
+			array(
+				'bio'          => 'Promotional profile',
+				'custom_title' => 'Promotional title',
+			)
+		);
+		$links_result   = extrachill_users_ability_update_links(
+			array(
+				'links' => array(
+					array(
+						'type_key' => 'website',
+						'url'      => 'https://example.com',
+					),
+				),
+			)
+		);
+
+		$this->assertWPError( $profile_result );
+		$this->assertSame( 'onboarding_incomplete', $profile_result->get_error_code() );
+		$this->assertWPError( $links_result );
+		$this->assertSame( 'onboarding_incomplete', $links_result->get_error_code() );
+		$this->assertSame( '', get_userdata( $user_id )->description );
+		$this->assertSame( '', get_user_meta( $user_id, 'ec_custom_title', true ) );
+		$this->assertSame( '', get_user_meta( $user_id, '_user_profile_dynamic_links', true ) );
+	}
+
+	/**
+	 * Minimal onboarding completion permits profile writes.
+	 */
+	public function test_completed_user_can_update_public_profile(): void {
+		$user_id = $this->create_authenticated_user();
+		update_user_meta( $user_id, 'onboarding_completed', '1' );
+
+		$profile_result = extrachill_users_ability_update_profile( array( 'bio' => 'Music fan' ) );
+		$links_result   = extrachill_users_ability_update_links(
+			array(
+				'links' => array(
+					array(
+						'type_key' => 'website',
+						'url'      => 'https://example.com',
+					),
+				),
+			)
+		);
+
+		$this->assertNotWPError( $profile_result );
+		$this->assertNotWPError( $links_result );
+		$this->assertSame( 'Music fan', get_userdata( $user_id )->description );
+		$this->assertCount( 1, get_user_meta( $user_id, '_user_profile_dynamic_links', true ) );
+	}
+
+	/**
+	 * Grandfathered users without onboarding metadata remain eligible.
+	 */
+	public function test_grandfathered_user_can_update_public_profile(): void {
+		$user_id = $this->create_authenticated_user();
+
+		$result = extrachill_users_ability_update_profile( array( 'bio' => 'Legacy member' ) );
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( 'Legacy member', get_userdata( $user_id )->description );
+	}
+}


### PR DESCRIPTION
## Summary
- block public profile and profile-link writes while canonical onboarding state is incomplete
- preserve access for minimally completed and grandfathered users through `ec_is_onboarding_complete()`
- cover incomplete, completed, and legacy account states with regression tests

Closes #199.

## Verification
- `homeboy review lint extrachill-users --changed-only --summary` passed
- `homeboy review extrachill-users --changed-since origin/main --summary`: audit and lint passed
- PHPUnit sandbox did not execute tests because Homeboy provisioned single-site WordPress and plugin activation correctly requires multisite; 0 tests ran