### PR TITLE
fix: preserve safe login continuations

### DIFF
--- a/blocks/login-register/render.php
+++ b/blocks/login-register/render.php
@@ -61,20 +61,36 @@ $current_url = set_url_scheme(
 	( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . strtok( $request_uri, '?' )
 );
 
-$login_redirect_url = ! empty( $attributes['redirectUrl'] ) ? esc_url( $attributes['redirectUrl'] ) : $current_url;
-$success_redirect   = ! empty( $attributes['redirectUrl'] ) ? esc_url( $attributes['redirectUrl'] ) : $current_url;
+$login_redirect_url = $current_url;
+$success_redirect   = $current_url;
+
+if ( ! empty( $attributes['redirectUrl'] )
+	&& function_exists( 'ec_users_is_valid_return_to_url' )
+	&& ec_users_is_valid_return_to_url( $attributes['redirectUrl'] ) ) {
+	$login_redirect_url = esc_url_raw( $attributes['redirectUrl'] );
+	$success_redirect   = $login_redirect_url;
+}
+
+if ( function_exists( 'ec_users_get_validated_login_redirect_from_request' ) ) {
+	$validated_login_redirect = ec_users_get_validated_login_redirect_from_request();
+	if ( null !== $validated_login_redirect ) {
+		$login_redirect_url = $validated_login_redirect;
+		$success_redirect   = $validated_login_redirect;
+	}
+}
 
 // Single-origin Google OAuth: when a non-canonical subsite redirected
 // the user here for sign-in, it carries the original page URL in the
 // google_redirect query param. Pick it up and use it as the post-auth
 // destination so the user lands back where they started. The helper
-// validates the host against the *.extrachill.com allowlist and
+// validates the host against the network redirect allowlist and
 // returns null on anything else, so this is safe to override
 // $success_redirect with.
 if ( function_exists( 'ec_users_get_validated_google_redirect_from_request' ) ) {
 	$validated_google_redirect = ec_users_get_validated_google_redirect_from_request();
 	if ( null !== $validated_google_redirect ) {
-		$success_redirect = $validated_google_redirect;
+		$login_redirect_url = $validated_google_redirect;
+		$success_redirect   = $validated_google_redirect;
 	}
 }
 
@@ -130,23 +146,23 @@ $from_join = isset( $_GET['from_join'] ) && 'true' === sanitize_text_field( wp_u
 // origins not pre-registered in GCP).
 $google_signin_redirect_url = null;
 if ( $google_oauth_enabled && ! $google_is_canonical && function_exists( 'ec_users_canonical_google_signin_url' ) ) {
-	$google_signin_redirect_url = ec_users_canonical_google_signin_url( $current_url );
+	$google_signin_redirect_url = ec_users_canonical_google_signin_url( $success_redirect );
 }
 
 $config = array(
-	'loggedIn'                 => is_user_logged_in(),
-	'googleOAuthEnabled'       => $google_oauth_enabled,
-	'googleSignInRedirectUrl'  => $google_signin_redirect_url,
-	'currentUrl'               => $current_url,
-	'loginRedirectUrl'         => $login_redirect_url,
-	'successRedirectUrl'       => $success_redirect,
-	'resetPasswordUrl'         => ec_get_site_url( 'community' ) . '/reset-password/',
-	'inviteToken'              => $invite_token,
-	'inviteArtistId'           => $invite_artist_id,
-	'invitedEmail'             => $invited_email,
-	'fromJoin'                 => $from_join,
-	'turnstileHtml'            => wp_kses_post( ec_render_turnstile_widget() ),
-	'initialNotice'            => $initial_notice ? array(
+	'loggedIn'                => is_user_logged_in(),
+	'googleOAuthEnabled'      => $google_oauth_enabled,
+	'googleSignInRedirectUrl' => $google_signin_redirect_url,
+	'currentUrl'              => $current_url,
+	'loginRedirectUrl'        => $login_redirect_url,
+	'successRedirectUrl'      => $success_redirect,
+	'resetPasswordUrl'        => ec_get_site_url( 'community' ) . '/reset-password/',
+	'inviteToken'             => $invite_token,
+	'inviteArtistId'          => $invite_artist_id,
+	'invitedEmail'            => $invited_email,
+	'fromJoin'                => $from_join,
+	'turnstileHtml'           => wp_kses_post( ec_render_turnstile_widget() ),
+	'initialNotice'           => $initial_notice ? array(
 		'message' => $initial_notice['text'] ?? '',
 		'type'    => $initial_notice['type'] ?? 'info',
 	) : null,

--- a/blocks/login-register/view.js
+++ b/blocks/login-register/view.js
@@ -65,7 +65,7 @@ function captureAttribution() {
 				referrer = raw;
 			}
 		}
-	} catch ( e ) {
+	} catch {
 		referrer = '';
 	}
 
@@ -78,7 +78,7 @@ function captureAttribution() {
 				utm[ key ] = value;
 			}
 		} );
