### PR TITLE
fix: make onboarding resilient to browser failures

### DIFF
--- a/blocks/onboarding/render.php
+++ b/blocks/onboarding/render.php
@@ -12,8 +12,6 @@ if ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
 	return;
 }
 
-wp_enqueue_script( 'extrachill-auth-utils' );
-
 if ( ! is_user_logged_in() ) {
 	$login_url = function_exists( 'ec_get_site_url' )
 		? ec_get_site_url( 'community' ) . '/login/'
@@ -30,14 +28,15 @@ if ( function_exists( 'ec_is_onboarding_complete' ) && ec_is_onboarding_complete
 	exit;
 }
 
-$user_id          = get_current_user_id();
-$stored_redirect  = get_user_meta( $user_id, 'onboarding_redirect_url', true );
-$default_url      = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) : home_url();
-$redirect_url     = $stored_redirect ? $stored_redirect : $default_url;
-$from_join        = get_user_meta( $user_id, 'onboarding_from_join', true ) === '1';
-$user             = get_userdata( $user_id );
-$current_username = $user ? $user->user_login : '';
-ec_users_emit_onboarding_event( EC_ANALYTICS_EVENT_ONBOARDING_VIEWED, $user_id );
+$user_id           = get_current_user_id();
+$stored_redirect   = get_user_meta( $user_id, 'onboarding_redirect_url', true );
+$default_url       = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) : home_url();
+$redirect_url      = $stored_redirect ? $stored_redirect : $default_url;
+$from_join         = get_user_meta( $user_id, 'onboarding_from_join', true ) === '1';
+$user              = get_userdata( $user_id );
+$current_username  = $user ? $user->user_login : '';
+$onboarding_notice = EC_Redirect_Handler::get_message( 'ec_onboarding' );
+ec_users_emit_onboarding_viewed_once( $user_id );
 ?>
 
 <div class="onboarding-container">
@@ -53,9 +52,20 @@ ec_users_emit_onboarding_event( EC_ANALYTICS_EVENT_ONBOARDING_VIEWED, $user_id )
 		data-rest-url="<?php echo esc_url( rest_url( 'extrachill/v1/' ) ); ?>"
 		data-abilities-url="<?php echo esc_url( rest_url( 'wp-abilities/v1/abilities/' ) ); ?>"
 		data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>"
+		data-analytics-url="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>"
+		data-analytics-nonce="<?php echo esc_attr( wp_create_nonce( 'extrachill_onboarding_analytics' ) ); ?>"
 		data-username="<?php echo esc_attr( $current_username ); ?>"
 	>
-		<form id="onboarding-form">
+		<?php if ( $onboarding_notice ) : ?>
+			<div class="ec-auth-notice ec-auth-notice--<?php echo esc_attr( $onboarding_notice['type'] ); ?>" data-ec-auth-notice="1">
+				<p><?php echo esc_html( $onboarding_notice['text'] ); ?></p>
+			</div>
+		<?php endif; ?>
+
+		<form id="onboarding-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+			<input type="hidden" name="action" value="extrachill_complete_onboarding">
+			<?php wp_nonce_field( 'extrachill_complete_onboarding', 'onboarding_nonce' ); ?>
+			<?php EC_Redirect_Handler::render_hidden_fields(); ?>
 			<div class="onboarding-field">
 				<label for="onboarding-username"><?php esc_html_e( 'Choose your username', 'extrachill-users' ); ?></label>
 				<input 
@@ -74,10 +84,11 @@ ec_users_emit_onboarding_event( EC_ANALYTICS_EVENT_ONBOARDING_VIEWED, $user_id )
 
 			<div class="onboarding-field onboarding-local-scene">
 				<label for="onboarding-local-scene"><?php esc_html_e( 'Local Scene (optional)', 'extrachill-users' ); ?></label>
