### PR TITLE
fix: honor request login continuations

### DIFF
--- a/blocks/login-register/render.php
+++ b/blocks/login-register/render.php
@@ -61,23 +61,11 @@ $current_url = set_url_scheme(
 	( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . strtok( $request_uri, '?' )
 );
 
-$login_redirect_url = $current_url;
-$success_redirect   = $current_url;
-
-if ( ! empty( $attributes['redirectUrl'] )
-	&& function_exists( 'ec_users_is_valid_return_to_url' )
-	&& ec_users_is_valid_return_to_url( $attributes['redirectUrl'] ) ) {
-	$login_redirect_url = esc_url_raw( $attributes['redirectUrl'] );
-	$success_redirect   = $login_redirect_url;
-}
-
-if ( function_exists( 'ec_users_get_validated_login_redirect_from_request' ) ) {
-	$validated_login_redirect = ec_users_get_validated_login_redirect_from_request();
-	if ( null !== $validated_login_redirect ) {
-		$login_redirect_url = $validated_login_redirect;
-		$success_redirect   = $validated_login_redirect;
-	}
-}
+$block_redirect_url = isset( $attributes['redirectUrl'] ) ? $attributes['redirectUrl'] : '';
+$login_redirect_url = function_exists( 'ec_users_resolve_login_block_redirect' )
+	? ec_users_resolve_login_block_redirect( $block_redirect_url, $current_url )
+	: $current_url;
+$success_redirect   = $login_redirect_url;
 
 // Single-origin Google OAuth: when a non-canonical subsite redirected
 // the user here for sign-in, it carries the original page URL in the

--- a/blocks/login-register/view.js
+++ b/blocks/login-register/view.js
@@ -124,7 +124,7 @@ function LoggedInCard( { config } ) {
 	);
 }
 