-	} catch ( e ) {
+	} catch {
 		// Leave utm empty on any parsing failure.
 	}
 
@@ -193,7 +193,7 @@ function LoginPanel( { config, notice, setNotice } ) {
 				return;
 			}
 
-			window.location.assign( redirectTo );
+			window.location.assign( data?.redirect_url || config.loginRedirectUrl );
 		} catch ( error ) {
 			const message = error instanceof Error ? error.message : 'Login failed. Please try again.';
 			setNotice( {

--- a/inc/auth-tokens/service.php
+++ b/inc/auth-tokens/service.php
@@ -216,10 +216,14 @@ function extrachill_users_maybe_handle_two_factor( string $identifier, string $p
  * @return array|WP_Error
  */
 function extrachill_users_login_with_tokens( string $identifier, string $password, string $device_id, array $options = array() ) {
-	$device_name = isset( $options['device_name'] ) ? (string) $options['device_name'] : '';
-	$remember    = ! empty( $options['remember'] );
-	$set_cookie  = ! empty( $options['set_cookie'] );
-	$redirect_to = isset( $options['redirect_to'] ) ? (string) $options['redirect_to'] : '';
+	$device_name      = isset( $options['device_name'] ) ? (string) $options['device_name'] : '';
+	$remember         = ! empty( $options['remember'] );
+	$set_cookie       = ! empty( $options['set_cookie'] );
+	$redirect_to      = isset( $options['redirect_to'] ) ? (string) $options['redirect_to'] : '';
+	$safe_redirect_to = function_exists( 'ec_users_is_valid_return_to_url' )
+		&& ec_users_is_valid_return_to_url( $redirect_to )
+		? esc_url_raw( $redirect_to )
+		: home_url();
 
 	if ( ! function_exists( 'ec_get_blog_id' ) ) {
 		return new WP_Error(
@@ -249,7 +253,7 @@ function extrachill_users_login_with_tokens( string $identifier, string $passwor
 	 * wp_authenticate(), validate the password manually, create a Two Factor
 	 * login nonce, and return a redirect URL to the existing validate_2fa page.
 	 */
-	$two_factor_redirect = extrachill_users_maybe_handle_two_factor( $identifier, $password, $remember, $redirect_to );
+	$two_factor_redirect = extrachill_users_maybe_handle_two_factor( $identifier, $password, $remember, $safe_redirect_to );
 	if ( null !== $two_factor_redirect ) {
 		return $two_factor_redirect;
 	}
@@ -292,6 +296,7 @@ function extrachill_users_login_with_tokens( string $identifier, string $passwor
 		'access_expires_at'  => gmdate( 'c', (int) $tokens['access']['expires_at'] ),
 		'refresh_token'      => $tokens['refresh']['token'],
 		'refresh_expires_at' => gmdate( 'c', (int) $tokens['refresh']['expires_at'] ),
+		'redirect_url'       => $safe_redirect_to,
 		'user'               => extrachill_users_token_user_payload( $user ),
 	);
 }

--- a/inc/auth/login.php
+++ b/inc/auth/login.php
@@ -236,7 +236,16 @@ function extrachill_redirect_wp_login_access() {
 	}
 	// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
-	wp_safe_redirect( home_url( '/login/' ) );
+	$login_url = home_url( '/login/' );
+	if ( function_exists( 'ec_users_get_validated_login_redirect_from_request' )
+		&& function_exists( 'ec_users_login_url_with_redirect' ) ) {
+		$redirect_to = ec_users_get_validated_login_redirect_from_request();
+		if ( null !== $redirect_to ) {
+			$login_url = ec_users_login_url_with_redirect( $login_url, $redirect_to );
+		}
+	}
+
+	wp_safe_redirect( $login_url );
 	exit;
 }
 add_action( 'init', 'extrachill_redirect_wp_login_access' );

--- a/inc/oauth/google-canonical-origin.php
+++ b/inc/oauth/google-canonical-origin.php
@@ -93,7 +93,7 @@ function ec_users_canonical_google_signin_url( $return_to ) {
  * external phishing page after auth. We require:
  *
  *   - Scheme is https (no http downgrades, no javascript: URLs)
- *   - Host is either extrachill.com or a subdomain of extrachill.com
+ *   - Host is registered by the network redirect policy
  *
  * @param mixed $url Candidate return URL (defensive against non-string input).
  * @return bool True iff the URL is safe to redirect a logged-in user to.
@@ -103,7 +103,12 @@ function ec_users_is_valid_return_to_url( $url ) {
 		return false;
 	}
 
-	$parts = wp_parse_url( $url );
+	$validated = wp_validate_redirect( $url, '' );
+	if ( '' === $validated ) {
+		return false;
+	}
+
+	$parts = wp_parse_url( $validated );
 	if ( ! is_array( $parts ) ) {
 		return false;
 	}
@@ -119,18 +124,70 @@ function ec_users_is_valid_return_to_url( $url ) {
 		return false;
 	}
 
-	// Allow the apex domain and any subdomain. We match against a
-	// trailing dot to avoid string-prefix attacks like
-	// "extrachill.com.attacker.example".
-	if ( 'extrachill.com' === $host ) {
-		return true;
+	if ( function_exists( 'ec_get_allowed_redirect_hosts' ) ) {
+		$allowed_hosts = array_map( 'strtolower', ec_get_allowed_redirect_hosts() );
+		return in_array( $host, $allowed_hosts, true );
 	}
 
-	if ( str_ends_with( $host, '.extrachill.com' ) ) {
-		return true;
+	// Keep the helper usable when the network plugin is unavailable, such as
+	// isolated tests, while preserving the original Extra Chill-only policy.
+	return 'extrachill.com' === $host
+		|| str_ends_with( $host, '.extrachill.com' )
+		|| in_array( $host, array( 'extrachill.link', 'www.extrachill.link' ), true );
+}
+
+/**
+ * Read a validated redirect parameter from the current request.
+ *
+ * @param string $parameter Query parameter name.
+ * @return string|null Validated destination, or null.
+ */
+function ec_users_get_validated_redirect_from_request( $parameter ) {
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only query parameter used only as a post-auth destination.
+	if ( ! isset( $_GET[ $parameter ] ) ) {
+		return null;
 	}
 
-	return false;
+	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Preserve encoded destination query values until the URL is validated below.
+	$raw = wp_unslash( $_GET[ $parameter ] );
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+	if ( ! is_string( $raw ) || '' === $raw ) {
+		return null;
+	}
+
+	if ( ! ec_users_is_valid_return_to_url( $raw ) ) {
+		return null;
+	}
+
+	return esc_url_raw( $raw );
+}
+
+/**
+ * Read the standard WordPress login continuation from the current request.
+ *
+ * The outer query value has already been decoded by PHP. Decoding it again
+ * would corrupt encoded query values inside the destination URL.
+ *
+ * @return string|null Validated destination, or null.
+ */
+function ec_users_get_validated_login_redirect_from_request() {
+	return ec_users_get_validated_redirect_from_request( 'redirect_to' );
+}
+
+/**
+ * Add a safe continuation to a custom login URL.
+ *
+ * @param string $login_url   Custom login URL.
+ * @param mixed  $redirect_to Candidate post-auth destination.
+ * @return string Login URL, with redirect_to only when it is safe.
+ */
+function ec_users_login_url_with_redirect( $login_url, $redirect_to ) {
+	if ( ! ec_users_is_valid_return_to_url( $redirect_to ) ) {
+		return $login_url;
+	}
+
+	return add_query_arg( 'redirect_to', rawurlencode( $redirect_to ), $login_url );
 }
 
 /**
@@ -148,23 +205,5 @@ function ec_users_is_valid_return_to_url( $url ) {
  * @return string|null Validated return-to URL, or null.
  */
 function ec_users_get_validated_google_redirect_from_request() {
-	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only query param used to compute a destination URL; no state change here.
-	if ( ! isset( $_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] ) ) {
-		return null;
-	}
-
-	$raw = wp_unslash( $_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] );
-	// phpcs:enable WordPress.Security.NonceVerification.Recommended
-
-	if ( ! is_string( $raw ) || '' === $raw ) {
-		return null;
-	}
-
-	$decoded = rawurldecode( $raw );
-
-	if ( ! ec_users_is_valid_return_to_url( $decoded ) ) {
-		return null;
-	}
-
-	return esc_url_raw( $decoded );
+	return ec_users_get_validated_redirect_from_request( EC_USERS_GOOGLE_REDIRECT_PARAM );
 }

--- a/tests/unit/GoogleCanonicalOriginTest.php
+++ b/tests/unit/GoogleCanonicalOriginTest.php
@@ -125,7 +125,7 @@ class Test_Google_Canonical_Origin extends WP_UnitTestCase {
 		parse_str( $parsed['query'] ?? '', $args );
 		$this->assertSame(
 			'https://studio.extrachill.com/compose?draft=42',
-			rawurldecode( $args[ EC_USERS_GOOGLE_REDIRECT_PARAM ] ?? '' )
+			$args[ EC_USERS_GOOGLE_REDIRECT_PARAM ] ?? ''
 		);
 	}
 
@@ -139,7 +139,7 @@ class Test_Google_Canonical_Origin extends WP_UnitTestCase {
 	}
 
 	public function test_get_validated_redirect_returns_valid_url(): void {
-		$_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] = rawurlencode( 'https://studio.extrachill.com/compose' );
+		$_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] = 'https://studio.extrachill.com/compose';
 		$this->assertSame(
 			'https://studio.extrachill.com/compose',
 			ec_users_get_validated_google_redirect_from_request()
@@ -147,12 +147,12 @@ class Test_Google_Canonical_Origin extends WP_UnitTestCase {
 	}
 
 	public function test_get_validated_redirect_rejects_external_host(): void {
-		$_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] = rawurlencode( 'https://attacker.example/phish' );
+		$_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] = 'https://attacker.example/phish';
 		$this->assertNull( ec_users_get_validated_google_redirect_from_request() );
 	}
 
 	public function test_get_validated_redirect_rejects_dangerous_scheme(): void {
-		$_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] = rawurlencode( 'javascript:alert(1)' );
+		$_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] = 'javascript:alert(1)';
 		$this->assertNull( ec_users_get_validated_google_redirect_from_request() );
 	}
 

--- a/tests/unit/LoginContinuationTest.php
+++ b/tests/unit/LoginContinuationTest.php
@@ -67,6 +67,12 @@ class Test_Login_Continuation extends WP_UnitTestCase {
 		$this->assertNull( ec_users_get_validated_login_redirect_from_request() );
 	}
 
+	public function test_relative_redirect_is_rejected(): void {
+		$_GET['redirect_to'] = '/my-shows/';
+
+		$this->assertNull( ec_users_get_validated_login_redirect_from_request() );
+	}
+
 	public function test_missing_continuation_returns_null(): void {
 		unset( $_GET['redirect_to'] );
 

--- a/tests/unit/LoginContinuationTest.php
+++ b/tests/unit/LoginContinuationTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Unit tests for login continuation handling (#206).
+ */
+
+class Test_Login_Continuation extends WP_UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		require_once dirname( __DIR__, 2 ) . '/inc/oauth/google-canonical-origin.php';
+	}
+
+	public function test_same_site_redirect_is_preserved(): void {
+		$_GET['redirect_to'] = 'https://extrachill.com/my-shows/';
+
+		$this->assertSame(
+			'https://extrachill.com/my-shows/',
+			ec_users_get_validated_login_redirect_from_request()
+		);
+	}
+
+	public function test_cross_subdomain_redirect_is_preserved(): void {
+		$_GET['redirect_to'] = 'https://events.extrachill.com/my-shows/';
+
+		$this->assertSame(
+			'https://events.extrachill.com/my-shows/',
+			ec_users_get_validated_login_redirect_from_request()
+		);
+	}
+
+	public function test_encoded_destination_query_round_trips_without_double_decoding(): void {
+		$destination         = 'https://events.extrachill.com/my-shows/?artist=Tyler%2C%20the%20Creator&source=local%26scene';
+		$_GET['redirect_to'] = $destination;
+
+		$this->assertSame( $destination, ec_users_get_validated_login_redirect_from_request() );
+
+		$login_url = ec_users_login_url_with_redirect( 'https://community.extrachill.com/login/', $destination );
+		parse_str( (string) wp_parse_url( $login_url, PHP_URL_QUERY ), $query );
+		$this->assertSame( $destination, $query['redirect_to'] );
+	}
+
+	public function test_google_continuation_preserves_encoded_destination_query(): void {
+		$destination = 'https://events.extrachill.com/my-shows/?artist=Tyler%2C%20the%20Creator&source=local%26scene';
+		$login_url   = ec_users_canonical_google_signin_url( $destination );
+		parse_str( (string) wp_parse_url( $login_url, PHP_URL_QUERY ), $query );
+
+		$_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] = $query[ EC_USERS_GOOGLE_REDIRECT_PARAM ] ?? '';
+		$this->assertSame( $destination, ec_users_get_validated_google_redirect_from_request() );
+	}
+
+	public function test_unsafe_external_redirect_is_rejected(): void {
+		$_GET['redirect_to'] = 'https://attacker.example/phish';
+
+		$this->assertNull( ec_users_get_validated_login_redirect_from_request() );
+		$this->assertSame(
+			'https://community.extrachill.com/login/',
+			ec_users_login_url_with_redirect(
+				'https://community.extrachill.com/login/',
+				'https://attacker.example/phish'
+			)
+		);
+	}
+
+	public function test_protocol_relative_redirect_is_rejected(): void {
+		$_GET['redirect_to'] = '//attacker.example/phish';
+
+		$this->assertNull( ec_users_get_validated_login_redirect_from_request() );
+	}
+
+	public function test_missing_continuation_returns_null(): void {
+		unset( $_GET['redirect_to'] );
+
+		$this->assertNull( ec_users_get_validated_login_redirect_from_request() );
+	}
+
+	public function test_network_custom_domain_is_allowed_by_existing_policy(): void {
+		$this->assertTrue( ec_users_is_valid_return_to_url( 'https://extrachill.link/chubes/' ) );
+	}
+
+	public function test_attendance_cta_round_trips_through_wp_login_and_custom_login(): void {
+		$attendance_url = 'https://events.extrachill.com/shows/khruangbin/?attendance=going&source=my-shows%2Fupcoming';
+		$wp_login_url   = wp_login_url( $attendance_url );
+
+		parse_str( (string) wp_parse_url( $wp_login_url, PHP_URL_QUERY ), $wp_login_query );
+		$custom_login_url = ec_users_login_url_with_redirect(
+			'https://community.extrachill.com/login/',
+			$wp_login_query['redirect_to'] ?? ''
+		);
+
+		parse_str( (string) wp_parse_url( $custom_login_url, PHP_URL_QUERY ), $custom_login_query );
+		$this->assertSame( $attendance_url, $custom_login_query['redirect_to'] ?? '' );
+	}
+
+	public function test_render_and_clients_consume_the_validated_continuation(): void {
+		$root   = dirname( __DIR__, 2 );
+		$render = file_get_contents( $root . '/blocks/login-register/render.php' );
+		$view   = file_get_contents( $root . '/blocks/login-register/view.js' );
+		$google = file_get_contents( $root . '/assets/js/google-signin.js' );
+
+		$this->assertStringContainsString( 'ec_users_get_validated_login_redirect_from_request()', $render );
+		$this->assertStringContainsString( 'ec_users_canonical_google_signin_url( $success_redirect )', $render );
+		$this->assertStringContainsString( 'data?.redirect_url || config.loginRedirectUrl', $view );
+		$this->assertStringContainsString( 'success_redirect_url: successRedirectUrl', $google );
+	}
+
+	protected function tearDown(): void {
+		unset( $_GET['redirect_to'], $_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] );
+		parent::tearDown();
+	}
+}


