### PR TITLE
fix: revoke sessions when banning users

### DIFF
--- a/inc/core/moderation/actions.php
+++ b/inc/core/moderation/actions.php
@@ -36,7 +36,7 @@ function extrachill_users_apply_moderation_action( int $user_id, array $args = a
 	update_user_meta( $user_id, extrachill_users_moderation_meta_key(), $payload );
 	delete_user_meta( $user_id, extrachill_users_legacy_ban_meta_key() );
 
-	if ( ! empty( $policy['effects']['revoke_sessions'] ) && function_exists( 'WP_Session_Tokens' ) ) {
+	if ( ! empty( $policy['effects']['revoke_sessions'] ) && class_exists( 'WP_Session_Tokens' ) ) {
 		$manager = WP_Session_Tokens::get_instance( $user_id );
 		$manager->destroy_all();
 	}

--- a/tests/unit/ModerationSessionRevocationTest.php
+++ b/tests/unit/ModerationSessionRevocationTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Tests for moderation session revocation.
+ *
+ * @package ExtraChill\Users
+ */
+
+/**
+ * Verify blocking moderation actions invalidate existing sessions.
+ */
+class Test_Moderation_Session_Revocation extends WP_UnitTestCase {
+
+	/**
+	 * A ban destroys every existing WordPress session for the user.
+	 */
+	public function test_ban_revokes_existing_sessions(): void {
+		$user_id  = self::factory()->user->create();
+		$sessions = WP_Session_Tokens::get_instance( $user_id );
+		$sessions->create( time() + HOUR_IN_SECONDS );
+
+		$this->assertCount( 1, $sessions->get_all() );
+
+		$result = extrachill_users_apply_moderation_action(
+			$user_id,
+			array(
+				'reason_key' => 'other',
+				'source'     => 'phpunit',
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( 'banned', $result['state'] );
+		$this->assertSame( array(), WP_Session_Tokens::get_instance( $user_id )->get_all() );
+	}
+}


### PR DESCRIPTION
## Summary
- fix the moderation revocation guard to detect `WP_Session_Tokens` as a class
- add regression coverage proving an existing browser session is destroyed by a ban

Closes #201.

## Verification
- PHP syntax checks passed
- `git diff --check` passed
- Homeboy PHPCS lint passed
- PHPUnit sandbox remains unavailable because it provisions single-site WordPress for this multisite-only plugin