-				<input type="search" id="onboarding-local-scene" autocomplete="off" placeholder="<?php esc_attr_e( 'Search cities and regions', 'extrachill-users' ); ?>" aria-autocomplete="list" aria-controls="onboarding-local-scene-results">
-				<input type="hidden" id="onboarding-local-scene-slug" value="">
+				<input type="search" id="onboarding-local-scene" autocomplete="off" placeholder="<?php esc_attr_e( 'Search cities and regions', 'extrachill-users' ); ?>" aria-autocomplete="list" aria-controls="onboarding-local-scene-results" disabled>
+				<input type="hidden" id="onboarding-local-scene-slug" name="local_scene" value="">
 				<div id="onboarding-local-scene-results" class="onboarding-local-scene-results" role="listbox" hidden></div>
 				<small class="onboarding-field-hint"><?php esc_html_e( 'Find people and live music near you. You can change this anytime.', 'extrachill-users' ); ?></small>
+				<noscript><small class="onboarding-field-hint"><?php esc_html_e( 'You can add a Local Scene from Settings after setup.', 'extrachill-users' ); ?></small></noscript>
 				<fieldset class="onboarding-visibility">
 					<legend><?php esc_html_e( 'Who can see your Local Scene?', 'extrachill-users' ); ?></legend>
 					<label><input type="radio" name="local_scene_visibility" value="public" checked> <?php esc_html_e( 'Public', 'extrachill-users' ); ?></label>

--- a/blocks/onboarding/view.asset.php
+++ b/blocks/onboarding/view.asset.php
@@ -1,0 +1,5 @@
+<?php
+return array(
+	'dependencies' => array( 'extrachill-auth-utils' ),
+	'version'      => filemtime( __DIR__ . '/view.js' ),
+);

--- a/blocks/onboarding/view.js
+++ b/blocks/onboarding/view.js
@@ -1,21 +1,45 @@
 (function () {
     'use strict';
 
-    const utils = window.ECAuthUtils;
-
     function init() {
-        if (!utils) {
-            console.error('ECAuthUtils not loaded');
-            return;
-        }
-
         const container = document.getElementById('extrachill-onboarding-form');
         if (!container) {
             return;
         }
 
+		const analyticsUrl = container.dataset.analyticsUrl || '';
+		const analyticsNonce = container.dataset.analyticsNonce || '';
+		function track(outcome, errorCode) {
+			if (!analyticsUrl || !analyticsNonce) {
+				return;
+			}
+
+			const body = new URLSearchParams({
+				action: 'extrachill_onboarding_analytics',
+				nonce: analyticsNonce,
+				outcome
+			});
+			if (errorCode) {
+				body.set('error_code', errorCode);
+			}
+
+			fetch(analyticsUrl, {
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+				body
+			}).catch(function () {});
+		}
+
+		const utils = window.ECAuthUtils;
+		if (!utils) {
+			track('client_failed', 'auth_utils_missing');
+			return;
+		}
+
         const form = document.getElementById('onboarding-form');
         if (!form) {
+			track('client_failed', 'form_missing');
             return;
         }
 
@@ -34,8 +58,36 @@
         const sceneResults = document.getElementById('onboarding-local-scene-results');
         let searchTimer;
         let searchRequest = 0;
+		const serverFailureCodes = [
+			'invalid_user',
+			'already_completed',
+			'username_too_short',
+			'username_too_long',
+			'username_invalid_chars',
+			'username_exists',
+			'username_reserved',
+			'artist_or_professional_required',
+			'invalid_local_scene_visibility',
+			'events_site_unavailable',
+			'location_taxonomy_unavailable',
+			'location_search_failed',
+			'invalid_location_mode',
+			'invalid_location_slug',
+			'location_not_found',
+			'user_event_locations_invalid_response',
+			'update_failed'
+		];
+
+		function fail(code, message, field) {
+			track('client_failed', code);
+			utils.renderNotice(container, 'error', message);
+			if (field) {
+				field.focus();
+			}
+		}
 
         if (sceneInput && sceneSlugInput && sceneResults) {
+			sceneInput.disabled = false;
             sceneInput.addEventListener('input', function () {
                 sceneSlugInput.value = '';
                 window.clearTimeout(searchTimer);
@@ -55,11 +107,15 @@
                         body: JSON.stringify({ input: { mode: 'search', search, limit: 10 } })
                     })
                         .then(function (response) {
-                            if (!response.ok) throw new Error('Local Scene search is temporarily unavailable.');
+							if (!response.ok) {
+								throw new Error('Local Scene search is temporarily unavailable.');
+							}
                             return response.json();
                         })
                         .then(function (response) {
-                            if (request !== searchRequest) return;
+							if (request !== searchRequest) {
+								return;
+							}
                             const data = response && response.result ? response.result : response;
                             const locations = data && Array.isArray(data.locations) ? data.locations : [];
                             sceneResults.replaceChildren();
@@ -79,7 +135,9 @@
                             sceneResults.hidden = locations.length === 0;
                         })
                         .catch(function (err) {
-                            if (request === searchRequest) utils.renderNotice(container, 'error', err.message);
+							if (request === searchRequest) {
+								utils.renderNotice(container, 'error', err.message);
+							}
                         });
                 }, 250);
             });