### PR DESCRIPTION
## Summary

- preserve `redirect_to` when `wp-login.php` hands off to the custom `/login/` page
- consume the validated continuation in password login, token/2FA responses, registration, and canonical-origin Google OAuth
- preserve encoded destination query parameters without double-decoding them

## Original redirect loss

Product CTAs correctly emitted `wp_login_url( $destination )` or a `redirect_to` value, but `inc/auth/login.php` redirected `wp-login.php` to `/login/` without carrying the query string. The custom login renderer also defaulted to the current login page instead of consuming `redirect_to`, so attendance, My Shows, Local Scene, imports, and other gated actions lost their initiating destination.

## Validation boundary

Continuation handling reuses `ec_users_is_valid_return_to_url()`, the existing Google canonical-origin policy, rather than creating a parallel redirect abstraction. A supported destination must be an absolute HTTPS URL whose host is registered by `ec_get_allowed_redirect_hosts()`. This covers same-site URLs, Extra Chill cross-subdomain URLs, and mapped network domains such as `extrachill.link`.

Missing, malformed, relative, protocol-relative, non-HTTPS, unsafe-scheme, prefix-confusion, and external-host destinations are rejected. Rejected values are never reflected to the browser: the renderer retains its current-page default, and the token service returns `home_url()`.