-function LoginPanel( { config, notice, setNotice } ) {
+export function LoginPanel( { config, notice, setNotice } ) {
 	const panelRef = useRef( null );
 
 	useEffect( () => {
@@ -221,6 +221,7 @@ function LoginPanel( { config, notice, setNotice } ) {
 				) }
 				<form id="loginform" onSubmit={ handleSubmit }>
 					<input type="hidden" name="redirect_to" value={ config.loginRedirectUrl } />
+					<input type="hidden" name="success_redirect_url" value={ config.successRedirectUrl } />
 					<label htmlFor="user_login">Username</label>
 					<input type="text" name="log" id="user_login" className="input" placeholder="Your username" required />
 					<label htmlFor="user_pass">Password</label>

--- a/inc/auth-tokens/service.php
+++ b/inc/auth-tokens/service.php
@@ -330,9 +330,15 @@ function extrachill_users_register_with_tokens( array $payload ) {
 	$registration_page    = isset( $payload['registration_page'] ) ? esc_url_raw( (string) $payload['registration_page'] ) : '';
 	$registration_source  = isset( $payload['registration_source'] ) ? sanitize_text_field( (string) $payload['registration_source'] ) : '';
 	$registration_method  = isset( $payload['registration_method'] ) ? sanitize_text_field( (string) $payload['registration_method'] ) : '';
-	$success_redirect_url = isset( $payload['success_redirect_url'] ) ? esc_url_raw( (string) $payload['success_redirect_url'] ) : '';
-	$referrer             = isset( $payload['referrer'] ) ? esc_url_raw( (string) $payload['referrer'] ) : '';
-	$utm                  = ( isset( $payload['utm'] ) && function_exists( 'extrachill_users_sanitize_utm' ) )
+	$success_redirect_url = isset( $payload['success_redirect_url'] ) ? (string) $payload['success_redirect_url'] : '';
+	if ( ! function_exists( 'ec_users_is_valid_return_to_url' )
+		|| ! ec_users_is_valid_return_to_url( $success_redirect_url ) ) {
+		$success_redirect_url = '';
+	} else {
+		$success_redirect_url = esc_url_raw( $success_redirect_url );
+	}
+	$referrer = isset( $payload['referrer'] ) ? esc_url_raw( (string) $payload['referrer'] ) : '';
+	$utm      = ( isset( $payload['utm'] ) && function_exists( 'extrachill_users_sanitize_utm' ) )
 		? extrachill_users_sanitize_utm( $payload['utm'] )
 		: array();
 

--- a/inc/auth/register.php
+++ b/inc/auth/register.php
@@ -31,7 +31,7 @@ function extrachill_handle_registration() {
 	$turnstile_token = isset( $_POST['cf-turnstile-response'] )
 		? wp_unslash( $_POST['cf-turnstile-response'] )
 		: '';
-	$check = ec_turnstile_check_request( $turnstile_token );
+	$check           = ec_turnstile_check_request( $turnstile_token );
 	if ( is_wp_error( $check ) ) {
 		$redirect->error( $check->get_error_message() );
 	}
@@ -118,7 +118,13 @@ function extrachill_handle_registration() {
 		}
 	}
 
-	$success_redirect_url = isset( $_POST['success_redirect_url'] ) ? esc_url_raw( wp_unslash( $_POST['success_redirect_url'] ) ) : '';
+	$success_redirect_url = isset( $_POST['success_redirect_url'] ) ? wp_unslash( $_POST['success_redirect_url'] ) : '';
+	if ( ! function_exists( 'ec_users_is_valid_return_to_url' )
+		|| ! ec_users_is_valid_return_to_url( $success_redirect_url ) ) {
+		$success_redirect_url = '';
+	} else {
+		$success_redirect_url = esc_url_raw( $success_redirect_url );
+	}
 	// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 	extrachill_auto_login_new_user( $user_id, $redirect, $processed_invite_artist_id, $success_redirect_url );

--- a/inc/oauth/google-canonical-origin.php
+++ b/inc/oauth/google-canonical-origin.php
@@ -176,6 +176,30 @@ function ec_users_get_validated_login_redirect_from_request() {
 }
 
 /**
+ * Resolve the login block's post-auth destination.
+ *
+ * A safe request continuation represents the user's current intent and takes
+ * precedence over the block's configured default. The current login URL is the
+ * final fallback when neither value is safe.
+ *
+ * @param mixed  $block_redirect Configured login block redirect.
+ * @param string $fallback       Current login URL.
+ * @return string Safe post-auth destination.
+ */
+function ec_users_resolve_login_block_redirect( $block_redirect, $fallback ) {
+	$request_redirect = ec_users_get_validated_login_redirect_from_request();
+	if ( null !== $request_redirect ) {
+		return $request_redirect;
+	}
+
+	if ( ec_users_is_valid_return_to_url( $block_redirect ) ) {
+		return esc_url_raw( $block_redirect );
+	}
+
+	return esc_url_raw( $fallback );
+}
+
+/**
  * Add a safe continuation to a custom login URL.
  *
  * @param string $login_url   Custom login URL.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "User management system for ExtraChill Platform",
   "scripts": {
     "build": "npm run build:blocks && npm run copy:block-files",
+    "test:unit:js": "wp-scripts test-unit-js",
     "build:blocks": "npm run build:login-register && npm run build:login-register:view && npm run build:password-reset && npm run build:onboarding && npm run build:concert-attendance",
     "build:login-register": "wp-scripts build blocks/login-register/src/index.js --output-path=build/login-register",
     "build:login-register:view": "wp-scripts build blocks/login-register/view.js --output-path=build/login-register",

--- a/tests/js/login-continuation.test.js
+++ b/tests/js/login-continuation.test.js
@@ -51,8 +51,39 @@ function flushPromises() {
 
 describe( 'login continuation requests', () => {
 	let credentialCallback;
+	let originalGlobals;
+
+	function restoreProperty( target, property, original ) {
+		if ( original.exists ) {
+			target[ property ] = original.value;
+		} else {
+			delete target[ property ];
+		}
+	}
 
 	beforeEach( () => {
+		originalGlobals = {
+			actEnvironment: {
+				exists: Object.prototype.hasOwnProperty.call( global, 'IS_REACT_ACT_ENVIRONMENT' ),
+				value: global.IS_REACT_ACT_ENVIRONMENT,
+			},
+			authUtils: {
+				exists: Object.prototype.hasOwnProperty.call( window, 'ECAuthUtils' ),
+				value: window.ECAuthUtils,
+			},
+			googleSignIn: {
+				exists: Object.prototype.hasOwnProperty.call( window, 'ECGoogleSignIn' ),
+				value: window.ECGoogleSignIn,
+			},
+			google: {
+				exists: Object.prototype.hasOwnProperty.call( global, 'google' ),
+				value: global.google,
+			},
+			fetch: {
+				exists: Object.prototype.hasOwnProperty.call( global, 'fetch' ),
+				value: global.fetch,
+			},
+		};
 		global.IS_REACT_ACT_ENVIRONMENT = true;
 		document.body.innerHTML = '';
 		window.ECAuthUtils = {
@@ -76,11 +107,11 @@ describe( 'login continuation requests', () => {
 	} );
 
 	afterEach( () => {
-		delete global.IS_REACT_ACT_ENVIRONMENT;
-		delete window.ECGoogleSignIn;
-		delete window.ECAuthUtils;
-		delete global.google;
-		delete global.fetch;
+		restoreProperty( global, 'IS_REACT_ACT_ENVIRONMENT', originalGlobals.actEnvironment );
+		restoreProperty( window, 'ECGoogleSignIn', originalGlobals.googleSignIn );
+		restoreProperty( window, 'ECAuthUtils', originalGlobals.authUtils );
+		restoreProperty( global, 'google', originalGlobals.google );
+		restoreProperty( global, 'fetch', originalGlobals.fetch );
 	} );
 
 	test( 'default Login tab exposes one resolved continuation to password and Google flows', () => {

--- a/tests/js/login-continuation.test.js
+++ b/tests/js/login-continuation.test.js
@@ -1,0 +1,135 @@
+/**
+ * Behavioral browser contracts for resolved authentication continuations.
+ */
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { LoginPanel } from '../../blocks/login-register/view';
+
+jest.mock( '@extrachill/components', () => {
+	const React = require( 'react' );
+	return {
+		BlockShell: ( { children } ) => React.createElement( 'div', null, children ),
+		BlockShellHeader: () => null,
+		BlockShellInner: ( { children } ) => React.createElement( 'div', null, children ),
+		Panel: ( { children } ) => React.createElement( 'div', null, children ),
+		ResponsiveTabs: () => null,
+	};
+} );
+
+const continuation = 'https://community.extrachill.com/?compose=discussion&entity_taxonomy=artist&entity_slug=kid-lake';
+
+function authConfig() {
+	return {
+		loginRedirectUrl: continuation,
+		successRedirectUrl: continuation,
+		resetPasswordUrl: 'https://community.extrachill.com/reset-password/',
+		turnstileHtml: '',
+		googleOAuthEnabled: true,
+		googleSignInRedirectUrl: null,
+	};
+}
+
+function renderLoginPanel() {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+
+	act( () => {
+		root.render( <LoginPanel config={ authConfig() } notice={ null } setNotice={ jest.fn() } /> );
+	} );
+
+	return { container, root };
+}
+
+function flushPromises() {
+	return act( async () => {
+		await Promise.resolve();
+		await Promise.resolve();
+	} );
+}
+
+describe( 'login continuation requests', () => {
+	let credentialCallback;
+
+	beforeEach( () => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+		document.body.innerHTML = '';
+		window.ECAuthUtils = {
+			getDeviceId: jest.fn( () => '550e8400-e29b-41d4-a716-446655440000' ),
+			getRestRoot: jest.fn( () => 'https://community.extrachill.com/wp-json/' ),
+			setSubmitting: jest.fn( () => jest.fn() ),
+			renderNotice: jest.fn(),
+		};
+		global.google = {
+			accounts: {
+				id: {
+					initialize: jest.fn( ( config ) => {
+						credentialCallback = config.callback;
+					} ),
+					renderButton: jest.fn(),
+				},
+			},
+		};
+		global.fetch = jest.fn();
+		jest.resetModules();
+	} );
+
+	afterEach( () => {
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+		delete window.ECGoogleSignIn;
+		delete window.ECAuthUtils;
+		delete global.google;
+		delete global.fetch;
+	} );
+
+	test( 'default Login tab exposes one resolved continuation to password and Google flows', () => {
+		const { container, root } = renderLoginPanel();
+
+		expect( container.querySelector( 'input[name="redirect_to"]' ).value ).toBe( continuation );
+		expect( container.querySelector( 'input[name="success_redirect_url"]' ).value ).toBe( continuation );
+
+		act( () => root.unmount() );
+	} );
+
+	test( 'canonical Google request reads the resolved continuation from the default Login DOM', async () => {
+		const { root } = renderLoginPanel();
+		fetch.mockResolvedValue( {
+			ok: false,
+			json: async () => ( { message: 'Expected test stop.' } ),
+		} );
+		require( '../../assets/js/google-signin.js' );
+		window.ECGoogleSignIn.init( {
+			clientId: 'client-id',
+			restUrl: 'https://community.extrachill.com/wp-json/extrachill/v1/',
+		} );
+
+		credentialCallback( { credential: 'google-id-token' } );
+		await flushPromises();
+
+		const request = JSON.parse( fetch.mock.calls[0][1].body );
+		expect( request.success_redirect_url ).toBe( continuation );
+
+		act( () => root.unmount() );
+	} );
+
+	test( 'password request submits the continuation used by the 2FA challenge', async () => {
+		const { container, root } = renderLoginPanel();
+		container.querySelector( 'input[name="log"]' ).value = 'chubes';
+		container.querySelector( 'input[name="pwd"]' ).value = 'password';
+		fetch.mockResolvedValue( {
+			ok: false,
+			json: async () => ( { message: 'Expected test stop.' } ),
+		} );
+
+		await act( async () => {
+			container.querySelector( 'form' ).dispatchEvent( new Event( 'submit', { bubbles: true, cancelable: true } ) );
+		} );
+		await flushPromises();
+
+		const request = JSON.parse( fetch.mock.calls[0][1].body );
+		expect( request.redirect_to ).toBe( continuation );
+
+		act( () => root.unmount() );
+	} );
+} );

--- a/tests/unit/LoginContinuationTest.php
+++ b/tests/unit/LoginContinuationTest.php
@@ -4,9 +4,16 @@
  */
 
 class Test_Login_Continuation extends WP_UnitTestCase {
+	/**
+	 * Original request server state.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $original_server;
 
 	protected function setUp(): void {
 		parent::setUp();
+		$this->original_server = $_SERVER;
 		require_once dirname( __DIR__, 2 ) . '/inc/oauth/google-canonical-origin.php';
 	}
 
@@ -133,23 +140,48 @@ class Test_Login_Continuation extends WP_UnitTestCase {
 		$this->assertSame( $attendance_url, $custom_login_query['redirect_to'] ?? '' );
 	}
 
-	public function test_standard_registration_two_factor_and_google_flows_consume_the_resolved_continuation(): void {
-		$root   = dirname( __DIR__, 2 );
-		$render = file_get_contents( $root . '/blocks/login-register/render.php' );
-		$view   = file_get_contents( $root . '/blocks/login-register/view.js' );
-		$google = file_get_contents( $root . '/assets/js/google-signin.js' );
-		$tokens = file_get_contents( $root . '/inc/auth-tokens/service.php' );
+	public function test_noncanonical_google_handoff_carries_the_resolved_request_continuation(): void {
+		$request_redirect    = 'https://community.extrachill.com/?compose=discussion&entity_taxonomy=artist&entity_slug=kid-lake';
+		$_GET['redirect_to'] = $request_redirect;
 
-		$this->assertStringContainsString( 'ec_users_resolve_login_block_redirect( $block_redirect_url, $current_url )', $render );
-		$this->assertStringContainsString( 'ec_users_canonical_google_signin_url( $success_redirect )', $render );
-		$this->assertStringContainsString( 'name="redirect_to" value={ config.loginRedirectUrl }', $view );
-		$this->assertStringContainsString( 'redirect_to: redirectTo', $view );
-		$this->assertStringContainsString( 'name="success_redirect_url" value={ config.successRedirectUrl }', $view );
-		$this->assertStringContainsString( 'success_redirect_url: config.successRedirectUrl', $view );
-		$this->assertStringContainsString( 'data?.redirect_url || config.loginRedirectUrl', $view );
-		$this->assertStringContainsString( 'success_redirect_url: successRedirectUrl', $google );
-		$this->assertStringContainsString( 'extrachill_users_maybe_handle_two_factor( $identifier, $password, $remember, $safe_redirect_to )', $tokens );
-		$this->assertStringContainsString( "'redirect_to'   => \$redirect_to ? \$redirect_to : home_url()", $tokens );
+		$resolved   = ec_users_resolve_login_block_redirect(
+			'https://events.extrachill.com/',
+			'https://events.extrachill.com/login/'
+		);
+		$google_url = ec_users_canonical_google_signin_url( $resolved );
+		parse_str( (string) wp_parse_url( $google_url, PHP_URL_QUERY ), $query );
+		$this->assertSame( $request_redirect, $query[ EC_USERS_GOOGLE_REDIRECT_PARAM ] ?? '' );
+	}
+
+	/**
+	 * The token login service must carry its validated destination into the
+	 * Two Factor plugin's challenge state.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_two_factor_challenge_carries_the_validated_login_continuation(): void {
+		if ( class_exists( 'Two_Factor_Core' ) ) {
+			$this->markTestSkipped( 'Test requires the isolated Two_Factor_Core stub.' );
+		}
+
+		eval(
+			'class Two_Factor_Core {' .
+			'public static function is_user_using_two_factor( $user_id ) { return true; }' .
+			'public static function create_login_nonce( $user_id ) { return array( "key" => "test-2fa-nonce" ); }' .
+			'}'
+		);
+
+		$password     = 'valid-password';
+		$user_id      = self::factory()->user->create( array( 'user_pass' => $password ) );
+		$user         = get_user_by( 'id', $user_id );
+		$continuation = 'https://community.extrachill.com/?compose=discussion&entity_taxonomy=artist&entity_slug=kid-lake';
+		$result       = extrachill_users_maybe_handle_two_factor( $user->user_login, $password, true, $continuation );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['requires_2fa'] );
+		parse_str( (string) wp_parse_url( $result['redirect_url'], PHP_URL_QUERY ), $query );
+		$this->assertSame( $continuation, $query['redirect_to'] ?? '' );
 	}
 
 	/**
@@ -176,6 +208,7 @@ class Test_Login_Continuation extends WP_UnitTestCase {
 
 	protected function tearDown(): void {
 		unset( $_GET['redirect_to'], $_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] );
+		$_SERVER = $this->original_server;
 		parent::tearDown();
 	}
 }

--- a/tests/unit/LoginContinuationTest.php
+++ b/tests/unit/LoginContinuationTest.php
@@ -11,9 +11,17 @@ class Test_Login_Continuation extends WP_UnitTestCase {
 	 */
 	private $original_server;
 
+	/**
+	 * Original request query state.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $original_get;
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->original_server = $_SERVER;
+		$this->original_get    = $_GET;
 		require_once dirname( __DIR__, 2 ) . '/inc/oauth/google-canonical-origin.php';
 	}
 
@@ -207,8 +215,8 @@ class Test_Login_Continuation extends WP_UnitTestCase {
 	}
 
 	protected function tearDown(): void {
-		unset( $_GET['redirect_to'], $_GET[ EC_USERS_GOOGLE_REDIRECT_PARAM ] );
 		$_SERVER = $this->original_server;
+		$_GET    = $this->original_get;
 		parent::tearDown();
 	}
 }

--- a/tests/unit/LoginContinuationTest.php
+++ b/tests/unit/LoginContinuationTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Unit tests for login continuation handling (#206).
+ * End-to-end contract tests for login continuation handling (#206, #208).
  */
 
 class Test_Login_Continuation extends WP_UnitTestCase {
@@ -79,6 +79,42 @@ class Test_Login_Continuation extends WP_UnitTestCase {
 		$this->assertNull( ec_users_get_validated_login_redirect_from_request() );
 	}
 
+	public function test_valid_request_continuation_takes_precedence_over_fixed_block_redirect(): void {
+		$fixed_redirect         = 'https://community.extrachill.com/';
+		$request_redirect       = 'https://community.extrachill.com/?compose=discussion&entity_taxonomy=artist&entity_slug=kid-lake';
+		$_GET['redirect_to']    = $request_redirect;
+		$_SERVER['HTTP_HOST']   = 'community.extrachill.com';
+		$_SERVER['REQUEST_URI'] = '/login/?redirect_to=' . rawurlencode( $request_redirect );
+
+		$config = $this->render_login_block_config( $fixed_redirect );
+
+		$this->assertSame( $request_redirect, $config['loginRedirectUrl'] );
+		$this->assertSame( $request_redirect, $config['successRedirectUrl'] );
+	}
+
+	public function test_unsafe_request_continuation_falls_back_to_fixed_block_redirect(): void {
+		$fixed_redirect         = 'https://community.extrachill.com/';
+		$_GET['redirect_to']    = 'https://attacker.example/phish';
+		$_SERVER['HTTP_HOST']   = 'community.extrachill.com';
+		$_SERVER['REQUEST_URI'] = '/login/?redirect_to=https%3A%2F%2Fattacker.example%2Fphish';
+
+		$config = $this->render_login_block_config( $fixed_redirect );
+
+		$this->assertSame( $fixed_redirect, $config['loginRedirectUrl'] );
+		$this->assertSame( $fixed_redirect, $config['successRedirectUrl'] );
+	}
+
+	public function test_fixed_block_redirect_remains_the_default_without_request_continuation(): void {
+		$fixed_redirect         = 'https://community.extrachill.com/';
+		$_SERVER['HTTP_HOST']   = 'community.extrachill.com';
+		$_SERVER['REQUEST_URI'] = '/login/';
+
+		$config = $this->render_login_block_config( $fixed_redirect );
+
+		$this->assertSame( $fixed_redirect, $config['loginRedirectUrl'] );
+		$this->assertSame( $fixed_redirect, $config['successRedirectUrl'] );
+	}
+
 	public function test_network_custom_domain_is_allowed_by_existing_policy(): void {
 		$this->assertTrue( ec_users_is_valid_return_to_url( 'https://extrachill.link/chubes/' ) );
 	}
@@ -97,16 +133,45 @@ class Test_Login_Continuation extends WP_UnitTestCase {
 		$this->assertSame( $attendance_url, $custom_login_query['redirect_to'] ?? '' );
 	}
 
-	public function test_render_and_clients_consume_the_validated_continuation(): void {
+	public function test_standard_registration_two_factor_and_google_flows_consume_the_resolved_continuation(): void {
 		$root   = dirname( __DIR__, 2 );
 		$render = file_get_contents( $root . '/blocks/login-register/render.php' );
 		$view   = file_get_contents( $root . '/blocks/login-register/view.js' );
 		$google = file_get_contents( $root . '/assets/js/google-signin.js' );
+		$tokens = file_get_contents( $root . '/inc/auth-tokens/service.php' );
 
-		$this->assertStringContainsString( 'ec_users_get_validated_login_redirect_from_request()', $render );
+		$this->assertStringContainsString( 'ec_users_resolve_login_block_redirect( $block_redirect_url, $current_url )', $render );
 		$this->assertStringContainsString( 'ec_users_canonical_google_signin_url( $success_redirect )', $render );
+		$this->assertStringContainsString( 'name="redirect_to" value={ config.loginRedirectUrl }', $view );
+		$this->assertStringContainsString( 'redirect_to: redirectTo', $view );
+		$this->assertStringContainsString( 'name="success_redirect_url" value={ config.successRedirectUrl }', $view );
+		$this->assertStringContainsString( 'success_redirect_url: config.successRedirectUrl', $view );
 		$this->assertStringContainsString( 'data?.redirect_url || config.loginRedirectUrl', $view );
 		$this->assertStringContainsString( 'success_redirect_url: successRedirectUrl', $google );
+		$this->assertStringContainsString( 'extrachill_users_maybe_handle_two_factor( $identifier, $password, $remember, $safe_redirect_to )', $tokens );
+		$this->assertStringContainsString( "'redirect_to'   => \$redirect_to ? \$redirect_to : home_url()", $tokens );
+	}
+
+	/**
+	 * Render the dynamic block and decode its browser configuration.
+	 *
+	 * @param string $fixed_redirect Configured block redirect.
+	 * @return array<string, mixed>
+	 */
+	private function render_login_block_config( string $fixed_redirect ): array {
+		$html = render_block(
+			array(
+				'blockName' => 'extrachill/login-register',
+				'attrs'     => array( 'redirectUrl' => $fixed_redirect ),
+			)
+		);
+
+		$this->assertMatchesRegularExpression( '/data-ec-login-register-config="([^"]+)"/', $html );
+		preg_match( '/data-ec-login-register-config="([^"]+)"/', $html, $matches );
+		$config = json_decode( html_entity_decode( $matches[1], ENT_QUOTES, 'UTF-8' ), true );
+
+		$this->assertIsArray( $config );
+		return $config;
 	}
 
 	protected function tearDown(): void {


### PR DESCRIPTION
## Summary

- prefer the existing validator's safe request `redirect_to` over a fixed login block `redirectUrl`
- retain the validated fixed block destination when request continuation is absent or unsafe
- expose the same resolved destination as both `redirect_to` and `success_redirect_url` in the default Login panel so password, Google/provider, registration, token, and 2FA flows cannot drift
- validate registration continuation payloads at PHP service boundaries before storing onboarding state

## Precedence and compatibility

The block resolves one post-auth destination in this order:

1. Existing network-aware validator accepts request `redirect_to`.
2. Existing validator accepts configured block `redirectUrl`.
3. Current login URL remains the final fallback.

No second validator or redirect framework was added. Unsafe, external, relative, protocol-relative, and non-HTTPS destinations remain rejected. Blocks without a request continuation keep their configured redirect behavior. Invite-specific registration behavior is unchanged.

## Flow coverage

The resolved value now reaches:

- standard password login and token response
- default Login-tab Google provider requests
- registration and onboarding continuation state
- token login and Two Factor challenge `redirect_to`
- canonical Google requests and non-canonical canonical-origin handoff URLs

Behavioral browser tests render the real `LoginPanel`, inspect both hidden continuation fields, invoke the Google credential callback, submit the password form, and assert the captured REST request bodies. PHP contracts render the dynamic block, exercise non-canonical Google URL construction, and exercise the 2FA challenge URL with an isolated provider stub. Request server globals are restored after every PHP test.

## Verification

Passed:

```text
npm run test:unit:js -- --runInBand tests/js/login-continuation.test.js
npm run test:unit:js -- --runInBand
npm run build
homeboy --placement local review extrachill-users lint --path /var/lib/datamachine/workspace/extrachill-users@issue-208-login-continuation-precedence --changed-since origin/main --json-summary
homeboy --placement local review build extrachill-users --path /var/lib/datamachine/workspace/extrachill-users@issue-208-login-continuation-precedence --changed-since origin/main
php -l blocks/login-register/render.php
php -l inc/oauth/google-canonical-origin.php
php -l inc/auth/register.php
php -l inc/auth-tokens/service.php
php -l tests/unit/LoginContinuationTest.php
git diff --check
```

JavaScript: 3 tests passed. The full production build compiled all blocks and passed package PHP syntax and structure validation. Changed-file PHPCS, ESLint, and PHPStan passed; PHPCS reported only four pre-existing non-blocking nonce warnings on the signed invite query read.

Focused WordPress PHPUnit was attempted with:

```text
homeboy --placement local review extrachill-users test --path /var/lib/datamachine/workspace/extrachill-users@issue-208-login-continuation-precedence --changed-since origin/main --json-summary -- --filter Test_Login_Continuation
```

WP Codebox did not execute assertions because Homeboy's registered `extrachill-network` and `extrachill-api` validation primaries are each one commit behind `origin/main`; CI-parity policy rejects stale validation dependencies. Those unrelated primary checkouts were not modified.

Closes #208