@@ -97,33 +155,32 @@
             const localSceneVisibility = visibilityInput ? visibilityInput.value : 'public';
 
             if (!username) {
-                utils.renderNotice(container, 'error', 'Please enter a username.');
+				fail('username_empty', 'Please enter a username.', usernameInput);
                 return;
             }
 
             if (username.length < 3) {
-                utils.renderNotice(container, 'error', 'Username must be at least 3 characters.');
+				fail('username_too_short', 'Username must be at least 3 characters.', usernameInput);
                 return;
             }
 
             if (username.length > 60) {
-                utils.renderNotice(container, 'error', 'Username must be 60 characters or less.');
+				fail('username_too_long', 'Username must be 60 characters or less.', usernameInput);
                 return;
             }
 
             if (!/^[a-zA-Z0-9_-]+$/.test(username)) {
-                utils.renderNotice(container, 'error', 'Username can only contain letters, numbers, hyphens, and underscores.');
+				fail('username_invalid_chars', 'Username can only contain letters, numbers, hyphens, and underscores.', usernameInput);
                 return;
             }
 
             if (sceneInput && sceneInput.value.trim() && !localScene) {
-                utils.renderNotice(container, 'error', 'Choose a Local Scene from the search results, or clear the field to skip it.');
-                sceneInput.focus();
+				fail('local_scene_unselected', 'Choose a Local Scene from the search results, or clear the field to skip it.', sceneInput);
                 return;
             }
 
             if (fromJoin && !isArtist && !isProfessional) {
-                utils.renderNotice(container, 'error', 'Please select "I am a musician" or "I work in the music industry" to continue.');
+				fail('role_required', 'Please select "I am a musician" or "I work in the music industry" to continue.');
                 return;
             }
 