## Changed surfaces

- `wp-login.php` to custom `/login/` handoff
- login/register block server configuration
- password login REST client and token response
- 2FA continuation
- canonical-origin Google sign-in and existing-user OAuth return
- unit coverage for same-site, cross-subdomain, mapped-domain, encoded-query, relative, missing, and unsafe destinations

## Verification

Passed:

```text
homeboy review extrachill-users lint --path /var/lib/datamachine/workspace/extrachill-users@issue-206-login-continuation --changed-since origin/main --summary
homeboy review extrachill-users build --path /var/lib/datamachine/workspace/extrachill-users@issue-206-login-continuation
php -l blocks/login-register/render.php
php -l inc/auth-tokens/service.php
php -l inc/auth/login.php
php -l inc/oauth/google-canonical-origin.php
php -l tests/unit/GoogleCanonicalOriginTest.php
php -l tests/unit/LoginContinuationTest.php
git diff --check origin/main...HEAD
```

The changed-file Homeboy lint passed for PHP and JavaScript; it reported only existing non-blocking warnings. The build gate passed frontend compilation, PHP syntax, package validation, and ZIP creation.

Focused PHPUnit was attempted through the repository-supported WordPress path:

```text
homeboy --placement local review test extrachill-users --path /var/lib/datamachine/workspace/extrachill-users@issue-206-login-continuation --changed-since origin/main --json-summary
```

No tests executed because the WP Codebox harness activated the network-only plugin in a single-site sandbox and stopped at `Extra Chill Users plugin requires a WordPress multisite installation.` Direct `vendor/bin/phpunit` likewise cannot bootstrap `WP_UnitTestCase` outside the WordPress test harness. This is a harness limitation, not a test assertion failure.

Closes #206