@@ -146,10 +203,20 @@
                 }, localScene ? { local_scene: localScene } : {}))
             })
                 .then(function (response) {
-                    return response.json().then(function (data) {
+					return response.json().catch(function () {
+						const error = new Error('The server returned an invalid response. Please try again.');
+						error.onboardingClientCode = 'invalid_response';
+						throw error;
+					}).then(function (data) {
                         if (!response.ok) {
                             const message = data && data.message ? data.message : 'Something went wrong. Please try again.';
-                            throw new Error(message);
+							const error = new Error(message);
+							if (data && serverFailureCodes.includes(data.code)) {
+								error.onboardingServerReported = true;
+							} else {
+								error.onboardingClientCode = 'response_rejected';
+							}
+							throw error;
                         }
                         return data;
                     });
@@ -160,6 +227,9 @@
                 })
                 .catch(function (err) {
                     const message = err && err.message ? err.message : 'Something went wrong. Please try again.';
+					if (!err || !err.onboardingServerReported) {
+						track('client_failed', err && err.onboardingClientCode ? err.onboardingClientCode : 'request_failed');
+					}
                     utils.renderNotice(container, 'error', message);
                     restore();
                 });

--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -146,6 +146,7 @@ function extrachill_users_init() {
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/rank-system/contribution-events.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/onboarding/analytics.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/onboarding/service.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/onboarding/form-handler.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/lifetime-membership.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/shop-permissions.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/brand-socials-permissions.php';

--- a/inc/onboarding/analytics.php
+++ b/inc/onboarding/analytics.php
@@ -32,6 +32,23 @@ function ec_users_emit_onboarding_event( string $event_type, int $user_id, array
 }
 
 /**
+ * Emit one viewed event when a dynamic block renders more than once per request.
+ *
+ * @param int $user_id User ID.
+ * @return int Event ID, or zero when already emitted or analytics is unavailable.
+ */
+function ec_users_emit_onboarding_viewed_once( int $user_id ): int {
+	static $emitted = array();
+
+	if ( isset( $emitted[ $user_id ] ) ) {
+		return 0;
+	}
+	$emitted[ $user_id ] = true;
+
+	return ec_users_emit_onboarding_event( EC_ANALYTICS_EVENT_ONBOARDING_VIEWED, $user_id );
+}
+
+/**
  * Get bounded registration attribution for onboarding events.
  *
  * @param int $user_id User ID.

--- a/inc/onboarding/form-handler.php
+++ b/inc/onboarding/form-handler.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Onboarding browser fallback and diagnostics.
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Complete onboarding when JavaScript is unavailable.
+ */
+function extrachill_users_handle_onboarding_form() {
+	$redirect = EC_Redirect_Handler::from_post( 'ec_onboarding' );
+
+	if ( ! is_user_logged_in() ) {
+		$redirect->error( __( 'Your session expired. Please log in and try again.', 'extrachill-users' ) );
+	}
+
+	$redirect->verify_nonce( 'onboarding_nonce', 'extrachill_complete_onboarding' );
+
+	// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce verified above.
+	$data = array(
+		'username'               => isset( $_POST['username'] ) ? sanitize_user( wp_unslash( $_POST['username'] ), true ) : '',
+		'user_is_artist'         => ! empty( $_POST['user_is_artist'] ),
+		'user_is_professional'   => ! empty( $_POST['user_is_professional'] ),
+		'local_scene'            => isset( $_POST['local_scene'] ) ? sanitize_title( wp_unslash( $_POST['local_scene'] ) ) : '',
+		'local_scene_visibility' => isset( $_POST['local_scene_visibility'] ) ? sanitize_key( wp_unslash( $_POST['local_scene_visibility'] ) ) : 'public',
+	);
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+	$result = ec_complete_onboarding( get_current_user_id(), $data );
+	if ( is_wp_error( $result ) ) {
+		$redirect->error( $result->get_error_message() );
+	}
+
+	$redirect_url = isset( $result['redirect_url'] ) ? esc_url_raw( $result['redirect_url'] ) : '';
+	$redirect->redirect_to( $redirect_url ? $redirect_url : home_url() );
+}
+add_action( 'admin_post_extrachill_complete_onboarding', 'extrachill_users_handle_onboarding_form' );
+add_action( 'admin_post_nopriv_extrachill_complete_onboarding', 'extrachill_users_handle_onboarding_form' );
+
+/**
+ * Resolve a bounded client diagnostic to an analytics event.
+ *
+ * @param string $outcome    Client outcome.
+ * @param string $error_code Stable client error code.
+ * @return array|WP_Error Event descriptor or validation error.
+ */
+function extrachill_users_get_onboarding_client_event( string $outcome, string $error_code = '' ) {
+	if ( 'viewed' === $outcome ) {
+		return array(
+			'event_type' => EC_ANALYTICS_EVENT_ONBOARDING_VIEWED,
+			'event_data' => array(),
+		);
+	}
+
+	$allowed_errors = array(
+		'auth_utils_missing',
+		'form_missing',
+		'username_empty',
+		'username_too_short',
+		'username_too_long',
+		'username_invalid_chars',
+		'local_scene_unselected',
+		'role_required',
+		'invalid_response',
+		'response_rejected',
+		'request_failed',
+	);
+	if ( 'client_failed' !== $outcome || ! in_array( $error_code, $allowed_errors, true ) ) {
+		return new WP_Error( 'invalid_onboarding_diagnostic', __( 'Invalid onboarding diagnostic.', 'extrachill-users' ) );
+	}
+
+	return array(
+		'event_type' => EC_ANALYTICS_EVENT_ONBOARDING_SUBMISSION_FAILED,
+		'event_data' => array( 'error_code' => 'client_' . $error_code ),
+	);
+}
+
+/**
+ * Record a privacy-safe onboarding browser event.
+ */
+function extrachill_users_onboarding_client_analytics() {
+	check_ajax_referer( 'extrachill_onboarding_analytics', 'nonce' );
+
+	if ( ! is_user_logged_in() ) {
+		wp_send_json_error( null, 403 );
+	}
+
+	$outcome    = isset( $_POST['outcome'] ) ? sanitize_key( wp_unslash( $_POST['outcome'] ) ) : '';
+	$error_code = isset( $_POST['error_code'] ) ? sanitize_key( wp_unslash( $_POST['error_code'] ) ) : '';
+	$event      = extrachill_users_get_onboarding_client_event( $outcome, $error_code );
+	if ( is_wp_error( $event ) ) {
+		wp_send_json_error( null, 400 );
+	}
+
+	ec_users_emit_onboarding_event( $event['event_type'], get_current_user_id(), $event['event_data'] );
+	wp_send_json_success();
+}
+add_action( 'wp_ajax_extrachill_onboarding_analytics', 'extrachill_users_onboarding_client_analytics' );

--- a/inc/onboarding/form-handler.php
+++ b/inc/onboarding/form-handler.php
@@ -48,13 +48,6 @@ add_action( 'admin_post_nopriv_extrachill_complete_onboarding', 'extrachill_user
  * @return array|WP_Error Event descriptor or validation error.
  */
 function extrachill_users_get_onboarding_client_event( string $outcome, string $error_code = '' ) {
-	if ( 'viewed' === $outcome ) {
-		return array(
-			'event_type' => EC_ANALYTICS_EVENT_ONBOARDING_VIEWED,
-			'event_data' => array(),
-		);
-	}
-
 	$allowed_errors = array(
 		'auth_utils_missing',
 		'form_missing',

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:password-reset": "wp-scripts build blocks/password-reset/src/index.js --output-path=build/password-reset",
     "build:onboarding": "wp-scripts build blocks/onboarding/src/index.js --output-path=build/onboarding",
     "build:concert-attendance": "wp-scripts build blocks/concert-attendance/src/index.js --output-path=build/concert-attendance",
-    "copy:block-files": "cp blocks/login-register/block.json blocks/login-register/render.php blocks/login-register/style.css build/login-register/ && cp blocks/password-reset/block.json blocks/password-reset/render.php blocks/password-reset/style.css blocks/password-reset/view.js build/password-reset/ && cp blocks/onboarding/block.json blocks/onboarding/render.php blocks/onboarding/style.css blocks/onboarding/view.js build/onboarding/",
+    "copy:block-files": "cp blocks/login-register/block.json blocks/login-register/render.php blocks/login-register/style.css build/login-register/ && cp blocks/password-reset/block.json blocks/password-reset/render.php blocks/password-reset/style.css blocks/password-reset/view.js build/password-reset/ && cp blocks/onboarding/block.json blocks/onboarding/render.php blocks/onboarding/style.css blocks/onboarding/view.js blocks/onboarding/view.asset.php build/onboarding/",
     "start": "wp-scripts start blocks/login-register/src/index.js --output-path=build/login-register"
   },
   "dependencies": {

--- a/tests/unit/OnboardingBrowserResilienceTest.php
+++ b/tests/unit/OnboardingBrowserResilienceTest.php
@@ -52,11 +52,8 @@ class Test_Onboarding_Browser_Resilience extends WP_UnitTestCase {
 	 * Client events reuse analytics-owned lifecycle event names.
 	 */
 	public function test_client_diagnostics_map_to_bounded_analytics_events(): void {
-		$viewed = extrachill_users_get_onboarding_client_event( 'viewed' );
 		$failed = extrachill_users_get_onboarding_client_event( 'client_failed', 'auth_utils_missing' );
 
-		$this->assertSame( EC_ANALYTICS_EVENT_ONBOARDING_VIEWED, $viewed['event_type'] );
-		$this->assertSame( array(), $viewed['event_data'] );
 		$this->assertSame( EC_ANALYTICS_EVENT_ONBOARDING_SUBMISSION_FAILED, $failed['event_type'] );
 		$this->assertSame( array( 'error_code' => 'client_auth_utils_missing' ), $failed['event_data'] );
 	}

--- a/tests/unit/OnboardingBrowserResilienceTest.php
+++ b/tests/unit/OnboardingBrowserResilienceTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Tests for resilient browser onboarding.
+ *
+ * @package ExtraChill\Users
+ */
+
+/**
+ * Verify onboarding remains actionable without JavaScript and emits bounded diagnostics.
+ */
+class Test_Onboarding_Browser_Resilience extends WP_UnitTestCase {
+
+	/**
+	 * Reset the authenticated user between tests.
+	 */
+	protected function tearDown(): void {
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	/**
+	 * The block view script has an actual dependency on the shared auth utility.
+	 */
+	public function test_onboarding_script_declares_auth_utils_dependency(): void {
+		$block = WP_Block_Type_Registry::get_instance()->get_registered( 'extrachill/onboarding' );
+
+		$this->assertInstanceOf( WP_Block_Type::class, $block );
+		$script = wp_scripts()->registered[ $block->view_script_handles[0] ];
+		$this->assertContains( 'extrachill-auth-utils', $script->deps );
+	}
+
+	/**
+	 * The rendered form has a native authenticated POST fallback.
+	 */
+	public function test_onboarding_form_has_native_submission_path(): void {
+		$user_id = self::factory()->user->create();
+		update_user_meta( $user_id, 'onboarding_completed', '0' );
+		wp_set_current_user( $user_id );
+
+		$html = render_block( array( 'blockName' => 'extrachill/onboarding' ) );
+
+		$this->assertStringContainsString( 'method="post"', $html );
+		$this->assertStringContainsString( 'admin-post.php', $html );
+		$this->assertStringContainsString( 'name="action" value="extrachill_complete_onboarding"', $html );
+		$this->assertStringContainsString( 'name="onboarding_nonce"', $html );
+		$this->assertStringContainsString( 'name="local_scene"', $html );
+		$this->assertSame( 10, has_action( 'admin_post_extrachill_complete_onboarding', 'extrachill_users_handle_onboarding_form' ) );
+		$this->assertSame( 10, has_action( 'admin_post_nopriv_extrachill_complete_onboarding', 'extrachill_users_handle_onboarding_form' ) );
+	}
+
+	/**
+	 * Client events reuse analytics-owned lifecycle event names.
+	 */
+	public function test_client_diagnostics_map_to_bounded_analytics_events(): void {
+		$viewed = extrachill_users_get_onboarding_client_event( 'viewed' );
+		$failed = extrachill_users_get_onboarding_client_event( 'client_failed', 'auth_utils_missing' );
+
+		$this->assertSame( EC_ANALYTICS_EVENT_ONBOARDING_VIEWED, $viewed['event_type'] );
+		$this->assertSame( array(), $viewed['event_data'] );
+		$this->assertSame( EC_ANALYTICS_EVENT_ONBOARDING_SUBMISSION_FAILED, $failed['event_type'] );
+		$this->assertSame( array( 'error_code' => 'client_auth_utils_missing' ), $failed['event_data'] );
+	}
+
+	/**
+	 * Arbitrary client strings cannot enter analytics payloads.
+	 */
+	public function test_client_diagnostics_reject_unbounded_values(): void {
+		$result = extrachill_users_get_onboarding_client_event( 'client_failed', 'raw user input' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_onboarding_diagnostic', $result->get_error_code() );
+	}
+}


### PR DESCRIPTION
## Summary
- make onboarding submit through the canonical ability even when JavaScript fails or is disabled
- declare the shared auth utility as a real WordPress script dependency
- record privacy-safe, allowlisted browser failure codes while retaining server-owned domain errors
- deduplicate onboarding view analytics once per request
- keep Local Scene optional and defer it clearly when JavaScript is unavailable

Closes #204.

## Verification
- PHP syntax checks passed for all changed PHP files
- scoped PHPCS and ESLint passed with zero findings
- Homeboy audit passed with zero findings
- regression tests cover script dependency metadata, native POST fallback, authenticated hooks, and bounded diagnostics
- PHPUnit sandbox executed zero tests because it provisions single-site WordPress and this plugin intentionally requires multisite