### PR TITLE
feat: add audited Artist Dispatch access lifecycle

### DIFF
--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -140,6 +140,8 @@ function extrachill_users_init() {
 
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/artist-profiles.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/team-members.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/artist-dispatch-role.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/artist-dispatch.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/badges/user-badges.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/rank-system/rank-tiers.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/rank-system/points-engine.php';
@@ -175,6 +177,7 @@ function extrachill_users_init() {
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/notifications/read-redirect.php';
 	// Header notification bell — renders network-wide via the theme header hook.
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/notifications/bell.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/artist-dispatch-admin.php';
 
 	// Private, network-wide entity update subscriptions.
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/entity-subscriptions/service.php';

--- a/inc/artist-dispatch-role.php
+++ b/inc/artist-dispatch-role.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Main-site Artist Dispatch contributor role.
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+const EC_USERS_ARTIST_DISPATCH_ROLE = 'extra_chill_artist_dispatch_contributor';
+
+/**
+ * Return the exact native capability contract for Artist Dispatch contributors.
+ *
+ * @return array<string,bool>
+ */
+function ec_users_get_artist_dispatch_role_caps() {
+	return array(
+		'read'              => true,
+		'edit_posts'        => true,
+		'delete_posts'      => true,
+		'submit_for_review' => true,
+	);
+}
+
+/**
+ * Resolve the publication blog.
+ *
+ * @return int
+ */
+function ec_users_get_artist_dispatch_blog_id() {
+	if ( function_exists( 'ec_get_blog_id' ) ) {
+		return (int) ec_get_blog_id( 'main' );
+	}
+
+	return function_exists( 'get_main_site_id' ) ? (int) get_main_site_id() : 1;
+}
+
+/**
+ * Register the role only when operating on the main publication site.
+ */
+function ec_users_register_artist_dispatch_role() {
+	if ( get_current_blog_id() !== ec_users_get_artist_dispatch_blog_id() ) {
+		return;
+	}
+
+	$caps     = ec_users_get_artist_dispatch_role_caps();
+	$existing = get_role( EC_USERS_ARTIST_DISPATCH_ROLE );
+	if ( $existing instanceof WP_Role ) {
+		$existing_caps = array_filter( $existing->capabilities );
+		$desired_caps  = $caps;
+		ksort( $existing_caps );
+		ksort( $desired_caps );
+		if ( $existing_caps === $desired_caps ) {
+			return;
+		}
+		remove_role( EC_USERS_ARTIST_DISPATCH_ROLE );
+	}
+
+	add_role(
+		EC_USERS_ARTIST_DISPATCH_ROLE,
+		__( 'Artist Dispatch Contributor', 'extrachill-users' ),
+		$caps
+	);
+}
+
+/**
+ * Ensure the role exists on blog 1 without leaking the role to other sites.
+ */
+function ec_users_register_artist_dispatch_role_on_main() {
+	$blog_id = ec_users_get_artist_dispatch_blog_id();
+	if ( $blog_id <= 0 ) {
+		return;
+	}
+
+	if ( get_current_blog_id() === $blog_id ) {
+		ec_users_register_artist_dispatch_role();
+		return;
+	}
+
+	switch_to_blog( $blog_id );
+	try {
+		ec_users_register_artist_dispatch_role();
+	} finally {
+		restore_current_blog();
+	}
+}
+
+add_action( 'init', 'ec_users_register_artist_dispatch_role', 5 );
+
+/**
+ * Keep the additive role out of WordPress's destructive single-role dropdown.
+ *
+ * @param array<string,array> $roles Editable roles.
+ * @return array<string,array>
+ */
+function ec_users_hide_artist_dispatch_role_from_editable_roles( $roles ) {
+	unset( $roles[ EC_USERS_ARTIST_DISPATCH_ROLE ] );
+	return $roles;
+}
+add_filter( 'editable_roles', 'ec_users_hide_artist_dispatch_role_from_editable_roles' );

--- a/inc/artist-dispatch.php
+++ b/inc/artist-dispatch.php
@@ -11,6 +11,9 @@ const EC_USERS_ARTIST_DISPATCH_POLICY_OPTION = 'extrachill_users_artist_dispatch
 const EC_USERS_ARTIST_DISPATCH_STATE_META    = 'extrachill_artist_dispatch_access';
 const EC_USERS_ARTIST_DISPATCH_AUDIT_META    = 'extrachill_artist_dispatch_access_event';
 const EC_USERS_ARTIST_DISPATCH_TERMS_VERSION = '2026-07-18';
+const EC_USERS_ARTIST_DISPATCH_LOCK_META     = 'extrachill_artist_dispatch_access_lock';
+const EC_USERS_ARTIST_DISPATCH_DELIVERY_META = 'extrachill_artist_dispatch_delivery_receipt';
+const EC_USERS_ARTIST_DISPATCH_LOCK_TTL      = 30;
 
 /**
  * Return the disabled-by-default network policy.
@@ -19,24 +22,23 @@ const EC_USERS_ARTIST_DISPATCH_TERMS_VERSION = '2026-07-18';
  */
 function ec_users_get_artist_dispatch_policy() {
 	$defaults = array(
-		'minimum_points'            => null,
-		'minimum_account_age_days'  => 0,
-		'require_onboarding'        => true,
-		'require_claimed_artist'    => true,
-		'require_active_moderation' => true,
-		'pilot_enabled'             => false,
+		'minimum_points'           => null,
+		'minimum_account_age_days' => 0,
+		'require_onboarding'       => true,
+		'require_claimed_artist'   => true,
+		'pilot_enabled'            => false,
 	);
 	$stored   = get_site_option( EC_USERS_ARTIST_DISPATCH_POLICY_OPTION, array() );
 	$policy   = wp_parse_args( is_array( $stored ) ? $stored : array(), $defaults );
 
-	$policy['minimum_points']            = null === $policy['minimum_points'] || '' === $policy['minimum_points']
+	$policy['minimum_points']           = null === $policy['minimum_points'] || '' === $policy['minimum_points']
 		? null
 		: max( 0, (float) $policy['minimum_points'] );
-	$policy['minimum_account_age_days']  = max( 0, (int) $policy['minimum_account_age_days'] );
-	$policy['require_onboarding']        = (bool) $policy['require_onboarding'];
-	$policy['require_claimed_artist']    = (bool) $policy['require_claimed_artist'];
-	$policy['require_active_moderation'] = (bool) $policy['require_active_moderation'];
-	$policy['pilot_enabled']             = (bool) $policy['pilot_enabled'];
+	$policy['minimum_account_age_days'] = max( 0, (int) $policy['minimum_account_age_days'] );
+	$policy['require_onboarding']       = (bool) $policy['require_onboarding'];
+	$policy['require_claimed_artist']   = (bool) $policy['require_claimed_artist'];
+	$policy['pilot_enabled']            = (bool) $policy['pilot_enabled'];
+	unset( $policy['require_active_moderation'] );
 
 	return $policy;
 }
@@ -58,7 +60,7 @@ function ec_users_update_artist_dispatch_policy( array $input ) {
 	if ( array_key_exists( 'minimum_account_age_days', $input ) ) {
 		$policy['minimum_account_age_days'] = max( 0, (int) $input['minimum_account_age_days'] );
 	}
-	foreach ( array( 'require_onboarding', 'require_claimed_artist', 'require_active_moderation', 'pilot_enabled' ) as $field ) {
+	foreach ( array( 'require_onboarding', 'require_claimed_artist', 'pilot_enabled' ) as $field ) {
 		if ( array_key_exists( $field, $input ) ) {
 			$policy[ $field ] = (bool) $input[ $field ];
 		}
@@ -161,10 +163,9 @@ function ec_users_get_artist_dispatch_eligibility( $user_id ) {
 			'value'  => (bool) $claimed,
 		),
 		'active_moderation' => array(
-			'passed'   => ! $policy['require_active_moderation'] || ! empty( $moderation['active'] ),
-			'value'    => ! empty( $moderation['active'] ),
-			'required' => $policy['require_active_moderation'],
-			'state'    => isset( $moderation['state'] ) ? (string) $moderation['state'] : 'unknown',
+			'passed' => ! empty( $moderation['active'] ),
+			'value'  => ! empty( $moderation['active'] ),
+			'state'  => isset( $moderation['state'] ) ? (string) $moderation['state'] : 'unknown',
 		),
 		'claimed_artist'    => array(
 			'passed'     => ! $policy['require_claimed_artist'] || ! empty( $artist_ids ),
@@ -213,23 +214,82 @@ function ec_users_get_artist_dispatch_state( $user_id ) {
 }
 
 /**
+ * Compare-and-swap the current state record.
+ *
+ * @param int   $user_id User ID.
+ * @param array $next    Replacement state.
+ * @param array $current State read while holding the transition lock.
+ * @return bool
+ */
+function ec_users_write_artist_dispatch_state( $user_id, array $next, array $current ) {
+	if ( empty( $current ) ) {
+		return false !== add_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_STATE_META, $next, true );
+	}
+
+	return false !== update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_STATE_META, $next, $current );
+}
+
+/**
+ * Acquire a bounded per-user transition lock.
+ *
+ * @param int    $user_id    User ID.
+ * @param string $request_id Request UUID or operation name.
+ * @return array|WP_Error Lock record or error.
+ */
+function ec_users_acquire_artist_dispatch_lock( $user_id, $request_id ) {
+	$user_id = absint( $user_id );
+	for ( $attempt = 0; 5 > $attempt; ++$attempt ) {
+		$now  = time();
+		$lock = array(
+			'owner_token' => wp_generate_uuid4(),
+			'request_id'  => sanitize_text_field( $request_id ),
+			'expires_at'  => $now + EC_USERS_ARTIST_DISPATCH_LOCK_TTL,
+		);
+		if ( false !== add_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_LOCK_META, $lock, true ) ) {
+			return $lock;
+		}
+
+		$current = get_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_LOCK_META, true );
+		if ( is_array( $current ) && $now >= (int) ( $current['expires_at'] ?? 0 ) && false !== update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_LOCK_META, $lock, $current ) ) {
+			return $lock;
+		}
+		usleep( 50000 );
+	}
+
+	return new WP_Error( 'artist_dispatch_locked', __( 'Another Artist Dispatch access update is in progress. Please retry.', 'extrachill-users' ), array( 'status' => 409 ) );
+}
+
+/**
+ * Release a lock only when this caller still owns it.
+ *
+ * @param int   $user_id User ID.
+ * @param array $lock    Owned lock record.
+ * @return bool
+ */
+function ec_users_release_artist_dispatch_lock( $user_id, array $lock ) {
+	return delete_user_meta( absint( $user_id ), EC_USERS_ARTIST_DISPATCH_LOCK_META, $lock );
+}
+
+/**
  * Return a self-safe view without application copy or decision notes.
  *
  * @param int $user_id User ID.
  * @return array<string,mixed>
  */
 function ec_users_get_artist_dispatch_safe_state( $user_id ) {
-	$state = ec_users_get_artist_dispatch_state( $user_id );
-	$safe  = array(
-		'status'             => isset( $state['status'] ) ? (string) $state['status'] : 'none',
-		'request_id'         => isset( $state['request_id'] ) ? (string) $state['request_id'] : '',
-		'requested_at'       => isset( $state['requested_at'] ) ? (int) $state['requested_at'] : 0,
-		'artist_id'          => isset( $state['artist_id'] ) ? (int) $state['artist_id'] : 0,
-		'terms_acknowledged' => ! empty( $state['terms_acknowledged'] ),
-		'terms_version'      => isset( $state['terms_version'] ) ? (string) $state['terms_version'] : '',
-		'decided_at'         => isset( $state['decision']['decided_at'] ) ? (int) $state['decision']['decided_at'] : 0,
-		'revoked_at'         => isset( $state['revocation']['revoked_at'] ) ? (int) $state['revocation']['revoked_at'] : 0,
-		'eligibility'        => ec_users_get_artist_dispatch_eligibility( $user_id ),
+	$state         = ec_users_get_artist_dispatch_state( $user_id );
+	$terms_current = ! empty( $state['terms_acknowledged'] ) && EC_USERS_ARTIST_DISPATCH_TERMS_VERSION === ( $state['terms_version'] ?? '' );
+	$safe          = array(
+		'status'                 => isset( $state['status'] ) ? (string) $state['status'] : 'none',
+		'request_id'             => isset( $state['request_id'] ) ? (string) $state['request_id'] : '',
+		'requested_at'           => isset( $state['requested_at'] ) ? (int) $state['requested_at'] : 0,
+		'artist_id'              => isset( $state['artist_id'] ) ? (int) $state['artist_id'] : 0,
+		'terms_acknowledged'     => $terms_current,
+		'terms_version'          => $terms_current ? EC_USERS_ARTIST_DISPATCH_TERMS_VERSION : '',
+		'terms_renewal_required' => 'approved' === ( $state['status'] ?? '' ) && ! $terms_current,
+		'decided_at'             => isset( $state['decision']['decided_at'] ) ? (int) $state['decision']['decided_at'] : 0,
+		'revoked_at'             => isset( $state['revocation']['revoked_at'] ) ? (int) $state['revocation']['revoked_at'] : 0,
+		'eligibility'            => ec_users_get_artist_dispatch_eligibility( $user_id ),
 	);
 	if ( $safe['artist_id'] ) {
 		$safe['artist_label'] = ec_users_get_artist_dispatch_artist_label( $safe['artist_id'] );
@@ -239,37 +299,142 @@ function ec_users_get_artist_dispatch_safe_state( $user_id ) {
 }
 
 /**
- * Return the bounded, non-PII analytics payload for a successful request.
+ * Validate a canonical lowercase UUID v4.
  *
- * @param int    $user_id       Subject user ID.
- * @param int    $artist_id     Canonical represented artist ID.
- * @param string $terms_version Accepted terms version.
+ * @param string $request_id Candidate request ID.
+ * @return bool
+ */
+function ec_users_is_artist_dispatch_request_id( $request_id ) {
+	return 1 === preg_match( '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/D', (string) $request_id );
+}
+
+/**
+ * Return the exact analytics payload allowed by the owner contract.
+ *
+ * @param int    $user_id    Subject user ID.
+ * @param string $request_id Optional canonical request UUID.
+ * @param string $cohort     Optional fixed-enum cohort.
  * @return array<string,mixed>
  */
-function ec_users_get_artist_dispatch_requested_event_payload( $user_id, $artist_id, $terms_version ) {
-	return array(
-		'user_id'       => absint( $user_id ),
-		'artist_id'     => absint( $artist_id ),
-		'terms_version' => sanitize_text_field( $terms_version ),
-		'surface'       => 'artist_dispatch',
+function ec_users_get_artist_dispatch_event_payload( $user_id, $request_id = '', $cohort = '' ) {
+	$user_id = absint( $user_id );
+	if ( 0 >= $user_id ) {
+		return array();
+	}
+
+	$payload = array( 'user_id' => $user_id );
+	if ( ec_users_is_artist_dispatch_request_id( $request_id ) ) {
+		$payload['request_id'] = $request_id;
+	}
+	if ( in_array( $cohort, array( 'eligible', 'moderated' ), true ) ) {
+		$payload['eligibility_cohort'] = $cohort;
+	}
+	return $payload;
+}
+
+/**
+ * Resolve a lifecycle event constant without local string fallbacks.
+ *
+ * @param string $event_type Lifecycle transition.
+ * @return string
+ */
+function ec_users_get_artist_dispatch_analytics_event( $event_type ) {
+	$constants = array(
+		'requested' => 'EC_ANALYTICS_EVENT_ARTIST_DISPATCH_ACCESS_REQUESTED',
+		'approved'  => 'EC_ANALYTICS_EVENT_ARTIST_DISPATCH_ACCESS_APPROVED',
+		'rejected'  => 'EC_ANALYTICS_EVENT_ARTIST_DISPATCH_ACCESS_REJECTED',
+		'revoked'   => 'EC_ANALYTICS_EVENT_ARTIST_DISPATCH_ACCESS_REVOKED',
+	);
+	$constant  = $constants[ $event_type ] ?? '';
+	return $constant && defined( $constant ) ? (string) constant( $constant ) : '';
+}
+
+/**
+ * Test whether an external side effect already has a durable receipt.
+ *
+ * @param int    $user_id    User ID.
+ * @param string $channel    Delivery channel.
+ * @param string $event_type Lifecycle transition.
+ * @param string $request_id Request UUID.
+ * @return bool
+ */
+function ec_users_has_artist_dispatch_delivery_receipt( $user_id, $channel, $event_type, $request_id ) {
+	foreach ( get_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_DELIVERY_META, false ) as $receipt ) {
+		if ( is_array( $receipt ) && ( $receipt['channel'] ?? '' ) === $channel && ( $receipt['event'] ?? '' ) === $event_type && ( $receipt['request_id'] ?? '' ) === $request_id ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Append a durable external-delivery receipt once while under lock.
+ *
+ * @param int    $user_id    User ID.
+ * @param string $channel    Delivery channel.
+ * @param string $event_type Lifecycle transition.
+ * @param string $request_id Request UUID.
+ * @return bool
+ */
+function ec_users_add_artist_dispatch_delivery_receipt( $user_id, $channel, $event_type, $request_id ) {
+	if ( ec_users_has_artist_dispatch_delivery_receipt( $user_id, $channel, $event_type, $request_id ) ) {
+		return true;
+	}
+	return false !== add_user_meta(
+		$user_id,
+		EC_USERS_ARTIST_DISPATCH_DELIVERY_META,
+		array(
+			'channel'      => sanitize_key( $channel ),
+			'event'        => sanitize_key( $event_type ),
+			'request_id'   => sanitize_text_field( $request_id ),
+			'delivered_at' => time(),
+		),
+		false
 	);
 }
 
 /**
- * Emit the successful request transition through the canonical analytics event.
+ * Emit one owner event and persist its delivery marker after success.
  *
- * @param int    $user_id       Subject user ID.
- * @param int    $artist_id     Canonical represented artist ID.
- * @param string $terms_version Accepted terms version.
+ * Must run while holding the user's transition lock.
+ *
+ * @param int    $user_id    User ID.
+ * @param string $event_type Lifecycle transition.
+ * @param array  $state      Current state under lock.
+ * @return array|WP_Error Updated state or error.
  */
-function ec_users_emit_artist_dispatch_requested_event( $user_id, $artist_id, $terms_version ) {
-	if ( ! defined( 'EC_ANALYTICS_EVENT_ARTIST_DISPATCH_ACCESS_REQUESTED' ) || ! function_exists( 'ec_users_emit_team_experience_event' ) ) {
-		return;
+function ec_users_maybe_emit_artist_dispatch_event( $user_id, $event_type, array $state ) {
+	if ( ! empty( $state['deliveries']['analytics'][ $event_type ] ) ) {
+		return $state;
+	}
+	$request_id = (string) ( $state['request_id'] ?? '' );
+	if ( ec_users_has_artist_dispatch_delivery_receipt( $user_id, 'analytics', $event_type, $request_id ) ) {
+		$next = $state;
+		$next['deliveries']['analytics'][ $event_type ] = time();
+		return ec_users_write_artist_dispatch_state( $user_id, $next, $state )
+			? $next
+			: new WP_Error( 'artist_dispatch_analytics_marker_failed', __( 'The Artist Dispatch analytics delivery marker could not be repaired.', 'extrachill-users' ) );
+	}
+	$event_name = ec_users_get_artist_dispatch_analytics_event( $event_type );
+	if ( ! $event_name || ! function_exists( 'ec_users_emit_team_experience_event' ) ) {
+		return $state;
 	}
 
-	$payload = ec_users_get_artist_dispatch_requested_event_payload( $user_id, $artist_id, $terms_version );
+	$payload = ec_users_get_artist_dispatch_event_payload( $user_id, $request_id );
 	unset( $payload['user_id'] );
-	ec_users_emit_team_experience_event( EC_ANALYTICS_EVENT_ARTIST_DISPATCH_ACCESS_REQUESTED, $user_id, $payload );
+	if ( 0 >= ec_users_emit_team_experience_event( $event_name, $user_id, $payload ) ) {
+		return new WP_Error( 'artist_dispatch_analytics_failed', __( 'The Artist Dispatch analytics event could not be recorded.', 'extrachill-users' ) );
+	}
+	if ( ! ec_users_add_artist_dispatch_delivery_receipt( $user_id, 'analytics', $event_type, $request_id ) ) {
+		return new WP_Error( 'artist_dispatch_analytics_receipt_failed', __( 'The Artist Dispatch analytics delivery receipt could not be saved.', 'extrachill-users' ) );
+	}
+
+	$next = $state;
+	$next['deliveries']['analytics'][ $event_type ] = time();
+	if ( ! ec_users_write_artist_dispatch_state( $user_id, $next, $state ) ) {
+		return new WP_Error( 'artist_dispatch_analytics_marker_failed', __( 'The Artist Dispatch analytics delivery marker could not be saved.', 'extrachill-users' ) );
+	}
+	return $next;
 }
 
 /**
@@ -285,7 +450,7 @@ function ec_users_emit_artist_dispatch_requested_event( $user_id, $artist_id, $t
 function ec_users_add_artist_dispatch_audit_event( $user_id, $event_type, $request_id, $actor_id, array $details = array() ) {
 	foreach ( get_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_AUDIT_META, false ) as $event ) {
 		if ( is_array( $event ) && ( $event['event'] ?? '' ) === $event_type && ( $event['request_id'] ?? '' ) === $request_id ) {
-			return false;
+			return true;
 		}
 	}
 
@@ -305,23 +470,34 @@ function ec_users_add_artist_dispatch_audit_event( $user_id, $event_type, $reque
 }
 
 /**
- * Send one transition notification, marking it before delivery for retry safety.
+ * Resolve the notification actor, including actorless WP-CLI transitions.
+ *
+ * @param int $actor_id Requested actor.
+ * @return int
+ */
+function ec_users_resolve_artist_dispatch_notification_actor( $actor_id ) {
+	$actor_id = absint( $actor_id );
+	if ( $actor_id && get_userdata( $actor_id ) ) {
+		return $actor_id;
+	}
+	$bot_id = function_exists( 'ec_get_network_bot_user_id' ) ? absint( ec_get_network_bot_user_id() ) : 0;
+	return $bot_id && get_userdata( $bot_id ) ? $bot_id : 0;
+}
+
+/**
+ * Send one transition notification and mark only successful delivery.
+ *
+ * Must run while holding the user's transition lock.
  *
  * @param int    $user_id    Recipient.
  * @param string $event_type Transition.
  * @param int    $actor_id   Actor.
- * @return void
+ * @param array  $state      Current state under lock.
+ * @return array|WP_Error Updated state or error.
  */
-function ec_users_maybe_notify_artist_dispatch_transition( $user_id, $event_type, $actor_id ) {
-	$state = ec_users_get_artist_dispatch_state( $user_id );
-	if ( ! empty( $state['notifications'][ $event_type ] ) ) {
-		return;
-	}
-
-	$state['notifications'][ $event_type ] = time();
-	update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_STATE_META, $state );
-	if ( ! function_exists( 'ec_users_notify' ) ) {
-		return;
+function ec_users_maybe_notify_artist_dispatch_transition( $user_id, $event_type, $actor_id, array $state ) {
+	if ( ! empty( $state['deliveries']['notifications'][ $event_type ] ) ) {
+		return $state;
 	}
 
 	$titles = array(
@@ -330,7 +506,19 @@ function ec_users_maybe_notify_artist_dispatch_transition( $user_id, $event_type
 		'revoked'  => __( 'Your Artist Dispatch access was revoked.', 'extrachill-users' ),
 	);
 	if ( ! isset( $titles[ $event_type ] ) ) {
-		return;
+		return $state;
+	}
+	$request_id = (string) ( $state['request_id'] ?? '' );
+	if ( ec_users_has_artist_dispatch_delivery_receipt( $user_id, 'notification', $event_type, $request_id ) ) {
+		$next = $state;
+		$next['deliveries']['notifications'][ $event_type ] = time();
+		return ec_users_write_artist_dispatch_state( $user_id, $next, $state )
+			? $next
+			: new WP_Error( 'artist_dispatch_notification_marker_failed', __( 'The Artist Dispatch notification delivery marker could not be repaired.', 'extrachill-users' ) );
+	}
+	$notification_actor = ec_users_resolve_artist_dispatch_notification_actor( $actor_id );
+	if ( ! $notification_actor || ! function_exists( 'ec_users_notify' ) ) {
+		return new WP_Error( 'artist_dispatch_notification_actor_missing', __( 'A valid Artist Dispatch notification actor is unavailable.', 'extrachill-users' ) );
 	}
 
 	$blog_id = ec_users_get_artist_dispatch_blog_id();
@@ -341,16 +529,55 @@ function ec_users_maybe_notify_artist_dispatch_transition( $user_id, $event_type
 		restore_current_blog();
 	}
 
-	ec_users_notify(
+	$inserted = ec_users_notify(
 		$user_id,
 		array(
-			'actor_id' => absint( $actor_id ),
+			'actor_id' => $notification_actor,
 			'type'     => 'artist_dispatch_' . $event_type,
 			'link'     => $link,
 			'title'    => $titles[ $event_type ],
 			'item_id'  => isset( $state['artist_id'] ) ? absint( $state['artist_id'] ) : 0,
 		)
 	);
+	if ( 1 > $inserted ) {
+		return new WP_Error( 'artist_dispatch_notification_failed', __( 'The Artist Dispatch notification could not be delivered.', 'extrachill-users' ) );
+	}
+	if ( ! ec_users_add_artist_dispatch_delivery_receipt( $user_id, 'notification', $event_type, $request_id ) ) {
+		return new WP_Error( 'artist_dispatch_notification_receipt_failed', __( 'The Artist Dispatch notification delivery receipt could not be saved.', 'extrachill-users' ) );
+	}
+
+	$next = $state;
+	$next['deliveries']['notifications'][ $event_type ] = time();
+	if ( ! ec_users_write_artist_dispatch_state( $user_id, $next, $state ) ) {
+		return new WP_Error( 'artist_dispatch_notification_marker_failed', __( 'The Artist Dispatch notification delivery marker could not be saved.', 'extrachill-users' ) );
+	}
+	return $next;
+}
+
+/**
+ * Repair/finalize append-only and delivered transition side effects.
+ *
+ * Must run while holding the user's transition lock.
+ *
+ * @param int    $user_id    User ID.
+ * @param string $event_type Lifecycle transition.
+ * @param int    $actor_id   Actor user ID.
+ * @param array  $state      Current state under lock.
+ * @param array  $details    Non-sensitive audit details.
+ * @return array|WP_Error Updated state or error.
+ */
+function ec_users_finalize_artist_dispatch_transition( $user_id, $event_type, $actor_id, array $state, array $details = array() ) {
+	if ( ! ec_users_add_artist_dispatch_audit_event( $user_id, $event_type, (string) $state['request_id'], $actor_id, $details ) ) {
+		return new WP_Error( 'artist_dispatch_audit_failed', __( 'The Artist Dispatch audit event could not be saved.', 'extrachill-users' ) );
+	}
+	$state = ec_users_maybe_emit_artist_dispatch_event( $user_id, $event_type, $state );
+	if ( is_wp_error( $state ) ) {
+		return $state;
+	}
+	if ( in_array( $event_type, array( 'approved', 'rejected', 'revoked' ), true ) ) {
+		$state = ec_users_maybe_notify_artist_dispatch_transition( $user_id, $event_type, $actor_id, $state );
+	}
+	return $state;
 }
 
 /**
@@ -368,6 +595,15 @@ function ec_users_grant_artist_dispatch_role( $user_id ) {
 
 	$membership_preexisted = is_user_member_of_blog( $user_id, $blog_id );
 	ec_users_register_artist_dispatch_role_on_main();
+	$role_preexisted = false;
+	if ( $membership_preexisted ) {
+		switch_to_blog( $blog_id );
+		try {
+			$role_preexisted = in_array( EC_USERS_ARTIST_DISPATCH_ROLE, (array) ( new WP_User( $user_id ) )->roles, true );
+		} finally {
+			restore_current_blog();
+		}
+	}
 	if ( ! $membership_preexisted ) {
 		$result = add_user_to_blog( $blog_id, $user_id, EC_USERS_ARTIST_DISPATCH_ROLE );
 		if ( is_wp_error( $result ) ) {
@@ -388,6 +624,9 @@ function ec_users_grant_artist_dispatch_role( $user_id ) {
 	}
 
 	if ( ! $granted ) {
+		if ( ! $membership_preexisted ) {
+			remove_user_from_blog( $user_id, $blog_id );
+		}
 		return new WP_Error( 'artist_dispatch_grant_failed', __( 'The Artist Dispatch role could not be granted.', 'extrachill-users' ) );
 	}
 
@@ -395,6 +634,7 @@ function ec_users_grant_artist_dispatch_role( $user_id ) {
 		'blog_id'               => $blog_id,
 		'role'                  => EC_USERS_ARTIST_DISPATCH_ROLE,
 		'membership_preexisted' => $membership_preexisted,
+		'role_preexisted'       => $role_preexisted,
 	);
 }
 
@@ -403,7 +643,7 @@ function ec_users_grant_artist_dispatch_role( $user_id ) {
  *
  * @param int  $user_id               User ID.
  * @param bool $membership_preexisted Whether membership existed before approval.
- * @return array<string,mixed>
+ * @return array<string,mixed>|WP_Error
  */
 function ec_users_revoke_artist_dispatch_role( $user_id, $membership_preexisted ) {
 	$user_id = absint( $user_id );
@@ -432,7 +672,21 @@ function ec_users_revoke_artist_dispatch_role( $user_id, $membership_preexisted 
 	}
 
 	if ( ! $membership_preexisted && ! $remaining_access && is_user_member_of_blog( $user_id, $blog_id ) ) {
-		$cleaned = true === remove_user_from_blog( $user_id, $blog_id );
+		$result = remove_user_from_blog( $user_id, $blog_id );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		$cleaned = true === $result;
+	}
+	if ( is_user_member_of_blog( $user_id, $blog_id ) ) {
+		switch_to_blog( $blog_id );
+		try {
+			if ( in_array( EC_USERS_ARTIST_DISPATCH_ROLE, (array) ( new WP_User( $user_id ) )->roles, true ) ) {
+				return new WP_Error( 'artist_dispatch_role_revoke_failed', __( 'The Artist Dispatch role could not be removed.', 'extrachill-users' ) );
+			}
+		} finally {
+			restore_current_blog();
+		}
 	}
 
 	return array(
@@ -450,7 +704,6 @@ function ec_users_revoke_artist_dispatch_role( $user_id, $membership_preexisted 
  */
 function ec_users_request_artist_dispatch_access( $user_id, array $input ) {
 	$user_id       = absint( $user_id );
-	$state         = ec_users_get_artist_dispatch_state( $user_id );
 	$terms_version = isset( $input['terms_version'] ) ? sanitize_text_field( (string) $input['terms_version'] ) : '';
 	if ( true !== ( $input['acknowledgement'] ?? false ) ) {
 		return new WP_Error( 'artist_dispatch_acknowledgement_required', __( 'You must acknowledge the Artist Dispatch terms and your affiliation disclosure.', 'extrachill-users' ), array( 'status' => 400 ) );
@@ -458,71 +711,88 @@ function ec_users_request_artist_dispatch_access( $user_id, array $input ) {
 	if ( EC_USERS_ARTIST_DISPATCH_TERMS_VERSION !== $terms_version ) {
 		return new WP_Error( 'invalid_artist_dispatch_terms_version', __( 'The Artist Dispatch terms version is missing or no longer current.', 'extrachill-users' ), array( 'status' => 400 ) );
 	}
-	if ( 'pending' === ( $state['status'] ?? '' ) ) {
-		if ( empty( $state['terms_acknowledged'] ) || ( $state['terms_version'] ?? '' ) !== $terms_version ) {
-			return new WP_Error( 'artist_dispatch_terms_mismatch', __( 'The pending request is bound to a different terms acceptance.', 'extrachill-users' ), array( 'status' => 409 ) );
+
+	$lock = ec_users_acquire_artist_dispatch_lock( $user_id, 'request' );
+	if ( is_wp_error( $lock ) ) {
+		return $lock;
+	}
+	try {
+		$current = ec_users_get_artist_dispatch_state( $user_id );
+		$status  = $current['status'] ?? '';
+		if ( 'approved' === $status ) {
+			if ( ! empty( $current['terms_acknowledged'] ) && ( $current['terms_version'] ?? '' ) === $terms_version ) {
+				return new WP_Error( 'artist_dispatch_already_approved', __( 'Artist Dispatch access is already approved with current terms.', 'extrachill-users' ), array( 'status' => 409 ) );
+			}
+			$moderation = extrachill_users_get_moderation_status( $user_id );
+			if ( empty( $moderation['active'] ) ) {
+				return new WP_Error( 'artist_dispatch_moderated', __( 'Active moderation prevents Artist Dispatch terms renewal.', 'extrachill-users' ), array( 'status' => 403 ) );
+			}
+			$renewed                        = $current;
+			$renewed['previous_request_id'] = $current['request_id'] ?? '';
+			$renewed['request_id']          = wp_generate_uuid4();
+			$renewed['terms_acknowledged']  = true;
+			$renewed['terms_version']       = $terms_version;
+			$renewed['terms_accepted_at']   = time();
+			if ( ! ec_users_write_artist_dispatch_state( $user_id, $renewed, $current ) ) {
+				return new WP_Error( 'artist_dispatch_state_write_failed', __( 'The Artist Dispatch terms renewal could not be saved.', 'extrachill-users' ) );
+			}
+			if ( ! ec_users_add_artist_dispatch_audit_event( $user_id, 'terms_renewed', $renewed['request_id'], $user_id, array( 'terms_version' => $terms_version ) ) ) {
+				return new WP_Error( 'artist_dispatch_audit_failed', __( 'The Artist Dispatch terms renewal audit could not be saved.', 'extrachill-users' ) );
+			}
+			return $renewed;
 		}
-		return $state;
-	}
-	if ( 'approved' === ( $state['status'] ?? '' ) ) {
-		return new WP_Error( 'artist_dispatch_already_approved', __( 'Artist Dispatch access is already approved.', 'extrachill-users' ), array( 'status' => 409 ) );
-	}
+		if ( 'pending' === $status ) {
+			if ( empty( $current['terms_acknowledged'] ) || ( $current['terms_version'] ?? '' ) !== $terms_version ) {
+				return new WP_Error( 'artist_dispatch_stale_terms', __( 'The pending request accepted an outdated terms version and cannot be changed in place.', 'extrachill-users' ), array( 'status' => 409 ) );
+			}
+			return ec_users_finalize_artist_dispatch_transition( $user_id, 'requested', $user_id, $current );
+		}
 
-	$eligibility = ec_users_get_artist_dispatch_eligibility( $user_id );
-	if ( empty( $eligibility['eligible'] ) ) {
-		return new WP_Error(
-			'artist_dispatch_ineligible',
-			implode( ' ', $eligibility['reasons'] ),
-			array(
-				'status'      => 403,
-				'eligibility' => $eligibility,
-			)
+		$eligibility = ec_users_get_artist_dispatch_eligibility( $user_id );
+		if ( empty( $eligibility['eligible'] ) ) {
+			return new WP_Error(
+				'artist_dispatch_ineligible',
+				implode( ' ', $eligibility['reasons'] ),
+				array(
+					'status'      => 403,
+					'eligibility' => $eligibility,
+				)
+			);
+		}
+		$artist_id = isset( $input['artist_id'] ) ? absint( $input['artist_id'] ) : 0;
+		if ( ! $artist_id || ! in_array( $artist_id, $eligibility['criteria']['claimed_artist']['artist_ids'], true ) ) {
+			return new WP_Error( 'invalid_artist_dispatch_artist', __( 'Select an artist profile you canonically manage or claim.', 'extrachill-users' ), array( 'status' => 403 ) );
+		}
+		$description = isset( $input['description'] ) ? sanitize_textarea_field( (string) $input['description'] ) : '';
+		$length      = function_exists( 'mb_strlen' ) ? mb_strlen( $description ) : strlen( $description );
+		if ( 50 > $length || 2000 < $length ) {
+			return new WP_Error( 'invalid_artist_dispatch_description', __( 'The proposed Dispatch description must be between 50 and 2,000 characters.', 'extrachill-users' ), array( 'status' => 400 ) );
+		}
+		$sample_url = isset( $input['sample_url'] ) ? esc_url_raw( (string) $input['sample_url'] ) : '';
+		if ( '' !== $sample_url && ! wp_http_validate_url( $sample_url ) ) {
+			return new WP_Error( 'invalid_artist_dispatch_sample_url', __( 'The sample URL must be a valid HTTP or HTTPS URL.', 'extrachill-users' ), array( 'status' => 400 ) );
+		}
+
+		$state = array(
+			'schema_version'       => 1,
+			'status'               => 'pending',
+			'request_id'           => wp_generate_uuid4(),
+			'requested_at'         => time(),
+			'artist_id'            => $artist_id,
+			'terms_acknowledged'   => true,
+			'terms_version'        => $terms_version,
+			'terms_accepted_at'    => time(),
+			'description'          => $description,
+			'sample_url'           => $sample_url,
+			'eligibility_snapshot' => $eligibility,
 		);
+		if ( ! ec_users_write_artist_dispatch_state( $user_id, $state, $current ) ) {
+			return new WP_Error( 'artist_dispatch_state_write_failed', __( 'The Artist Dispatch request could not be saved.', 'extrachill-users' ) );
+		}
+		return ec_users_finalize_artist_dispatch_transition( $user_id, 'requested', $user_id, $state, array( 'terms_version' => $terms_version ) );
+	} finally {
+		ec_users_release_artist_dispatch_lock( $user_id, $lock );
 	}
-
-	$artist_id = isset( $input['artist_id'] ) ? absint( $input['artist_id'] ) : 0;
-	if ( ! $artist_id || ! in_array( $artist_id, $eligibility['criteria']['claimed_artist']['artist_ids'], true ) ) {
-		return new WP_Error( 'invalid_artist_dispatch_artist', __( 'Select an artist profile you canonically manage or claim.', 'extrachill-users' ), array( 'status' => 403 ) );
-	}
-
-	$description = isset( $input['description'] ) ? sanitize_textarea_field( (string) $input['description'] ) : '';
-	$length      = function_exists( 'mb_strlen' ) ? mb_strlen( $description ) : strlen( $description );
-	if ( $length < 50 || $length > 2000 ) {
-		return new WP_Error( 'invalid_artist_dispatch_description', __( 'The proposed Dispatch description must be between 50 and 2,000 characters.', 'extrachill-users' ), array( 'status' => 400 ) );
-	}
-
-	$sample_url = isset( $input['sample_url'] ) ? esc_url_raw( (string) $input['sample_url'] ) : '';
-	if ( '' !== $sample_url && ! wp_http_validate_url( $sample_url ) ) {
-		return new WP_Error( 'invalid_artist_dispatch_sample_url', __( 'The sample URL must be a valid HTTP or HTTPS URL.', 'extrachill-users' ), array( 'status' => 400 ) );
-	}
-
-	$state = array(
-		'schema_version'       => 1,
-		'status'               => 'pending',
-		'request_id'           => wp_generate_uuid4(),
-		'requested_at'         => time(),
-		'artist_id'            => $artist_id,
-		'terms_acknowledged'   => true,
-		'terms_version'        => $terms_version,
-		'terms_accepted_at'    => time(),
-		'description'          => $description,
-		'sample_url'           => $sample_url,
-		'eligibility_snapshot' => $eligibility,
-	);
-	update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_STATE_META, $state );
-	ec_users_add_artist_dispatch_audit_event(
-		$user_id,
-		'requested',
-		$state['request_id'],
-		$user_id,
-		array(
-			'artist_id'     => $artist_id,
-			'terms_version' => $terms_version,
-		)
-	);
-	ec_users_emit_artist_dispatch_requested_event( $user_id, $artist_id, $terms_version );
-
-	return $state;
 }
 
 /**
@@ -537,63 +807,70 @@ function ec_users_request_artist_dispatch_access( $user_id, array $input ) {
 function ec_users_approve_artist_dispatch_access( $user_id, $request_id, $note, $actor_id ) {
 	$user_id    = absint( $user_id );
 	$request_id = sanitize_text_field( $request_id );
-	$state      = ec_users_get_artist_dispatch_state( $user_id );
-	if ( ( $state['request_id'] ?? '' ) !== $request_id ) {
-		return new WP_Error( 'artist_dispatch_request_mismatch', __( 'The request ID does not match current state.', 'extrachill-users' ), array( 'status' => 409 ) );
+	$lock       = ec_users_acquire_artist_dispatch_lock( $user_id, $request_id );
+	if ( is_wp_error( $lock ) ) {
+		return $lock;
 	}
-	if ( 'approved' === ( $state['status'] ?? '' ) ) {
-		$repair = ec_users_grant_artist_dispatch_role( $user_id );
-		return is_wp_error( $repair ) ? $repair : $state;
-	}
-	if ( 'pending' !== ( $state['status'] ?? '' ) ) {
-		return new WP_Error( 'artist_dispatch_not_pending', __( 'Only pending requests can be approved.', 'extrachill-users' ), array( 'status' => 409 ) );
-	}
+	try {
+		$current = ec_users_get_artist_dispatch_state( $user_id );
+		if ( ( $current['request_id'] ?? '' ) !== $request_id ) {
+			return new WP_Error( 'artist_dispatch_request_mismatch', __( 'The request ID does not match current state.', 'extrachill-users' ), array( 'status' => 409 ) );
+		}
+		if ( 'approved' === ( $current['status'] ?? '' ) ) {
+			$repair = ec_users_grant_artist_dispatch_role( $user_id );
+			return is_wp_error( $repair ) ? $repair : ec_users_finalize_artist_dispatch_transition( $user_id, 'approved', $actor_id, $current );
+		}
+		if ( 'pending' !== ( $current['status'] ?? '' ) ) {
+			return new WP_Error( 'artist_dispatch_not_pending', __( 'Only pending requests can be approved.', 'extrachill-users' ), array( 'status' => 409 ) );
+		}
+		if ( empty( $current['terms_acknowledged'] ) || EC_USERS_ARTIST_DISPATCH_TERMS_VERSION !== ( $current['terms_version'] ?? '' ) ) {
+			return new WP_Error( 'artist_dispatch_stale_terms', __( 'The pending request must accept the current Artist Dispatch terms before approval.', 'extrachill-users' ), array( 'status' => 409 ) );
+		}
+		$moderation = extrachill_users_get_moderation_status( $user_id );
+		if ( empty( $moderation['active'] ) ) {
+			return new WP_Error( 'artist_dispatch_moderated', __( 'Active moderation prevents Artist Dispatch approval.', 'extrachill-users' ), array( 'status' => 403 ) );
+		}
+		$eligibility = ec_users_get_artist_dispatch_eligibility( $user_id );
+		if ( empty( $eligibility['eligible'] ) || ! in_array( (int) $current['artist_id'], $eligibility['criteria']['claimed_artist']['artist_ids'], true ) ) {
+			return new WP_Error(
+				'artist_dispatch_no_longer_eligible',
+				__( 'The request no longer satisfies the Artist Dispatch policy.', 'extrachill-users' ),
+				array(
+					'status'      => 403,
+					'eligibility' => $eligibility,
+				)
+			);
+		}
 
-	$eligibility = ec_users_get_artist_dispatch_eligibility( $user_id );
-	if ( empty( $eligibility['eligible'] ) || ! in_array( (int) $state['artist_id'], $eligibility['criteria']['claimed_artist']['artist_ids'], true ) ) {
-		return new WP_Error(
-			'artist_dispatch_no_longer_eligible',
-			__( 'The request no longer satisfies the Artist Dispatch policy.', 'extrachill-users' ),
+		$grant = ec_users_grant_artist_dispatch_role( $user_id );
+		if ( is_wp_error( $grant ) ) {
+			return $grant;
+		}
+		$now                  = time();
+		$approved             = $current;
+		$approved['status']   = 'approved';
+		$approved['decision'] = array(
+			'decided_at' => $now,
+			'actor_id'   => absint( $actor_id ),
+			'note'       => sanitize_textarea_field( $note ),
+		);
+		$approved['grant']    = array_merge(
+			$grant,
 			array(
-				'status'      => 403,
-				'eligibility' => $eligibility,
+				'granted_at' => $now,
+				'actor_id'   => absint( $actor_id ),
 			)
 		);
+		if ( ! ec_users_write_artist_dispatch_state( $user_id, $approved, $current ) ) {
+			if ( empty( $grant['role_preexisted'] ) ) {
+				ec_users_revoke_artist_dispatch_role( $user_id, ! empty( $grant['membership_preexisted'] ) );
+			}
+			return new WP_Error( 'artist_dispatch_state_write_failed', __( 'Artist Dispatch approval could not be saved; the role grant was rolled back.', 'extrachill-users' ) );
+		}
+		return ec_users_finalize_artist_dispatch_transition( $user_id, 'approved', $actor_id, $approved );
+	} finally {
+		ec_users_release_artist_dispatch_lock( $user_id, $lock );
 	}
-
-	$grant = ec_users_grant_artist_dispatch_role( $user_id );
-	if ( is_wp_error( $grant ) ) {
-		return $grant;
-	}
-	$now               = time();
-	$state['status']   = 'approved';
-	$state['decision'] = array(
-		'decided_at' => $now,
-		'actor_id'   => absint( $actor_id ),
-		'note'       => sanitize_textarea_field( $note ),
-	);
-	$state['grant']    = array_merge(
-		$grant,
-		array(
-			'granted_at' => $now,
-			'actor_id'   => absint( $actor_id ),
-		)
-	);
-	update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_STATE_META, $state );
-	ec_users_add_artist_dispatch_audit_event(
-		$user_id,
-		'approved',
-		$request_id,
-		$actor_id,
-		array(
-			'artist_id' => (int) $state['artist_id'],
-			'blog_id'   => (int) $grant['blog_id'],
-			'role'      => $grant['role'],
-		)
-	);
-	ec_users_maybe_notify_artist_dispatch_transition( $user_id, 'approved', $actor_id );
-
-	return ec_users_get_artist_dispatch_state( $user_id );
 }
 
 /**
@@ -609,31 +886,38 @@ function ec_users_reject_artist_dispatch_access( $user_id, $request_id, $reason,
 	$user_id    = absint( $user_id );
 	$request_id = sanitize_text_field( $request_id );
 	$reason     = sanitize_textarea_field( $reason );
-	$state      = ec_users_get_artist_dispatch_state( $user_id );
 	if ( '' === $reason ) {
 		return new WP_Error( 'artist_dispatch_reason_required', __( 'A rejection reason is required.', 'extrachill-users' ), array( 'status' => 400 ) );
 	}
-	if ( ( $state['request_id'] ?? '' ) !== $request_id ) {
-		return new WP_Error( 'artist_dispatch_request_mismatch', __( 'The request ID does not match current state.', 'extrachill-users' ), array( 'status' => 409 ) );
+	$lock = ec_users_acquire_artist_dispatch_lock( $user_id, $request_id );
+	if ( is_wp_error( $lock ) ) {
+		return $lock;
 	}
-	if ( 'rejected' === ( $state['status'] ?? '' ) ) {
-		return $state;
+	try {
+		$current = ec_users_get_artist_dispatch_state( $user_id );
+		if ( ( $current['request_id'] ?? '' ) !== $request_id ) {
+			return new WP_Error( 'artist_dispatch_request_mismatch', __( 'The request ID does not match current state.', 'extrachill-users' ), array( 'status' => 409 ) );
+		}
+		if ( 'rejected' === ( $current['status'] ?? '' ) ) {
+			return ec_users_finalize_artist_dispatch_transition( $user_id, 'rejected', $actor_id, $current );
+		}
+		if ( 'pending' !== ( $current['status'] ?? '' ) ) {
+			return new WP_Error( 'artist_dispatch_not_pending', __( 'Only pending requests can be rejected.', 'extrachill-users' ), array( 'status' => 409 ) );
+		}
+		$rejected             = $current;
+		$rejected['status']   = 'rejected';
+		$rejected['decision'] = array(
+			'decided_at' => time(),
+			'actor_id'   => absint( $actor_id ),
+			'note'       => $reason,
+		);
+		if ( ! ec_users_write_artist_dispatch_state( $user_id, $rejected, $current ) ) {
+			return new WP_Error( 'artist_dispatch_state_write_failed', __( 'The Artist Dispatch rejection could not be saved.', 'extrachill-users' ) );
+		}
+		return ec_users_finalize_artist_dispatch_transition( $user_id, 'rejected', $actor_id, $rejected );
+	} finally {
+		ec_users_release_artist_dispatch_lock( $user_id, $lock );
 	}
-	if ( 'pending' !== ( $state['status'] ?? '' ) ) {
-		return new WP_Error( 'artist_dispatch_not_pending', __( 'Only pending requests can be rejected.', 'extrachill-users' ), array( 'status' => 409 ) );
-	}
-
-	$state['status']   = 'rejected';
-	$state['decision'] = array(
-		'decided_at' => time(),
-		'actor_id'   => absint( $actor_id ),
-		'note'       => $reason,
-	);
-	update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_STATE_META, $state );
-	ec_users_add_artist_dispatch_audit_event( $user_id, 'rejected', $request_id, $actor_id );
-	ec_users_maybe_notify_artist_dispatch_transition( $user_id, 'rejected', $actor_id );
-
-	return ec_users_get_artist_dispatch_state( $user_id );
 }
 
 /**
@@ -649,34 +933,47 @@ function ec_users_revoke_artist_dispatch_access( $user_id, $request_id, $reason,
 	$user_id    = absint( $user_id );
 	$request_id = sanitize_text_field( $request_id );
 	$reason     = sanitize_textarea_field( $reason );
-	$state      = ec_users_get_artist_dispatch_state( $user_id );
 	if ( '' === $reason ) {
 		return new WP_Error( 'artist_dispatch_reason_required', __( 'A revocation reason is required.', 'extrachill-users' ), array( 'status' => 400 ) );
 	}
-	if ( ( $state['request_id'] ?? '' ) !== $request_id ) {
-		return new WP_Error( 'artist_dispatch_request_mismatch', __( 'The request ID does not match current state.', 'extrachill-users' ), array( 'status' => 409 ) );
+	$lock = ec_users_acquire_artist_dispatch_lock( $user_id, $request_id );
+	if ( is_wp_error( $lock ) ) {
+		return $lock;
 	}
-	if ( 'revoked' === ( $state['status'] ?? '' ) ) {
-		return $state;
+	try {
+		$current = ec_users_get_artist_dispatch_state( $user_id );
+		if ( ( $current['request_id'] ?? '' ) !== $request_id ) {
+			return new WP_Error( 'artist_dispatch_request_mismatch', __( 'The request ID does not match current state.', 'extrachill-users' ), array( 'status' => 409 ) );
+		}
+		if ( 'revoked' === ( $current['status'] ?? '' ) ) {
+			return ec_users_finalize_artist_dispatch_transition( $user_id, 'revoked', $actor_id, $current );
+		}
+		if ( 'approved' !== ( $current['status'] ?? '' ) ) {
+			return new WP_Error( 'artist_dispatch_not_approved', __( 'Only approved access can be revoked.', 'extrachill-users' ), array( 'status' => 409 ) );
+		}
+		$membership_preexisted = ! empty( $current['grant']['membership_preexisted'] );
+		$cleanup               = ec_users_revoke_artist_dispatch_role( $user_id, $membership_preexisted );
+		if ( is_wp_error( $cleanup ) ) {
+			return $cleanup;
+		}
+		$revoked               = $current;
+		$revoked['status']     = 'revoked';
+		$revoked['revocation'] = array(
+			'revoked_at' => time(),
+			'actor_id'   => absint( $actor_id ),
+			'reason'     => $reason,
+			'cleanup'    => $cleanup,
+		);
+		if ( ! ec_users_write_artist_dispatch_state( $user_id, $revoked, $current ) ) {
+			$restored = ec_users_grant_artist_dispatch_role( $user_id );
+			return is_wp_error( $restored )
+				? new WP_Error( 'artist_dispatch_rollback_failed', __( 'The revocation state and role could not be restored consistently.', 'extrachill-users' ) )
+				: new WP_Error( 'artist_dispatch_state_write_failed', __( 'The revocation state could not be saved; the role was restored.', 'extrachill-users' ) );
+		}
+		return ec_users_finalize_artist_dispatch_transition( $user_id, 'revoked', $actor_id, $revoked, $cleanup );
+	} finally {
+		ec_users_release_artist_dispatch_lock( $user_id, $lock );
 	}
-	if ( 'approved' !== ( $state['status'] ?? '' ) ) {
-		return new WP_Error( 'artist_dispatch_not_approved', __( 'Only approved access can be revoked.', 'extrachill-users' ), array( 'status' => 409 ) );
-	}
-
-	$membership_preexisted = ! empty( $state['grant']['membership_preexisted'] );
-	$cleanup               = ec_users_revoke_artist_dispatch_role( $user_id, $membership_preexisted );
-	$state['status']       = 'revoked';
-	$state['revocation']   = array(
-		'revoked_at' => time(),
-		'actor_id'   => absint( $actor_id ),
-		'reason'     => $reason,
-		'cleanup'    => $cleanup,
-	);
-	update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_STATE_META, $state );
-	ec_users_add_artist_dispatch_audit_event( $user_id, 'revoked', $request_id, $actor_id, $cleanup );
-	ec_users_maybe_notify_artist_dispatch_transition( $user_id, 'revoked', $actor_id );
-
-	return ec_users_get_artist_dispatch_state( $user_id );
 }
 
 /**
@@ -685,17 +982,17 @@ function ec_users_revoke_artist_dispatch_access( $user_id, $request_id, $reason,
  * @param int    $user_id  User ID.
  * @param int    $actor_id Moderation actor.
  * @param string $reason   Moderation reason.
- * @return void
+ * @return array|WP_Error
  */
 function ec_users_revoke_artist_dispatch_for_moderation( $user_id, $actor_id, $reason ) {
 	$state = ec_users_get_artist_dispatch_state( $user_id );
 	if ( 'approved' !== ( $state['status'] ?? '' ) ) {
-		return;
+		return $state;
 	}
 	/* translators: %s: moderation reason. */
 	$revocation_reason = sprintf( __( 'Revoked by account moderation: %s', 'extrachill-users' ), sanitize_text_field( $reason ) );
 
-	ec_users_revoke_artist_dispatch_access(
+	return ec_users_revoke_artist_dispatch_access(
 		$user_id,
 		(string) $state['request_id'],
 		$revocation_reason,

--- a/inc/artist-dispatch.php
+++ b/inc/artist-dispatch.php
@@ -1,0 +1,704 @@
+<?php
+/**
+ * Artist Dispatch eligibility and audited access lifecycle.
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+const EC_USERS_ARTIST_DISPATCH_POLICY_OPTION = 'extrachill_users_artist_dispatch_policy';
+const EC_USERS_ARTIST_DISPATCH_STATE_META    = 'extrachill_artist_dispatch_access';
+const EC_USERS_ARTIST_DISPATCH_AUDIT_META    = 'extrachill_artist_dispatch_access_event';
+const EC_USERS_ARTIST_DISPATCH_TERMS_VERSION = '2026-07-18';
+
+/**
+ * Return the disabled-by-default network policy.
+ *
+ * @return array<string,mixed>
+ */
+function ec_users_get_artist_dispatch_policy() {
+	$defaults = array(
+		'minimum_points'            => null,
+		'minimum_account_age_days'  => 0,
+		'require_onboarding'        => true,
+		'require_claimed_artist'    => true,
+		'require_active_moderation' => true,
+		'pilot_enabled'             => false,
+	);
+	$stored   = get_site_option( EC_USERS_ARTIST_DISPATCH_POLICY_OPTION, array() );
+	$policy   = wp_parse_args( is_array( $stored ) ? $stored : array(), $defaults );
+
+	$policy['minimum_points']            = null === $policy['minimum_points'] || '' === $policy['minimum_points']
+		? null
+		: max( 0, (float) $policy['minimum_points'] );
+	$policy['minimum_account_age_days']  = max( 0, (int) $policy['minimum_account_age_days'] );
+	$policy['require_onboarding']        = (bool) $policy['require_onboarding'];
+	$policy['require_claimed_artist']    = (bool) $policy['require_claimed_artist'];
+	$policy['require_active_moderation'] = (bool) $policy['require_active_moderation'];
+	$policy['pilot_enabled']             = (bool) $policy['pilot_enabled'];
+
+	return $policy;
+}
+
+/**
+ * Store operator-owned policy values.
+ *
+ * @param array<string,mixed> $input Policy values.
+ * @return array<string,mixed>
+ */
+function ec_users_update_artist_dispatch_policy( array $input ) {
+	$policy = ec_users_get_artist_dispatch_policy();
+
+	if ( array_key_exists( 'minimum_points', $input ) ) {
+		$policy['minimum_points'] = '' === $input['minimum_points'] || null === $input['minimum_points']
+			? null
+			: max( 0, (float) $input['minimum_points'] );
+	}
+	if ( array_key_exists( 'minimum_account_age_days', $input ) ) {
+		$policy['minimum_account_age_days'] = max( 0, (int) $input['minimum_account_age_days'] );
+	}
+	foreach ( array( 'require_onboarding', 'require_claimed_artist', 'require_active_moderation', 'pilot_enabled' ) as $field ) {
+		if ( array_key_exists( $field, $input ) ) {
+			$policy[ $field ] = (bool) $input[ $field ];
+		}
+	}
+
+	update_site_option( EC_USERS_ARTIST_DISPATCH_POLICY_OPTION, $policy );
+	return $policy;
+}
+
+/**
+ * Return published artist profiles canonically linked to a user.
+ *
+ * Ec_get_artists_for_user() is the network-safe read side of the Artist
+ * Platform's bidirectional membership primitive. It validates IDs against
+ * published artist_profile posts on the artist site.
+ *
+ * @param int $user_id User ID.
+ * @return int[]
+ */
+function ec_users_get_artist_dispatch_artist_ids( $user_id ) {
+	if ( ! function_exists( 'ec_get_artists_for_user' ) ) {
+		return array();
+	}
+
+	return array_values( array_unique( array_map( 'absint', ec_get_artists_for_user( (int) $user_id, false ) ) ) );
+}
+
+/**
+ * Return a server-resolved artist label for administration displays.
+ *
+ * @param int $artist_id Artist profile ID.
+ * @return string
+ */
+function ec_users_get_artist_dispatch_artist_label( $artist_id ) {
+	$artist_id      = absint( $artist_id );
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : 0;
+	if ( ! $artist_id || ! $artist_blog_id ) {
+		return '';
+	}
+
+	switch_to_blog( $artist_blog_id );
+	try {
+		return 'artist_profile' === get_post_type( $artist_id ) ? (string) get_the_title( $artist_id ) : '';
+	} finally {
+		restore_current_blog();
+	}
+}
+
+/**
+ * Evaluate every request criterion independently.
+ *
+ * @param int $user_id User ID.
+ * @return array<string,mixed>
+ */
+function ec_users_get_artist_dispatch_eligibility( $user_id ) {
+	$user_id = absint( $user_id );
+	$user    = get_userdata( $user_id );
+	$policy  = ec_users_get_artist_dispatch_policy();
+	$reasons = array();
+
+	$points       = $user && function_exists( 'extrachill_get_user_total_points' ) ? (float) extrachill_get_user_total_points( $user_id ) : 0.0;
+	$onboarding   = $user && function_exists( 'ec_is_onboarding_complete' ) ? (bool) ec_is_onboarding_complete( $user_id ) : false;
+	$claimed      = $user && '1' !== (string) get_user_meta( $user_id, 'ec_unclaimed', true );
+	$moderation   = $user && function_exists( 'extrachill_users_get_moderation_status' )
+		? extrachill_users_get_moderation_status( $user_id )
+		: array(
+			'active' => false,
+			'state'  => 'unknown',
+		);
+	$artist_ids   = $user ? ec_users_get_artist_dispatch_artist_ids( $user_id ) : array();
+	$registered   = $user ? strtotime( $user->user_registered . ' UTC' ) : false;
+	$account_days = $registered ? max( 0, (int) floor( ( time() - $registered ) / DAY_IN_SECONDS ) ) : 0;
+
+	$criteria = array(
+		'policy_configured' => array(
+			'passed' => null !== $policy['minimum_points'],
+			'value'  => null !== $policy['minimum_points'],
+		),
+		'pilot_enabled'     => array(
+			'passed' => $policy['pilot_enabled'],
+			'value'  => $policy['pilot_enabled'],
+		),
+		'points'            => array(
+			'passed'  => null !== $policy['minimum_points'] && $points >= $policy['minimum_points'],
+			'value'   => $points,
+			'minimum' => $policy['minimum_points'],
+		),
+		'onboarding'        => array(
+			'passed'   => ! $policy['require_onboarding'] || $onboarding,
+			'value'    => $onboarding,
+			'required' => $policy['require_onboarding'],
+		),
+		'account_age'       => array(
+			'passed'       => $account_days >= $policy['minimum_account_age_days'],
+			'value_days'   => $account_days,
+			'minimum_days' => $policy['minimum_account_age_days'],
+		),
+		'claimed_account'   => array(
+			'passed' => (bool) $claimed,
+			'value'  => (bool) $claimed,
+		),
+		'active_moderation' => array(
+			'passed'   => ! $policy['require_active_moderation'] || ! empty( $moderation['active'] ),
+			'value'    => ! empty( $moderation['active'] ),
+			'required' => $policy['require_active_moderation'],
+			'state'    => isset( $moderation['state'] ) ? (string) $moderation['state'] : 'unknown',
+		),
+		'claimed_artist'    => array(
+			'passed'     => ! $policy['require_claimed_artist'] || ! empty( $artist_ids ),
+			'value'      => ! empty( $artist_ids ),
+			'required'   => $policy['require_claimed_artist'],
+			'artist_ids' => $artist_ids,
+		),
+	);
+
+	$messages = array(
+		'policy_configured' => __( 'The points threshold has not been configured.', 'extrachill-users' ),
+		'pilot_enabled'     => __( 'The Artist Dispatch pilot is disabled.', 'extrachill-users' ),
+		'points'            => __( 'The minimum points threshold has not been met.', 'extrachill-users' ),
+		'onboarding'        => __( 'Account onboarding is incomplete.', 'extrachill-users' ),
+		'account_age'       => __( 'The account is too new for this pilot.', 'extrachill-users' ),
+		'claimed_account'   => __( 'The account must be claimed before requesting access.', 'extrachill-users' ),
+		'active_moderation' => __( 'Active moderation prevents Artist Dispatch access.', 'extrachill-users' ),
+		'claimed_artist'    => __( 'A managed or claimed artist profile is required.', 'extrachill-users' ),
+	);
+	if ( ! $user ) {
+		$reasons[] = __( 'A valid account is required.', 'extrachill-users' );
+	}
+	foreach ( $criteria as $key => $criterion ) {
+		if ( empty( $criterion['passed'] ) ) {
+			$reasons[] = $messages[ $key ];
+		}
+	}
+
+	return array(
+		'eligible' => $user && empty( $reasons ),
+		'criteria' => $criteria,
+		'reasons'  => array_values( array_unique( $reasons ) ),
+		'policy'   => $policy,
+	);
+}
+
+/**
+ * Read the current network user-meta state.
+ *
+ * @param int $user_id User ID.
+ * @return array<string,mixed>
+ */
+function ec_users_get_artist_dispatch_state( $user_id ) {
+	$state = get_user_meta( absint( $user_id ), EC_USERS_ARTIST_DISPATCH_STATE_META, true );
+	return is_array( $state ) ? $state : array();
+}
+
+/**
+ * Return a self-safe view without application copy or decision notes.
+ *
+ * @param int $user_id User ID.
+ * @return array<string,mixed>
+ */
+function ec_users_get_artist_dispatch_safe_state( $user_id ) {
+	$state = ec_users_get_artist_dispatch_state( $user_id );
+	$safe  = array(
+		'status'             => isset( $state['status'] ) ? (string) $state['status'] : 'none',
+		'request_id'         => isset( $state['request_id'] ) ? (string) $state['request_id'] : '',
+		'requested_at'       => isset( $state['requested_at'] ) ? (int) $state['requested_at'] : 0,
+		'artist_id'          => isset( $state['artist_id'] ) ? (int) $state['artist_id'] : 0,
+		'terms_acknowledged' => ! empty( $state['terms_acknowledged'] ),
+		'terms_version'      => isset( $state['terms_version'] ) ? (string) $state['terms_version'] : '',
+		'decided_at'         => isset( $state['decision']['decided_at'] ) ? (int) $state['decision']['decided_at'] : 0,
+		'revoked_at'         => isset( $state['revocation']['revoked_at'] ) ? (int) $state['revocation']['revoked_at'] : 0,
+		'eligibility'        => ec_users_get_artist_dispatch_eligibility( $user_id ),
+	);
+	if ( $safe['artist_id'] ) {
+		$safe['artist_label'] = ec_users_get_artist_dispatch_artist_label( $safe['artist_id'] );
+	}
+
+	return $safe;
+}
+
+/**
+ * Return the bounded, non-PII analytics payload for a successful request.
+ *
+ * @param int    $user_id       Subject user ID.
+ * @param int    $artist_id     Canonical represented artist ID.
+ * @param string $terms_version Accepted terms version.
+ * @return array<string,mixed>
+ */
+function ec_users_get_artist_dispatch_requested_event_payload( $user_id, $artist_id, $terms_version ) {
+	return array(
+		'user_id'       => absint( $user_id ),
+		'artist_id'     => absint( $artist_id ),
+		'terms_version' => sanitize_text_field( $terms_version ),
+		'surface'       => 'artist_dispatch',
+	);
+}
+
+/**
+ * Emit the successful request transition through the canonical analytics event.
+ *
+ * @param int    $user_id       Subject user ID.
+ * @param int    $artist_id     Canonical represented artist ID.
+ * @param string $terms_version Accepted terms version.
+ */
+function ec_users_emit_artist_dispatch_requested_event( $user_id, $artist_id, $terms_version ) {
+	if ( ! defined( 'EC_ANALYTICS_EVENT_ARTIST_DISPATCH_ACCESS_REQUESTED' ) || ! function_exists( 'ec_users_emit_team_experience_event' ) ) {
+		return;
+	}
+
+	$payload = ec_users_get_artist_dispatch_requested_event_payload( $user_id, $artist_id, $terms_version );
+	unset( $payload['user_id'] );
+	ec_users_emit_team_experience_event( EC_ANALYTICS_EVENT_ARTIST_DISPATCH_ACCESS_REQUESTED, $user_id, $payload );
+}
+
+/**
+ * Append an event once for a request UUID and transition.
+ *
+ * @param int    $user_id    User ID.
+ * @param string $event_type Event type.
+ * @param string $request_id Request UUID.
+ * @param int    $actor_id   Actor user ID.
+ * @param array  $details    Non-sensitive event details.
+ * @return bool
+ */
+function ec_users_add_artist_dispatch_audit_event( $user_id, $event_type, $request_id, $actor_id, array $details = array() ) {
+	foreach ( get_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_AUDIT_META, false ) as $event ) {
+		if ( is_array( $event ) && ( $event['event'] ?? '' ) === $event_type && ( $event['request_id'] ?? '' ) === $request_id ) {
+			return false;
+		}
+	}
+
+	return false !== add_user_meta(
+		$user_id,
+		EC_USERS_ARTIST_DISPATCH_AUDIT_META,
+		array(
+			'schema_version' => 1,
+			'event'          => sanitize_key( $event_type ),
+			'request_id'     => sanitize_text_field( $request_id ),
+			'occurred_at'    => time(),
+			'actor_id'       => absint( $actor_id ),
+			'details'        => $details,
+		),
+		false
+	);
+}
+
+/**
+ * Send one transition notification, marking it before delivery for retry safety.
+ *
+ * @param int    $user_id    Recipient.
+ * @param string $event_type Transition.
+ * @param int    $actor_id   Actor.
+ * @return void
+ */
+function ec_users_maybe_notify_artist_dispatch_transition( $user_id, $event_type, $actor_id ) {
+	$state = ec_users_get_artist_dispatch_state( $user_id );
+	if ( ! empty( $state['notifications'][ $event_type ] ) ) {
+		return;
+	}
+
+	$state['notifications'][ $event_type ] = time();
+	update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_STATE_META, $state );
+	if ( ! function_exists( 'ec_users_notify' ) ) {
+		return;
+	}
+
+	$titles = array(
+		'approved' => __( 'Your Artist Dispatch access was approved.', 'extrachill-users' ),
+		'rejected' => __( 'Your Artist Dispatch access request was not approved.', 'extrachill-users' ),
+		'revoked'  => __( 'Your Artist Dispatch access was revoked.', 'extrachill-users' ),
+	);
+	if ( ! isset( $titles[ $event_type ] ) ) {
+		return;
+	}
+
+	$blog_id = ec_users_get_artist_dispatch_blog_id();
+	switch_to_blog( $blog_id );
+	try {
+		$link = home_url( '/submit/' );
+	} finally {
+		restore_current_blog();
+	}
+
+	ec_users_notify(
+		$user_id,
+		array(
+			'actor_id' => absint( $actor_id ),
+			'type'     => 'artist_dispatch_' . $event_type,
+			'link'     => $link,
+			'title'    => $titles[ $event_type ],
+			'item_id'  => isset( $state['artist_id'] ) ? absint( $state['artist_id'] ) : 0,
+		)
+	);
+}
+
+/**
+ * Add the bounded role on the main site without replacing existing roles.
+ *
+ * @param int $user_id User ID.
+ * @return array|WP_Error Grant details.
+ */
+function ec_users_grant_artist_dispatch_role( $user_id ) {
+	$user_id = absint( $user_id );
+	$blog_id = ec_users_get_artist_dispatch_blog_id();
+	if ( ! $user_id || ! get_userdata( $user_id ) || ! $blog_id ) {
+		return new WP_Error( 'invalid_artist_dispatch_user', __( 'A valid user and main site are required.', 'extrachill-users' ) );
+	}
+
+	$membership_preexisted = is_user_member_of_blog( $user_id, $blog_id );
+	ec_users_register_artist_dispatch_role_on_main();
+	if ( ! $membership_preexisted ) {
+		$result = add_user_to_blog( $blog_id, $user_id, EC_USERS_ARTIST_DISPATCH_ROLE );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+	}
+
+	switch_to_blog( $blog_id );
+	try {
+		ec_users_register_artist_dispatch_role();
+		$user = new WP_User( $user_id );
+		if ( ! in_array( EC_USERS_ARTIST_DISPATCH_ROLE, (array) $user->roles, true ) ) {
+			$user->add_role( EC_USERS_ARTIST_DISPATCH_ROLE );
+		}
+		$granted = in_array( EC_USERS_ARTIST_DISPATCH_ROLE, (array) ( new WP_User( $user_id ) )->roles, true );
+	} finally {
+		restore_current_blog();
+	}
+
+	if ( ! $granted ) {
+		return new WP_Error( 'artist_dispatch_grant_failed', __( 'The Artist Dispatch role could not be granted.', 'extrachill-users' ) );
+	}
+
+	return array(
+		'blog_id'               => $blog_id,
+		'role'                  => EC_USERS_ARTIST_DISPATCH_ROLE,
+		'membership_preexisted' => $membership_preexisted,
+	);
+}
+
+/**
+ * Remove only the product role and clean up grant-created empty membership.
+ *
+ * @param int  $user_id               User ID.
+ * @param bool $membership_preexisted Whether membership existed before approval.
+ * @return array<string,mixed>
+ */
+function ec_users_revoke_artist_dispatch_role( $user_id, $membership_preexisted ) {
+	$user_id = absint( $user_id );
+	$blog_id = ec_users_get_artist_dispatch_blog_id();
+	$removed = false;
+	$cleaned = false;
+
+	if ( ! $user_id || ! $blog_id || ! is_user_member_of_blog( $user_id, $blog_id ) ) {
+		return array(
+			'role_removed'       => false,
+			'membership_removed' => false,
+		);
+	}
+
+	switch_to_blog( $blog_id );
+	try {
+		$user = new WP_User( $user_id );
+		if ( in_array( EC_USERS_ARTIST_DISPATCH_ROLE, (array) $user->roles, true ) ) {
+			$user->remove_role( EC_USERS_ARTIST_DISPATCH_ROLE );
+			$removed = true;
+		}
+		$user             = new WP_User( $user_id );
+		$remaining_access = ! empty( $user->roles ) || ! empty( array_filter( (array) $user->caps ) );
+	} finally {
+		restore_current_blog();
+	}
+
+	if ( ! $membership_preexisted && ! $remaining_access && is_user_member_of_blog( $user_id, $blog_id ) ) {
+		$cleaned = true === remove_user_from_blog( $user_id, $blog_id );
+	}
+
+	return array(
+		'role_removed'       => $removed,
+		'membership_removed' => $cleaned,
+	);
+}
+
+/**
+ * Create or return a pending self-service request.
+ *
+ * @param int   $user_id User ID.
+ * @param array $input   Application fields.
+ * @return array|WP_Error
+ */
+function ec_users_request_artist_dispatch_access( $user_id, array $input ) {
+	$user_id       = absint( $user_id );
+	$state         = ec_users_get_artist_dispatch_state( $user_id );
+	$terms_version = isset( $input['terms_version'] ) ? sanitize_text_field( (string) $input['terms_version'] ) : '';
+	if ( true !== ( $input['acknowledgement'] ?? false ) ) {
+		return new WP_Error( 'artist_dispatch_acknowledgement_required', __( 'You must acknowledge the Artist Dispatch terms and your affiliation disclosure.', 'extrachill-users' ), array( 'status' => 400 ) );
+	}
+	if ( EC_USERS_ARTIST_DISPATCH_TERMS_VERSION !== $terms_version ) {
+		return new WP_Error( 'invalid_artist_dispatch_terms_version', __( 'The Artist Dispatch terms version is missing or no longer current.', 'extrachill-users' ), array( 'status' => 400 ) );
+	}
+	if ( 'pending' === ( $state['status'] ?? '' ) ) {
+		if ( empty( $state['terms_acknowledged'] ) || ( $state['terms_version'] ?? '' ) !== $terms_version ) {
+			return new WP_Error( 'artist_dispatch_terms_mismatch', __( 'The pending request is bound to a different terms acceptance.', 'extrachill-users' ), array( 'status' => 409 ) );
+		}
+		return $state;
+	}
+	if ( 'approved' === ( $state['status'] ?? '' ) ) {
+		return new WP_Error( 'artist_dispatch_already_approved', __( 'Artist Dispatch access is already approved.', 'extrachill-users' ), array( 'status' => 409 ) );
+	}
+
+	$eligibility = ec_users_get_artist_dispatch_eligibility( $user_id );
+	if ( empty( $eligibility['eligible'] ) ) {
+		return new WP_Error(
+			'artist_dispatch_ineligible',
+			implode( ' ', $eligibility['reasons'] ),
+			array(
+				'status'      => 403,
+				'eligibility' => $eligibility,
+			)
+		);
+	}
+
+	$artist_id = isset( $input['artist_id'] ) ? absint( $input['artist_id'] ) : 0;
+	if ( ! $artist_id || ! in_array( $artist_id, $eligibility['criteria']['claimed_artist']['artist_ids'], true ) ) {
+		return new WP_Error( 'invalid_artist_dispatch_artist', __( 'Select an artist profile you canonically manage or claim.', 'extrachill-users' ), array( 'status' => 403 ) );
+	}
+
+	$description = isset( $input['description'] ) ? sanitize_textarea_field( (string) $input['description'] ) : '';
+	$length      = function_exists( 'mb_strlen' ) ? mb_strlen( $description ) : strlen( $description );
+	if ( $length < 50 || $length > 2000 ) {
+		return new WP_Error( 'invalid_artist_dispatch_description', __( 'The proposed Dispatch description must be between 50 and 2,000 characters.', 'extrachill-users' ), array( 'status' => 400 ) );
+	}
+
+	$sample_url = isset( $input['sample_url'] ) ? esc_url_raw( (string) $input['sample_url'] ) : '';
+	if ( '' !== $sample_url && ! wp_http_validate_url( $sample_url ) ) {
+		return new WP_Error( 'invalid_artist_dispatch_sample_url', __( 'The sample URL must be a valid HTTP or HTTPS URL.', 'extrachill-users' ), array( 'status' => 400 ) );
+	}
+
+	$state = array(
+		'schema_version'       => 1,
+		'status'               => 'pending',
+		'request_id'           => wp_generate_uuid4(),
+		'requested_at'         => time(),
+		'artist_id'            => $artist_id,
+		'terms_acknowledged'   => true,
+		'terms_version'        => $terms_version,
+		'terms_accepted_at'    => time(),
+		'description'          => $description,
+		'sample_url'           => $sample_url,
+		'eligibility_snapshot' => $eligibility,
+	);
+	update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_STATE_META, $state );
+	ec_users_add_artist_dispatch_audit_event(
+		$user_id,
+		'requested',
+		$state['request_id'],
+		$user_id,
+		array(
+			'artist_id'     => $artist_id,
+			'terms_version' => $terms_version,
+		)
+	);
+	ec_users_emit_artist_dispatch_requested_event( $user_id, $artist_id, $terms_version );
+
+	return $state;
+}
+
+/**
+ * Approve a matching pending request or repair its missing role on retry.
+ *
+ * @param int    $user_id    User ID.
+ * @param string $request_id Request UUID.
+ * @param string $note       Internal note.
+ * @param int    $actor_id   Decision actor.
+ * @return array|WP_Error
+ */
+function ec_users_approve_artist_dispatch_access( $user_id, $request_id, $note, $actor_id ) {
+	$user_id    = absint( $user_id );
+	$request_id = sanitize_text_field( $request_id );
+	$state      = ec_users_get_artist_dispatch_state( $user_id );
+	if ( ( $state['request_id'] ?? '' ) !== $request_id ) {
+		return new WP_Error( 'artist_dispatch_request_mismatch', __( 'The request ID does not match current state.', 'extrachill-users' ), array( 'status' => 409 ) );
+	}
+	if ( 'approved' === ( $state['status'] ?? '' ) ) {
+		$repair = ec_users_grant_artist_dispatch_role( $user_id );
+		return is_wp_error( $repair ) ? $repair : $state;
+	}
+	if ( 'pending' !== ( $state['status'] ?? '' ) ) {
+		return new WP_Error( 'artist_dispatch_not_pending', __( 'Only pending requests can be approved.', 'extrachill-users' ), array( 'status' => 409 ) );
+	}
+
+	$eligibility = ec_users_get_artist_dispatch_eligibility( $user_id );
+	if ( empty( $eligibility['eligible'] ) || ! in_array( (int) $state['artist_id'], $eligibility['criteria']['claimed_artist']['artist_ids'], true ) ) {
+		return new WP_Error(
+			'artist_dispatch_no_longer_eligible',
+			__( 'The request no longer satisfies the Artist Dispatch policy.', 'extrachill-users' ),
+			array(
+				'status'      => 403,
+				'eligibility' => $eligibility,
+			)
+		);
+	}
+
+	$grant = ec_users_grant_artist_dispatch_role( $user_id );
+	if ( is_wp_error( $grant ) ) {
+		return $grant;
+	}
+	$now               = time();
+	$state['status']   = 'approved';
+	$state['decision'] = array(
+		'decided_at' => $now,
+		'actor_id'   => absint( $actor_id ),
+		'note'       => sanitize_textarea_field( $note ),
+	);
+	$state['grant']    = array_merge(
+		$grant,
+		array(
+			'granted_at' => $now,
+			'actor_id'   => absint( $actor_id ),
+		)
+	);
+	update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_STATE_META, $state );
+	ec_users_add_artist_dispatch_audit_event(
+		$user_id,
+		'approved',
+		$request_id,
+		$actor_id,
+		array(
+			'artist_id' => (int) $state['artist_id'],
+			'blog_id'   => (int) $grant['blog_id'],
+			'role'      => $grant['role'],
+		)
+	);
+	ec_users_maybe_notify_artist_dispatch_transition( $user_id, 'approved', $actor_id );
+
+	return ec_users_get_artist_dispatch_state( $user_id );
+}
+
+/**
+ * Reject a matching pending request.
+ *
+ * @param int    $user_id    User ID.
+ * @param string $request_id Request UUID.
+ * @param string $reason     Rejection reason.
+ * @param int    $actor_id   Decision actor.
+ * @return array|WP_Error
+ */
+function ec_users_reject_artist_dispatch_access( $user_id, $request_id, $reason, $actor_id ) {
+	$user_id    = absint( $user_id );
+	$request_id = sanitize_text_field( $request_id );
+	$reason     = sanitize_textarea_field( $reason );
+	$state      = ec_users_get_artist_dispatch_state( $user_id );
+	if ( '' === $reason ) {
+		return new WP_Error( 'artist_dispatch_reason_required', __( 'A rejection reason is required.', 'extrachill-users' ), array( 'status' => 400 ) );
+	}
+	if ( ( $state['request_id'] ?? '' ) !== $request_id ) {
+		return new WP_Error( 'artist_dispatch_request_mismatch', __( 'The request ID does not match current state.', 'extrachill-users' ), array( 'status' => 409 ) );
+	}
+	if ( 'rejected' === ( $state['status'] ?? '' ) ) {
+		return $state;
+	}
+	if ( 'pending' !== ( $state['status'] ?? '' ) ) {
+		return new WP_Error( 'artist_dispatch_not_pending', __( 'Only pending requests can be rejected.', 'extrachill-users' ), array( 'status' => 409 ) );
+	}
+
+	$state['status']   = 'rejected';
+	$state['decision'] = array(
+		'decided_at' => time(),
+		'actor_id'   => absint( $actor_id ),
+		'note'       => $reason,
+	);
+	update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_STATE_META, $state );
+	ec_users_add_artist_dispatch_audit_event( $user_id, 'rejected', $request_id, $actor_id );
+	ec_users_maybe_notify_artist_dispatch_transition( $user_id, 'rejected', $actor_id );
+
+	return ec_users_get_artist_dispatch_state( $user_id );
+}
+
+/**
+ * Revoke an approved grant without touching posts or unrelated roles.
+ *
+ * @param int    $user_id    User ID.
+ * @param string $request_id Request UUID.
+ * @param string $reason     Revocation reason.
+ * @param int    $actor_id   Decision actor.
+ * @return array|WP_Error
+ */
+function ec_users_revoke_artist_dispatch_access( $user_id, $request_id, $reason, $actor_id ) {
+	$user_id    = absint( $user_id );
+	$request_id = sanitize_text_field( $request_id );
+	$reason     = sanitize_textarea_field( $reason );
+	$state      = ec_users_get_artist_dispatch_state( $user_id );
+	if ( '' === $reason ) {
+		return new WP_Error( 'artist_dispatch_reason_required', __( 'A revocation reason is required.', 'extrachill-users' ), array( 'status' => 400 ) );
+	}
+	if ( ( $state['request_id'] ?? '' ) !== $request_id ) {
+		return new WP_Error( 'artist_dispatch_request_mismatch', __( 'The request ID does not match current state.', 'extrachill-users' ), array( 'status' => 409 ) );
+	}
+	if ( 'revoked' === ( $state['status'] ?? '' ) ) {
+		return $state;
+	}
+	if ( 'approved' !== ( $state['status'] ?? '' ) ) {
+		return new WP_Error( 'artist_dispatch_not_approved', __( 'Only approved access can be revoked.', 'extrachill-users' ), array( 'status' => 409 ) );
+	}
+
+	$membership_preexisted = ! empty( $state['grant']['membership_preexisted'] );
+	$cleanup               = ec_users_revoke_artist_dispatch_role( $user_id, $membership_preexisted );
+	$state['status']       = 'revoked';
+	$state['revocation']   = array(
+		'revoked_at' => time(),
+		'actor_id'   => absint( $actor_id ),
+		'reason'     => $reason,
+		'cleanup'    => $cleanup,
+	);
+	update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_STATE_META, $state );
+	ec_users_add_artist_dispatch_audit_event( $user_id, 'revoked', $request_id, $actor_id, $cleanup );
+	ec_users_maybe_notify_artist_dispatch_transition( $user_id, 'revoked', $actor_id );
+
+	return ec_users_get_artist_dispatch_state( $user_id );
+}
+
+/**
+ * Moderation integration: revoke now, never restore when moderation clears.
+ *
+ * @param int    $user_id  User ID.
+ * @param int    $actor_id Moderation actor.
+ * @param string $reason   Moderation reason.
+ * @return void
+ */
+function ec_users_revoke_artist_dispatch_for_moderation( $user_id, $actor_id, $reason ) {
+	$state = ec_users_get_artist_dispatch_state( $user_id );
+	if ( 'approved' !== ( $state['status'] ?? '' ) ) {
+		return;
+	}
+	/* translators: %s: moderation reason. */
+	$revocation_reason = sprintf( __( 'Revoked by account moderation: %s', 'extrachill-users' ), sanitize_text_field( $reason ) );
+
+	ec_users_revoke_artist_dispatch_access(
+		$user_id,
+		(string) $state['request_id'],
+		$revocation_reason,
+		$actor_id
+	);
+}

--- a/inc/artist-dispatch.php
+++ b/inc/artist-dispatch.php
@@ -238,6 +238,8 @@ function ec_users_write_artist_dispatch_state( $user_id, array $next, array $cur
  */
 function ec_users_acquire_artist_dispatch_lock( $user_id, $request_id ) {
 	$user_id = absint( $user_id );
+	$key     = EC_USERS_ARTIST_DISPATCH_LOCK_META . '_' . $user_id;
+	$blog_id                      = ec_users_get_artist_dispatch_blog_id();
 	for ( $attempt = 0; 5 > $attempt; ++$attempt ) {
 		$now  = time();
 		$lock = array(
@@ -245,13 +247,18 @@ function ec_users_acquire_artist_dispatch_lock( $user_id, $request_id ) {
 			'request_id'  => sanitize_text_field( $request_id ),
 			'expires_at'  => $now + EC_USERS_ARTIST_DISPATCH_LOCK_TTL,
 		);
-		if ( false !== add_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_LOCK_META, $lock, true ) ) {
+		switch_to_blog( $blog_id );
+		$acquired = ec_users_add_artist_dispatch_option_once( $key, $lock );
+		restore_current_blog();
+		if ( $acquired ) {
 			return $lock;
 		}
 
-		$current = get_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_LOCK_META, true );
-		if ( is_array( $current ) && $now >= (int) ( $current['expires_at'] ?? 0 ) && false !== update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_LOCK_META, $lock, $current ) ) {
-			return $lock;
+		switch_to_blog( $blog_id );
+		$current = get_option( $key, array() );
+		restore_current_blog();
+		if ( is_array( $current ) && $now >= (int) ( $current['expires_at'] ?? 0 ) ) {
+			return new WP_Error( 'artist_dispatch_lock_reconciliation_required', __( 'A prior Artist Dispatch update exceeded its lock window and requires reconciliation.', 'extrachill-users' ), array( 'status' => 409 ) );
 		}
 		usleep( 50000 );
 	}
@@ -267,7 +274,63 @@ function ec_users_acquire_artist_dispatch_lock( $user_id, $request_id ) {
  * @return bool
  */
 function ec_users_release_artist_dispatch_lock( $user_id, array $lock ) {
-	return delete_user_meta( absint( $user_id ), EC_USERS_ARTIST_DISPATCH_LOCK_META, $lock );
+	$blog_id = ec_users_get_artist_dispatch_blog_id();
+	$key     = EC_USERS_ARTIST_DISPATCH_LOCK_META . '_' . absint( $user_id );
+	switch_to_blog( $blog_id );
+	try {
+		return ec_users_delete_artist_dispatch_option_if_value( $key, $lock );
+	} finally {
+		restore_current_blog();
+	}
+}
+
+/**
+ * Atomically delete an option only when its serialized value still matches.
+ *
+ * @param string $key      Option name.
+ * @param array  $expected Expected current value.
+ * @return bool
+ */
+function ec_users_delete_artist_dispatch_option_if_value( $key, array $expected ) {
+	global $wpdb;
+
+	$deleted = $wpdb->query(
+		$wpdb->prepare(
+			"DELETE FROM {$wpdb->options} WHERE option_name = %s AND option_value = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Core-owned options table name.
+			$key,
+			maybe_serialize( $expected )
+		)
+	);
+	if ( $deleted ) {
+		wp_cache_delete( $key, 'options' );
+		wp_cache_delete( 'alloptions', 'options' );
+	}
+	return 1 === $deleted;
+}
+
+/**
+ * Atomically reserve a unique option key without core's overwrite-on-conflict upsert.
+ *
+ * @param string $key   Option name.
+ * @param array  $value Option value.
+ * @return bool
+ */
+function ec_users_add_artist_dispatch_option_once( $key, array $value ) {
+	global $wpdb;
+
+	$inserted = $wpdb->query(
+		$wpdb->prepare(
+			"INSERT IGNORE INTO {$wpdb->options} (option_name, option_value, autoload) VALUES (%s, %s, 'off')", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Core-owned options table name; the unique option key is the lock primitive.
+			$key,
+			maybe_serialize( $value )
+		)
+	);
+	if ( 1 === $inserted ) {
+		wp_cache_delete( $key, 'options' );
+		wp_cache_delete( 'notoptions', 'options' );
+		return true;
+	}
+	return false;
 }
 
 /**
@@ -359,12 +422,39 @@ function ec_users_get_artist_dispatch_analytics_event( $event_type ) {
  * @return bool
  */
 function ec_users_has_artist_dispatch_delivery_receipt( $user_id, $channel, $event_type, $request_id ) {
-	foreach ( get_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_DELIVERY_META, false ) as $receipt ) {
-		if ( is_array( $receipt ) && ( $receipt['channel'] ?? '' ) === $channel && ( $receipt['event'] ?? '' ) === $event_type && ( $receipt['request_id'] ?? '' ) === $request_id ) {
-			return true;
-		}
+	return ! empty( ec_users_get_artist_dispatch_delivery_receipt( $user_id, $channel, $event_type, $request_id ) );
+}
+
+/**
+ * Build the unique user-meta key for one external delivery.
+ *
+ * @param string $channel    Delivery channel.
+ * @param string $event_type Lifecycle transition.
+ * @param string $request_id Request UUID.
+ * @return string
+ */
+function ec_users_get_artist_dispatch_delivery_meta_key( $user_id, $channel, $event_type, $request_id ) {
+	return EC_USERS_ARTIST_DISPATCH_DELIVERY_META . '_' . md5( absint( $user_id ) . '|' . sanitize_key( $channel ) . '|' . sanitize_key( $event_type ) . '|' . sanitize_text_field( $request_id ) );
+}
+
+/**
+ * Get a durable external-delivery receipt.
+ *
+ * @param int    $user_id    User ID.
+ * @param string $channel    Delivery channel.
+ * @param string $event_type Lifecycle transition.
+ * @param string $request_id Request UUID.
+ * @return array
+ */
+function ec_users_get_artist_dispatch_delivery_receipt( $user_id, $channel, $event_type, $request_id ) {
+	$blog_id = ec_users_get_artist_dispatch_blog_id();
+	switch_to_blog( $blog_id );
+	try {
+		$receipt = get_option( ec_users_get_artist_dispatch_delivery_meta_key( $user_id, $channel, $event_type, $request_id ), array() );
+	} finally {
+		restore_current_blog();
 	}
-	return false;
+	return is_array( $receipt ) ? $receipt : array();
 }
 
 /**
@@ -377,20 +467,74 @@ function ec_users_has_artist_dispatch_delivery_receipt( $user_id, $channel, $eve
  * @return bool
  */
 function ec_users_add_artist_dispatch_delivery_receipt( $user_id, $channel, $event_type, $request_id ) {
-	if ( ec_users_has_artist_dispatch_delivery_receipt( $user_id, $channel, $event_type, $request_id ) ) {
+	$blog_id = ec_users_get_artist_dispatch_blog_id();
+	switch_to_blog( $blog_id );
+	try {
+		return ec_users_add_artist_dispatch_option_once(
+			ec_users_get_artist_dispatch_delivery_meta_key( $user_id, $channel, $event_type, $request_id ),
+			array(
+				'channel'     => sanitize_key( $channel ),
+				'event'       => sanitize_key( $event_type ),
+				'request_id'  => sanitize_text_field( $request_id ),
+				'status'      => 'reserved',
+				'reserved_at' => time(),
+			)
+		);
+	} finally {
+		restore_current_blog();
+	}
+}
+
+/**
+ * Mark a reserved receipt delivered after the external side effect succeeds.
+ *
+ * @param int    $user_id    User ID.
+ * @param string $channel    Delivery channel.
+ * @param string $event_type Lifecycle transition.
+ * @param string $request_id Request UUID.
+ * @return bool
+ */
+function ec_users_mark_artist_dispatch_delivery_receipt( $user_id, $channel, $event_type, $request_id ) {
+	$receipt = ec_users_get_artist_dispatch_delivery_receipt( $user_id, $channel, $event_type, $request_id );
+	if ( empty( $receipt ) ) {
+		return false;
+	}
+	if ( 'delivered' === ( $receipt['status'] ?? '' ) ) {
 		return true;
 	}
-	return false !== add_user_meta(
-		$user_id,
-		EC_USERS_ARTIST_DISPATCH_DELIVERY_META,
-		array(
-			'channel'      => sanitize_key( $channel ),
-			'event'        => sanitize_key( $event_type ),
-			'request_id'   => sanitize_text_field( $request_id ),
-			'delivered_at' => time(),
-		),
-		false
-	);
+	$delivered                 = $receipt;
+	$delivered['status']       = 'delivered';
+	$delivered['delivered_at'] = time();
+	$blog_id = ec_users_get_artist_dispatch_blog_id();
+	switch_to_blog( $blog_id );
+	try {
+		return update_option( ec_users_get_artist_dispatch_delivery_meta_key( $user_id, $channel, $event_type, $request_id ), $delivered, false );
+	} finally {
+		restore_current_blog();
+	}
+}
+
+/**
+ * Remove a reserved delivery receipt after an explicit delivery failure.
+ *
+ * @param int    $user_id    User ID.
+ * @param string $channel    Delivery channel.
+ * @param string $event_type Lifecycle transition.
+ * @param string $request_id Request UUID.
+ * @return bool
+ */
+function ec_users_remove_artist_dispatch_delivery_receipt( $user_id, $channel, $event_type, $request_id ) {
+	$receipt = ec_users_get_artist_dispatch_delivery_receipt( $user_id, $channel, $event_type, $request_id );
+	if ( empty( $receipt ) ) {
+		return true;
+	}
+	$blog_id = ec_users_get_artist_dispatch_blog_id();
+	switch_to_blog( $blog_id );
+	try {
+		return ec_users_delete_artist_dispatch_option_if_value( ec_users_get_artist_dispatch_delivery_meta_key( $user_id, $channel, $event_type, $request_id ), $receipt );
+	} finally {
+		restore_current_blog();
+	}
 }
 
 /**
@@ -408,7 +552,11 @@ function ec_users_maybe_emit_artist_dispatch_event( $user_id, $event_type, array
 		return $state;
 	}
 	$request_id = (string) ( $state['request_id'] ?? '' );
-	if ( ec_users_has_artist_dispatch_delivery_receipt( $user_id, 'analytics', $event_type, $request_id ) ) {
+	$receipt    = ec_users_get_artist_dispatch_delivery_receipt( $user_id, 'analytics', $event_type, $request_id );
+	if ( ! empty( $receipt ) && 'delivered' !== ( $receipt['status'] ?? '' ) ) {
+		return new WP_Error( 'artist_dispatch_analytics_reconciliation_required', __( 'The prior analytics delivery outcome is ambiguous and requires reconciliation.', 'extrachill-users' ) );
+	}
+	if ( ! empty( $receipt ) ) {
 		$next = $state;
 		$next['deliveries']['analytics'][ $event_type ] = time();
 		return ec_users_write_artist_dispatch_state( $user_id, $next, $state )
@@ -419,14 +567,20 @@ function ec_users_maybe_emit_artist_dispatch_event( $user_id, $event_type, array
 	if ( ! $event_name || ! function_exists( 'ec_users_emit_team_experience_event' ) ) {
 		return $state;
 	}
+	if ( ! ec_users_add_artist_dispatch_delivery_receipt( $user_id, 'analytics', $event_type, $request_id ) ) {
+		return new WP_Error( 'artist_dispatch_analytics_receipt_failed', __( 'The Artist Dispatch analytics delivery receipt could not be reserved.', 'extrachill-users' ) );
+	}
 
 	$payload = ec_users_get_artist_dispatch_event_payload( $user_id, $request_id );
 	unset( $payload['user_id'] );
 	if ( 0 >= ec_users_emit_team_experience_event( $event_name, $user_id, $payload ) ) {
+		if ( ! ec_users_remove_artist_dispatch_delivery_receipt( $user_id, 'analytics', $event_type, $request_id ) ) {
+			return new WP_Error( 'artist_dispatch_analytics_reconciliation_required', __( 'Analytics delivery failed and its reservation could not be cleared.', 'extrachill-users' ) );
+		}
 		return new WP_Error( 'artist_dispatch_analytics_failed', __( 'The Artist Dispatch analytics event could not be recorded.', 'extrachill-users' ) );
 	}
-	if ( ! ec_users_add_artist_dispatch_delivery_receipt( $user_id, 'analytics', $event_type, $request_id ) ) {
-		return new WP_Error( 'artist_dispatch_analytics_receipt_failed', __( 'The Artist Dispatch analytics delivery receipt could not be saved.', 'extrachill-users' ) );
+	if ( ! ec_users_mark_artist_dispatch_delivery_receipt( $user_id, 'analytics', $event_type, $request_id ) ) {
+		return new WP_Error( 'artist_dispatch_analytics_reconciliation_required', __( 'Analytics delivery succeeded but its durable receipt could not be finalized.', 'extrachill-users' ) );
 	}
 
 	$next = $state;
@@ -509,7 +663,11 @@ function ec_users_maybe_notify_artist_dispatch_transition( $user_id, $event_type
 		return $state;
 	}
 	$request_id = (string) ( $state['request_id'] ?? '' );
-	if ( ec_users_has_artist_dispatch_delivery_receipt( $user_id, 'notification', $event_type, $request_id ) ) {
+	$receipt    = ec_users_get_artist_dispatch_delivery_receipt( $user_id, 'notification', $event_type, $request_id );
+	if ( ! empty( $receipt ) && 'delivered' !== ( $receipt['status'] ?? '' ) ) {
+		return new WP_Error( 'artist_dispatch_notification_reconciliation_required', __( 'The prior notification delivery outcome is ambiguous and requires reconciliation.', 'extrachill-users' ) );
+	}
+	if ( ! empty( $receipt ) ) {
 		$next = $state;
 		$next['deliveries']['notifications'][ $event_type ] = time();
 		return ec_users_write_artist_dispatch_state( $user_id, $next, $state )
@@ -528,6 +686,9 @@ function ec_users_maybe_notify_artist_dispatch_transition( $user_id, $event_type
 	} finally {
 		restore_current_blog();
 	}
+	if ( ! ec_users_add_artist_dispatch_delivery_receipt( $user_id, 'notification', $event_type, $request_id ) ) {
+		return new WP_Error( 'artist_dispatch_notification_receipt_failed', __( 'The Artist Dispatch notification delivery receipt could not be reserved.', 'extrachill-users' ) );
+	}
 
 	$inserted = ec_users_notify(
 		$user_id,
@@ -540,10 +701,13 @@ function ec_users_maybe_notify_artist_dispatch_transition( $user_id, $event_type
 		)
 	);
 	if ( 1 > $inserted ) {
+		if ( ! ec_users_remove_artist_dispatch_delivery_receipt( $user_id, 'notification', $event_type, $request_id ) ) {
+			return new WP_Error( 'artist_dispatch_notification_reconciliation_required', __( 'Notification delivery failed and its reservation could not be cleared.', 'extrachill-users' ) );
+		}
 		return new WP_Error( 'artist_dispatch_notification_failed', __( 'The Artist Dispatch notification could not be delivered.', 'extrachill-users' ) );
 	}
-	if ( ! ec_users_add_artist_dispatch_delivery_receipt( $user_id, 'notification', $event_type, $request_id ) ) {
-		return new WP_Error( 'artist_dispatch_notification_receipt_failed', __( 'The Artist Dispatch notification delivery receipt could not be saved.', 'extrachill-users' ) );
+	if ( ! ec_users_mark_artist_dispatch_delivery_receipt( $user_id, 'notification', $event_type, $request_id ) ) {
+		return new WP_Error( 'artist_dispatch_notification_reconciliation_required', __( 'Notification delivery succeeded but its durable receipt could not be finalized.', 'extrachill-users' ) );
 	}
 
 	$next = $state;
@@ -737,6 +901,9 @@ function ec_users_request_artist_dispatch_access( $user_id, array $input ) {
 				return new WP_Error( 'artist_dispatch_state_write_failed', __( 'The Artist Dispatch terms renewal could not be saved.', 'extrachill-users' ) );
 			}
 			if ( ! ec_users_add_artist_dispatch_audit_event( $user_id, 'terms_renewed', $renewed['request_id'], $user_id, array( 'terms_version' => $terms_version ) ) ) {
+				if ( ! ec_users_write_artist_dispatch_state( $user_id, $current, $renewed ) ) {
+					return new WP_Error( 'artist_dispatch_rollback_failed', __( 'The terms renewal audit and state rollback both failed.', 'extrachill-users' ) );
+				}
 				return new WP_Error( 'artist_dispatch_audit_failed', __( 'The Artist Dispatch terms renewal audit could not be saved.', 'extrachill-users' ) );
 			}
 			return $renewed;
@@ -863,7 +1030,10 @@ function ec_users_approve_artist_dispatch_access( $user_id, $request_id, $note, 
 		);
 		if ( ! ec_users_write_artist_dispatch_state( $user_id, $approved, $current ) ) {
 			if ( empty( $grant['role_preexisted'] ) ) {
-				ec_users_revoke_artist_dispatch_role( $user_id, ! empty( $grant['membership_preexisted'] ) );
+				$rollback = ec_users_revoke_artist_dispatch_role( $user_id, ! empty( $grant['membership_preexisted'] ) );
+				if ( is_wp_error( $rollback ) ) {
+					return new WP_Error( 'artist_dispatch_rollback_failed', __( 'The approval state failed and the granted role could not be rolled back.', 'extrachill-users' ) );
+				}
 			}
 			return new WP_Error( 'artist_dispatch_state_write_failed', __( 'Artist Dispatch approval could not be saved; the role grant was rolled back.', 'extrachill-users' ) );
 		}

--- a/inc/artist-profiles.php
+++ b/inc/artist-profiles.php
@@ -20,8 +20,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Single source of truth for user-artist profile relationships across the network.
  * Handles both frontend (user's own artists) and management contexts (admin override for all artists).
  *
- * @param int|null $user_id       User ID (defaults to current user)
- * @param bool     $admin_override Allow admins to access ALL artists (default: false)
+ * @param int|null $user_id       User ID (defaults to current user).
+ * @param bool     $admin_override Allow admins to access ALL artists (default: false).
  * @return array                   Array of published artist profile IDs
  */
 function ec_get_artists_for_user( $user_id = null, $admin_override = false ) {
@@ -33,7 +33,7 @@ function ec_get_artists_for_user( $user_id = null, $admin_override = false ) {
 		return array();
 	}
 
-	// Admin override: return ALL artists (only for management contexts)
+	// Admin override: return ALL artists (only for management contexts).
 	if ( $admin_override && user_can( $user_id, 'manage_options' ) ) {
 		$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
 		if ( ! $artist_blog_id ) {
@@ -57,7 +57,7 @@ function ec_get_artists_for_user( $user_id = null, $admin_override = false ) {
 		}
 	}
 
-	// Default: return user's owned artists (for both regular users and admins in frontend contexts)
+	// Default: return user's owned artists (for regular users and frontend admins).
 	$user_artist_ids = get_user_meta( $user_id, '_artist_profile_ids', true );
 	if ( ! is_array( $user_artist_ids ) ) {
 		return array();
@@ -73,7 +73,12 @@ function ec_get_artists_for_user( $user_id = null, $admin_override = false ) {
 		$published_artists = array();
 		foreach ( $user_artist_ids as $artist_id ) {
 			$artist_id_int = absint( $artist_id );
-			if ( $artist_id_int > 0 && get_post_status( $artist_id_int ) === 'publish' ) {
+			if ( 0 >= $artist_id_int || 'artist_profile' !== get_post_type( $artist_id_int ) || 'publish' !== get_post_status( $artist_id_int ) ) {
+				continue;
+			}
+
+			$member_ids = get_post_meta( $artist_id_int, '_artist_member_ids', true );
+			if ( is_array( $member_ids ) && in_array( (int) $user_id, array_map( 'intval', $member_ids ), true ) ) {
 				$published_artists[] = $artist_id_int;
 			}
 		}
@@ -92,7 +97,7 @@ function ec_get_artists_for_user( $user_id = null, $admin_override = false ) {
  *                  refactor tooling in homeboy#3075). Kept as a thin compat
  *                  function; ec_user_can() delegates here so logic has one home.
  *
- * @param int|null $user_id User ID (defaults to current user)
+ * @param int|null $user_id User ID (defaults to current user).
  * @return bool             True if user has permission to create artist profiles
  */
 function ec_can_create_artist_profiles( $user_id = null ) {
@@ -116,7 +121,7 @@ function ec_can_create_artist_profiles( $user_id = null ) {
  * based on link page modification time. Falls back to first artist
  * if no link pages exist.
  *
- * @param int|null $user_id User ID (defaults to current user)
+ * @param int|null $user_id User ID (defaults to current user).
  * @return int Artist profile ID, or 0 if none found
  */
 function ec_get_latest_artist_for_user( $user_id = null ) {
@@ -140,8 +145,8 @@ function ec_get_latest_artist_for_user( $user_id = null ) {
 			$link_pages = get_posts(
 				array(
 					'post_type'      => 'artist_link_page',
-					'meta_key'       => '_associated_artist_profile_id',
-					'meta_value'     => (string) $artist_id,
+					'meta_key'       => '_associated_artist_profile_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Canonical relationship lookup.
+					'meta_value'     => (string) $artist_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Canonical relationship lookup.
 					'posts_per_page' => 1,
 					'fields'         => 'ids',
 				)
@@ -163,7 +168,7 @@ function ec_get_latest_artist_for_user( $user_id = null ) {
 		restore_current_blog();
 	}
 
-	// Fall back to first artist if no link pages found
+	// Fall back to first artist if no link pages are found.
 	return $latest_artist_id > 0 ? $latest_artist_id : reset( $user_artists );
 }
 
@@ -180,8 +185,8 @@ function ec_get_latest_artist_for_user( $user_id = null ) {
  *                  refactor tooling in homeboy#3075). Kept as a thin compat
  *                  function; ec_user_can() delegates here so logic has one home.
  *
- * @param int|null $user_id   User ID (defaults to current user)
- * @param int|null $artist_id Artist profile post ID
+ * @param int|null $user_id   User ID (defaults to current user).
+ * @param int|null $artist_id Artist profile post ID.
  * @return bool               True if user can manage the artist
  */
 function ec_can_manage_artist( $user_id = null, $artist_id = null ) {
@@ -193,18 +198,18 @@ function ec_can_manage_artist( $user_id = null, $artist_id = null ) {
 		return false;
 	}
 
-	// Admins can manage any artist
+	// Admins can manage any artist.
 	if ( user_can( $user_id, 'manage_options' ) ) {
 		return true;
 	}
 
-	// Check if user owns this artist via user meta
+	// Check if user owns this artist via user meta.
 	$user_artist_ids = get_user_meta( $user_id, '_artist_profile_ids', true );
 	if ( is_array( $user_artist_ids ) && in_array( (int) $artist_id, array_map( 'intval', $user_artist_ids ), true ) ) {
 		return true;
 	}
 
-	// Check if user is post author (requires blog switch for cross-site check)
+	// Check if user is post author (requires a cross-site blog switch).
 	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
 	if ( $artist_blog_id ) {
 		switch_to_blog( $artist_blog_id );
@@ -226,7 +231,7 @@ function ec_can_manage_artist( $user_id = null, $artist_id = null ) {
  *
  * Counts how many link pages exist across all of a user's artist profiles.
  *
- * @param int|null $user_id User ID (defaults to current user)
+ * @param int|null $user_id User ID (defaults to current user).
  * @return int Count of link pages
  */
 function ec_get_link_page_count_for_user( $user_id = null ) {
@@ -250,8 +255,8 @@ function ec_get_link_page_count_for_user( $user_id = null ) {
 				array(
 					'post_type'      => 'artist_link_page',
 					'post_status'    => 'publish',
-					'meta_key'       => '_associated_artist_profile_id',
-					'meta_value'     => (string) $artist_id,
+					'meta_key'       => '_associated_artist_profile_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Canonical relationship lookup.
+					'meta_value'     => (string) $artist_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Canonical relationship lookup.
 					'posts_per_page' => 1,
 					'fields'         => 'ids',
 				)

--- a/inc/core/abilities/artist-dispatch.php
+++ b/inc/core/abilities/artist-dispatch.php
@@ -63,7 +63,7 @@ function extrachill_users_register_artist_dispatch_abilities() {
 						'enum' => array( EC_USERS_ARTIST_DISPATCH_TERMS_VERSION ),
 					),
 				),
-				'required'   => array( 'artist_id', 'description', 'acknowledgement', 'terms_version' ),
+				'required'   => array( 'acknowledgement', 'terms_version' ),
 			),
 			'callback'    => 'extrachill_users_ability_request_artist_dispatch_access',
 			'permission'  => $self_permission,

--- a/inc/core/abilities/artist-dispatch.php
+++ b/inc/core/abilities/artist-dispatch.php
@@ -1,0 +1,328 @@
+<?php
+/**
+ * Artist Dispatch access abilities.
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_users_register_artist_dispatch_abilities' );
+
+/**
+ * Administrative permission shared by registration and execution checks.
+ *
+ * @return bool
+ */
+function ec_users_artist_dispatch_admin_permission() {
+	return current_user_can( 'manage_network_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+}
+
+/**
+ * Register the publication-specific ability surface.
+ */
+function extrachill_users_register_artist_dispatch_abilities() {
+	$self_permission = static function () {
+		return is_user_logged_in();
+	};
+	$definitions     = array(
+		'extrachill/get-artist-dispatch-access'           => array(
+			'label'       => __( 'Get Artist Dispatch Access', 'extrachill-users' ),
+			'description' => __( 'Get the current user\'s safe Artist Dispatch eligibility and access state.', 'extrachill-users' ),
+			'input'       => array(
+				'type'       => 'object',
+				'properties' => array(),
+			),
+			'callback'    => 'extrachill_users_ability_get_artist_dispatch_access',
+			'permission'  => $self_permission,
+			'rest'        => true,
+			'readonly'    => true,
+		),
+		'extrachill/request-artist-dispatch-access'       => array(
+			'label'       => __( 'Request Artist Dispatch Access', 'extrachill-users' ),
+			'description' => __( 'Submit the current user\'s eligible Artist Dispatch access request.', 'extrachill-users' ),
+			'input'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'artist_id'       => array( 'type' => 'integer' ),
+					'description'     => array(
+						'type'      => 'string',
+						'minLength' => 50,
+						'maxLength' => 2000,
+					),
+					'sample_url'      => array(
+						'type'   => 'string',
+						'format' => 'uri',
+					),
+					'acknowledgement' => array(
+						'type' => 'boolean',
+						'enum' => array( true ),
+					),
+					'terms_version'   => array(
+						'type' => 'string',
+						'enum' => array( EC_USERS_ARTIST_DISPATCH_TERMS_VERSION ),
+					),
+				),
+				'required'   => array( 'artist_id', 'description', 'acknowledgement', 'terms_version' ),
+			),
+			'callback'    => 'extrachill_users_ability_request_artist_dispatch_access',
+			'permission'  => $self_permission,
+			'rest'        => true,
+			'readonly'    => false,
+		),
+		'extrachill/list-artist-dispatch-access-requests' => array(
+			'label'       => __( 'List Artist Dispatch Access Requests', 'extrachill-users' ),
+			'description' => __( 'List Artist Dispatch applications and grants for network administration.', 'extrachill-users' ),
+			'input'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'status' => array(
+						'type' => 'string',
+						'enum' => array( 'pending', 'approved', 'rejected', 'revoked' ),
+					),
+				),
+			),
+			'callback'    => 'extrachill_users_ability_list_artist_dispatch_access_requests',
+			'permission'  => 'ec_users_artist_dispatch_admin_permission',
+			'rest'        => false,
+			'readonly'    => true,
+		),
+		'extrachill/approve-artist-dispatch-access'       => array(
+			'label'       => __( 'Approve Artist Dispatch Access', 'extrachill-users' ),
+			'description' => __( 'Approve a matching pending Artist Dispatch request.', 'extrachill-users' ),
+			'input'       => ec_users_artist_dispatch_decision_input_schema( false ),
+			'callback'    => 'extrachill_users_ability_approve_artist_dispatch_access',
+			'permission'  => 'ec_users_artist_dispatch_admin_permission',
+			'rest'        => false,
+			'readonly'    => false,
+		),
+		'extrachill/reject-artist-dispatch-access'        => array(
+			'label'       => __( 'Reject Artist Dispatch Access', 'extrachill-users' ),
+			'description' => __( 'Reject a matching pending Artist Dispatch request.', 'extrachill-users' ),
+			'input'       => ec_users_artist_dispatch_decision_input_schema( true ),
+			'callback'    => 'extrachill_users_ability_reject_artist_dispatch_access',
+			'permission'  => 'ec_users_artist_dispatch_admin_permission',
+			'rest'        => false,
+			'readonly'    => false,
+		),
+		'extrachill/revoke-artist-dispatch-access'        => array(
+			'label'       => __( 'Revoke Artist Dispatch Access', 'extrachill-users' ),
+			'description' => __( 'Revoke an approved Artist Dispatch grant.', 'extrachill-users' ),
+			'input'       => ec_users_artist_dispatch_decision_input_schema( true ),
+			'callback'    => 'extrachill_users_ability_revoke_artist_dispatch_access',
+			'permission'  => 'ec_users_artist_dispatch_admin_permission',
+			'rest'        => false,
+			'readonly'    => false,
+		),
+	);
+
+	foreach ( $definitions as $name => $definition ) {
+		wp_register_ability(
+			$name,
+			array(
+				'label'               => $definition['label'],
+				'description'         => $definition['description'],
+				'category'            => 'extrachill-users',
+				'input_schema'        => $definition['input'],
+				'output_schema'       => array( 'type' => 'object' ),
+				'execute_callback'    => $definition['callback'],
+				'permission_callback' => $definition['permission'],
+				'meta'                => array(
+					'show_in_rest' => $definition['rest'],
+					'annotations'  => array(
+						'readonly'   => $definition['readonly'],
+						'idempotent' => true,
+					),
+				),
+			)
+		);
+	}
+}
+
+/**
+ * Build the common administrative transition schema.
+ *
+ * @param bool $reason_required Whether reason is mandatory.
+ * @return array<string,mixed>
+ */
+function ec_users_artist_dispatch_decision_input_schema( $reason_required ) {
+	$schema = array(
+		'type'       => 'object',
+		'properties' => array(
+			'user_id'    => array( 'type' => 'integer' ),
+			'request_id' => array(
+				'type'   => 'string',
+				'format' => 'uuid',
+			),
+			'note'       => array(
+				'type'      => 'string',
+				'maxLength' => 2000,
+			),
+			'reason'     => array(
+				'type'      => 'string',
+				'minLength' => 1,
+				'maxLength' => 2000,
+			),
+		),
+		'required'   => array( 'user_id', 'request_id' ),
+	);
+	if ( $reason_required ) {
+		$schema['required'][] = 'reason';
+	}
+	return $schema;
+}
+
+/**
+ * Resolve the authenticated self or return an authentication error.
+ *
+ * @return int|WP_Error
+ */
+function ec_users_artist_dispatch_self_user_id() {
+	if ( function_exists( 'extrachill_users_resolve_self_user_id' ) ) {
+		return extrachill_users_resolve_self_user_id();
+	}
+
+	$user_id = get_current_user_id();
+	return $user_id ? $user_id : new WP_Error( 'not_authenticated', __( 'You must be logged in.', 'extrachill-users' ), array( 'status' => 401 ) );
+}
+
+/**
+ * Get self-safe state.
+ *
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_get_artist_dispatch_access() {
+	$user_id = ec_users_artist_dispatch_self_user_id();
+	return is_wp_error( $user_id ) ? $user_id : ec_users_get_artist_dispatch_safe_state( $user_id );
+}
+
+/**
+ * Request access for the authenticated user only.
+ *
+ * @param array $input Request input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_request_artist_dispatch_access( $input ) {
+	$user_id = ec_users_artist_dispatch_self_user_id();
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
+
+	$result = ec_users_request_artist_dispatch_access( $user_id, is_array( $input ) ? $input : array() );
+	return is_wp_error( $result ) ? $result : ec_users_get_artist_dispatch_safe_state( $user_id );
+}
+
+/**
+ * Require administrative execution authorization.
+ *
+ * @return true|WP_Error
+ */
+function ec_users_require_artist_dispatch_admin() {
+	return ec_users_artist_dispatch_admin_permission()
+		? true
+		: new WP_Error( 'artist_dispatch_forbidden', __( 'You cannot manage Artist Dispatch access.', 'extrachill-users' ), array( 'status' => 403 ) );
+}
+
+/**
+ * List protected application records.
+ *
+ * @param array $input List filters.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_list_artist_dispatch_access_requests( $input ) {
+	$allowed = ec_users_require_artist_dispatch_admin();
+	if ( is_wp_error( $allowed ) ) {
+		return $allowed;
+	}
+
+	$status = isset( $input['status'] ) ? sanitize_key( $input['status'] ) : '';
+	$users  = get_users(
+		array(
+			'blog_id'  => 0,
+			'meta_key' => EC_USERS_ARTIST_DISPATCH_STATE_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- The dedicated network user-meta state is the required queue index.
+			'fields'   => 'all',
+		)
+	);
+	$items  = array();
+	foreach ( $users as $user ) {
+		$state = ec_users_get_artist_dispatch_state( $user->ID );
+		if ( ! $state || ( $status && ( $state['status'] ?? '' ) !== $status ) ) {
+			continue;
+		}
+		$items[] = array(
+			'user_id'         => (int) $user->ID,
+			'user_login'      => $user->user_login,
+			'display_name'    => $user->display_name,
+			'state'           => $state,
+			'artist_label'    => ec_users_get_artist_dispatch_artist_label( $state['artist_id'] ?? 0 ),
+			'eligibility'     => ec_users_get_artist_dispatch_eligibility( $user->ID ),
+			'moderation'      => extrachill_users_get_moderation_status( (int) $user->ID ),
+			'main_membership' => is_user_member_of_blog( (int) $user->ID, ec_users_get_artist_dispatch_blog_id() ),
+		);
+	}
+
+	usort(
+		$items,
+		static function ( $a, $b ) {
+			return (int) ( $b['state']['requested_at'] ?? 0 ) <=> (int) ( $a['state']['requested_at'] ?? 0 );
+		}
+	);
+	return array( 'requests' => $items );
+}
+
+/**
+ * Approve a request.
+ *
+ * @param array $input Decision input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_approve_artist_dispatch_access( $input ) {
+	$allowed = ec_users_require_artist_dispatch_admin();
+	if ( is_wp_error( $allowed ) ) {
+		return $allowed;
+	}
+	return ec_users_approve_artist_dispatch_access(
+		$input['user_id'] ?? 0,
+		$input['request_id'] ?? '',
+		$input['note'] ?? '',
+		get_current_user_id()
+	);
+}
+
+/**
+ * Reject a request.
+ *
+ * @param array $input Decision input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_reject_artist_dispatch_access( $input ) {
+	$allowed = ec_users_require_artist_dispatch_admin();
+	if ( is_wp_error( $allowed ) ) {
+		return $allowed;
+	}
+	return ec_users_reject_artist_dispatch_access(
+		$input['user_id'] ?? 0,
+		$input['request_id'] ?? '',
+		$input['reason'] ?? '',
+		get_current_user_id()
+	);
+}
+
+/**
+ * Revoke a grant.
+ *
+ * @param array $input Decision input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_revoke_artist_dispatch_access( $input ) {
+	$allowed = ec_users_require_artist_dispatch_admin();
+	if ( is_wp_error( $allowed ) ) {
+		return $allowed;
+	}
+	return ec_users_revoke_artist_dispatch_access(
+		$input['user_id'] ?? 0,
+		$input['request_id'] ?? '',
+		$input['reason'] ?? '',
+		get_current_user_id()
+	);
+}

--- a/inc/core/abilities/register.php
+++ b/inc/core/abilities/register.php
@@ -69,6 +69,7 @@ require_once __DIR__ . '/onboarding.php';
 require_once __DIR__ . '/moderation.php';
 require_once __DIR__ . '/welcome-email.php';
 require_once __DIR__ . '/artist-access.php';
+require_once __DIR__ . '/artist-dispatch.php';
 require_once __DIR__ . '/user-administration.php';
 require_once __DIR__ . '/user-settings.php';
 require_once __DIR__ . '/user-event-locations.php';

--- a/inc/core/activation.php
+++ b/inc/core/activation.php
@@ -62,6 +62,9 @@ function extrachill_users_run_activation() {
 	ec_users_migrate_team_meta_to_role();
 	update_site_option( 'extrachill_users_team_migration_version', EXTRACHILL_USERS_VERSION );
 
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/artist-dispatch-role.php';
+	ec_users_register_artist_dispatch_role_on_main();
+
 	if ( ! wp_next_scheduled( 'extrachill_welcome_email_fallback' ) ) {
 		wp_schedule_event( time(), 'hourly', 'extrachill_welcome_email_fallback' );
 	}

--- a/inc/core/artist-dispatch-admin.php
+++ b/inc/core/artist-dispatch-admin.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Focused network administration for Artist Dispatch access.
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'network_admin_menu', 'ec_users_add_artist_dispatch_admin_menu' );
+add_action( 'network_admin_edit_extrachill_artist_dispatch', 'ec_users_handle_artist_dispatch_admin_action' );
+
+/**
+ * Register the network-admin queue and policy screen.
+ */
+function ec_users_add_artist_dispatch_admin_menu() {
+	$parent = defined( 'EXTRACHILL_NETWORK_MENU_SLUG' ) ? EXTRACHILL_NETWORK_MENU_SLUG : 'settings.php';
+	add_submenu_page(
+		$parent,
+		__( 'Artist Dispatch', 'extrachill-users' ),
+		__( 'Artist Dispatch', 'extrachill-users' ),
+		'manage_network_options',
+		'extrachill-artist-dispatch',
+		'ec_users_render_artist_dispatch_admin_page'
+	);
+}
+
+/**
+ * Process policy and lifecycle actions through their canonical service/ability.
+ */
+function ec_users_handle_artist_dispatch_admin_action() {
+	if ( ! current_user_can( 'manage_network_options' ) ) {
+		wp_die( esc_html__( 'You cannot manage Artist Dispatch access.', 'extrachill-users' ) );
+	}
+	check_admin_referer( 'extrachill_artist_dispatch_action' );
+
+	$action = isset( $_POST['dispatch_action'] ) ? sanitize_key( wp_unslash( $_POST['dispatch_action'] ) ) : '';
+	$result = true;
+	if ( 'save_policy' === $action ) {
+		$minimum_points = isset( $_POST['minimum_points'] ) ? trim( sanitize_text_field( wp_unslash( $_POST['minimum_points'] ) ) ) : '';
+		ec_users_update_artist_dispatch_policy(
+			array(
+				'pilot_enabled'            => isset( $_POST['pilot_enabled'] ),
+				'minimum_points'           => $minimum_points,
+				'minimum_account_age_days' => isset( $_POST['minimum_account_age_days'] ) ? absint( $_POST['minimum_account_age_days'] ) : 0,
+			)
+		);
+	} elseif ( in_array( $action, array( 'approve', 'reject', 'revoke' ), true ) ) {
+		$ability = wp_get_ability( 'extrachill/' . $action . '-artist-dispatch-access' );
+		$input   = array(
+			'user_id'    => isset( $_POST['user_id'] ) ? absint( $_POST['user_id'] ) : 0,
+			'request_id' => isset( $_POST['request_id'] ) ? sanitize_text_field( wp_unslash( $_POST['request_id'] ) ) : '',
+		);
+		if ( 'approve' === $action ) {
+			$input['note'] = isset( $_POST['note'] ) ? sanitize_textarea_field( wp_unslash( $_POST['note'] ) ) : '';
+		} else {
+			$input['reason'] = isset( $_POST['reason'] ) ? sanitize_textarea_field( wp_unslash( $_POST['reason'] ) ) : '';
+		}
+		$result = $ability ? $ability->execute( $input ) : new WP_Error( 'ability_not_found', __( 'Artist Dispatch ability is unavailable.', 'extrachill-users' ) );
+	} else {
+		$result = new WP_Error( 'invalid_artist_dispatch_action', __( 'Invalid Artist Dispatch action.', 'extrachill-users' ) );
+	}
+
+	wp_safe_redirect(
+		add_query_arg(
+			array(
+				'page'   => 'extrachill-artist-dispatch',
+				'status' => is_wp_error( $result ) ? 'error' : 'updated',
+			),
+			network_admin_url( 'admin.php' )
+		)
+	);
+	exit;
+}
+
+/**
+ * Render the policy, pending queue, and approved grants.
+ */
+function ec_users_render_artist_dispatch_admin_page() {
+	if ( ! current_user_can( 'manage_network_options' ) ) {
+		wp_die( esc_html__( 'You cannot manage Artist Dispatch access.', 'extrachill-users' ) );
+	}
+
+	$policy   = ec_users_get_artist_dispatch_policy();
+	$ability  = wp_get_ability( 'extrachill/list-artist-dispatch-access-requests' );
+	$result   = $ability ? $ability->execute( array() ) : new WP_Error( 'ability_not_found', 'Artist Dispatch ability unavailable.' );
+	$requests = ! is_wp_error( $result ) && isset( $result['requests'] ) ? $result['requests'] : array();
+	$pending  = array_values( array_filter( $requests, static fn( $item ) => 'pending' === ( $item['state']['status'] ?? '' ) ) );
+	$approved = array_values( array_filter( $requests, static fn( $item ) => 'approved' === ( $item['state']['status'] ?? '' ) ) );
+	$status   = isset( $_GET['status'] ) ? sanitize_key( wp_unslash( $_GET['status'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Display-only redirect flag.
+	$action   = network_admin_url( 'edit.php?action=extrachill_artist_dispatch' );
+	?>
+	<div class="wrap">
+		<h1><?php esc_html_e( 'Artist Dispatch Access', 'extrachill-users' ); ?></h1>
+		<?php if ( $status ) : ?>
+			<div class="notice notice-<?php echo 'updated' === $status ? 'success' : 'error'; ?> is-dismissible"><p><?php esc_html_e( 'Artist Dispatch settings or access were processed.', 'extrachill-users' ); ?></p></div>
+		<?php endif; ?>
+
+		<h2><?php esc_html_e( 'Pilot Policy', 'extrachill-users' ); ?></h2>
+		<p><?php esc_html_e( 'Requests remain unavailable until a points threshold is set and the pilot is enabled.', 'extrachill-users' ); ?></p>
+		<form method="post" action="<?php echo esc_url( $action ); ?>">
+			<?php wp_nonce_field( 'extrachill_artist_dispatch_action' ); ?>
+			<input type="hidden" name="dispatch_action" value="save_policy">
+			<table class="form-table" role="presentation">
+				<tr><th scope="row"><label for="minimum_points"><?php esc_html_e( 'Minimum points', 'extrachill-users' ); ?></label></th><td><input id="minimum_points" name="minimum_points" type="number" min="0" step="1" value="<?php echo esc_attr( null === $policy['minimum_points'] ? '' : $policy['minimum_points'] ); ?>"><p class="description"><?php esc_html_e( 'Leave blank to keep requests unconfigured.', 'extrachill-users' ); ?></p></td></tr>
+				<tr><th scope="row"><label for="minimum_account_age_days"><?php esc_html_e( 'Minimum account age', 'extrachill-users' ); ?></label></th><td><input id="minimum_account_age_days" name="minimum_account_age_days" type="number" min="0" step="1" value="<?php echo esc_attr( $policy['minimum_account_age_days'] ); ?>"> <?php esc_html_e( 'days', 'extrachill-users' ); ?></td></tr>
+				<tr><th scope="row"><?php esc_html_e( 'Pilot', 'extrachill-users' ); ?></th><td><label><input name="pilot_enabled" type="checkbox" value="1" <?php checked( $policy['pilot_enabled'] ); ?>> <?php esc_html_e( 'Enable eligible access requests', 'extrachill-users' ); ?></label></td></tr>
+			</table>
+			<?php submit_button( __( 'Save Policy', 'extrachill-users' ) ); ?>
+		</form>
+
+		<h2><?php esc_html_e( 'Pending Requests', 'extrachill-users' ); ?></h2>
+		<?php if ( empty( $pending ) ) : ?>
+			<p><?php esc_html_e( 'No pending Artist Dispatch requests.', 'extrachill-users' ); ?></p>
+		<?php else : ?>
+			<table class="widefat striped">
+				<thead><tr><th><?php esc_html_e( 'Member / Artist', 'extrachill-users' ); ?></th><th><?php esc_html_e( 'Application', 'extrachill-users' ); ?></th><th><?php esc_html_e( 'Checks', 'extrachill-users' ); ?></th><th><?php esc_html_e( 'Decision', 'extrachill-users' ); ?></th></tr></thead>
+				<tbody>
+				<?php foreach ( $pending as $item ) : ?>
+					<tr>
+						<td><strong><?php echo esc_html( $item['display_name'] ? $item['display_name'] : $item['user_login'] ); ?></strong><br><?php echo esc_html( $item['artist_label'] ? $item['artist_label'] : '#' . (int) $item['state']['artist_id'] ); ?><br><small><?php echo esc_html( gmdate( 'Y-m-d H:i', (int) $item['state']['requested_at'] ) ); ?> UTC</small></td>
+						<td><?php echo nl2br( esc_html( $item['state']['description'] ) ); ?>
+						<?php
+						if ( ! empty( $item['state']['sample_url'] ) ) :
+							?>
+							<p><a href="<?php echo esc_url( $item['state']['sample_url'] ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Writing sample', 'extrachill-users' ); ?></a></p><?php endif; ?></td>
+						<td><?php echo esc_html( $item['eligibility']['eligible'] ? __( 'Eligible now', 'extrachill-users' ) : implode( ' ', $item['eligibility']['reasons'] ) ); ?><br><?php echo esc_html( ! empty( $item['moderation']['active'] ) ? __( 'Moderation: active', 'extrachill-users' ) : __( 'Moderation: blocked', 'extrachill-users' ) ); ?><br><?php echo esc_html( $item['main_membership'] ? __( 'Main-site member', 'extrachill-users' ) : __( 'Not a main-site member', 'extrachill-users' ) ); ?></td>
+						<td>
+							<form method="post" action="<?php echo esc_url( $action ); ?>">
+								<?php wp_nonce_field( 'extrachill_artist_dispatch_action' ); ?>
+								<input type="hidden" name="user_id" value="<?php echo esc_attr( $item['user_id'] ); ?>"><input type="hidden" name="request_id" value="<?php echo esc_attr( $item['state']['request_id'] ); ?>">
+								<textarea name="note" rows="2" placeholder="<?php esc_attr_e( 'Optional approval note', 'extrachill-users' ); ?>"></textarea><br><button class="button button-primary" name="dispatch_action" value="approve"><?php esc_html_e( 'Approve', 'extrachill-users' ); ?></button>
+							</form>
+							<form method="post" action="<?php echo esc_url( $action ); ?>" style="margin-top:8px">
+								<?php wp_nonce_field( 'extrachill_artist_dispatch_action' ); ?>
+								<input type="hidden" name="user_id" value="<?php echo esc_attr( $item['user_id'] ); ?>"><input type="hidden" name="request_id" value="<?php echo esc_attr( $item['state']['request_id'] ); ?>">
+								<textarea name="reason" rows="2" required placeholder="<?php esc_attr_e( 'Required rejection reason', 'extrachill-users' ); ?>"></textarea><br><button class="button" name="dispatch_action" value="reject"><?php esc_html_e( 'Reject', 'extrachill-users' ); ?></button>
+							</form>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+				</tbody>
+			</table>
+		<?php endif; ?>
+
+		<h2><?php esc_html_e( 'Approved Grants', 'extrachill-users' ); ?></h2>
+		<?php if ( empty( $approved ) ) : ?>
+			<p><?php esc_html_e( 'No approved Artist Dispatch grants.', 'extrachill-users' ); ?></p>
+		<?php else : ?>
+			<table class="widefat striped"><thead><tr><th><?php esc_html_e( 'Member', 'extrachill-users' ); ?></th><th><?php esc_html_e( 'Artist', 'extrachill-users' ); ?></th><th><?php esc_html_e( 'Granted', 'extrachill-users' ); ?></th><th><?php esc_html_e( 'Revoke', 'extrachill-users' ); ?></th></tr></thead><tbody>
+			<?php foreach ( $approved as $item ) : ?>
+				<tr><td><?php echo esc_html( $item['display_name'] ? $item['display_name'] : $item['user_login'] ); ?></td><td><?php echo esc_html( $item['artist_label'] ? $item['artist_label'] : '#' . (int) $item['state']['artist_id'] ); ?></td><td><?php echo esc_html( gmdate( 'Y-m-d H:i', (int) $item['state']['grant']['granted_at'] ) ); ?> UTC</td><td><form method="post" action="<?php echo esc_url( $action ); ?>"><?php wp_nonce_field( 'extrachill_artist_dispatch_action' ); ?><input type="hidden" name="user_id" value="<?php echo esc_attr( $item['user_id'] ); ?>"><input type="hidden" name="request_id" value="<?php echo esc_attr( $item['state']['request_id'] ); ?>"><input name="reason" type="text" required placeholder="<?php esc_attr_e( 'Required reason', 'extrachill-users' ); ?>"> <button class="button" name="dispatch_action" value="revoke"><?php esc_html_e( 'Revoke', 'extrachill-users' ); ?></button></form></td></tr>
+			<?php endforeach; ?>
+			</tbody></table>
+		<?php endif; ?>
+	</div>
+	<?php
+}

--- a/inc/core/moderation/actions.php
+++ b/inc/core/moderation/actions.php
@@ -7,6 +7,13 @@
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Apply a moderation state and its configured effects.
+ *
+ * @param int   $user_id User ID.
+ * @param array $args    Moderation inputs.
+ * @return array|WP_Error
+ */
 function extrachill_users_apply_moderation_action( int $user_id, array $args = array() ) {
 	if ( $user_id <= 0 ) {
 		return new WP_Error( 'invalid_user', __( 'A valid user ID is required.', 'extrachill-users' ) );
@@ -55,6 +62,10 @@ function extrachill_users_apply_moderation_action( int $user_id, array $args = a
 	}
 
 	$status = extrachill_users_get_moderation_status( $user_id );
+	if ( function_exists( 'ec_users_revoke_artist_dispatch_for_moderation' ) && empty( $status['active'] ) ) {
+		$dispatch_reason = $payload['reason'] ? $payload['reason'] : $reason_key;
+		ec_users_revoke_artist_dispatch_for_moderation( $user_id, $actor_id, $dispatch_reason );
+	}
 
 	if ( ! empty( $policy['effects']['send_email'] ) ) {
 		extrachill_users_send_moderation_email( $user, $status );
@@ -67,6 +78,12 @@ function extrachill_users_apply_moderation_action( int $user_id, array $args = a
 	return $status;
 }
 
+/**
+ * Clear moderation state without restoring separately revoked product access.
+ *
+ * @param int $user_id User ID.
+ * @return array|WP_Error
+ */
 function extrachill_users_clear_moderation_action( int $user_id ) {
 	if ( $user_id <= 0 ) {
 		return new WP_Error( 'invalid_user', __( 'A valid user ID is required.', 'extrachill-users' ) );

--- a/inc/core/moderation/actions.php
+++ b/inc/core/moderation/actions.php
@@ -64,7 +64,13 @@ function extrachill_users_apply_moderation_action( int $user_id, array $args = a
 	$status = extrachill_users_get_moderation_status( $user_id );
 	if ( function_exists( 'ec_users_revoke_artist_dispatch_for_moderation' ) && empty( $status['active'] ) ) {
 		$dispatch_reason = $payload['reason'] ? $payload['reason'] : $reason_key;
-		ec_users_revoke_artist_dispatch_for_moderation( $user_id, $actor_id, $dispatch_reason );
+		$dispatch_result = ec_users_revoke_artist_dispatch_for_moderation( $user_id, $actor_id, $dispatch_reason );
+		if ( is_wp_error( $dispatch_result ) ) {
+			$results['artist_dispatch'] = array(
+				'error'   => $dispatch_result->get_error_code(),
+				'message' => $dispatch_result->get_error_message(),
+			);
+		}
 	}
 
 	if ( ! empty( $policy['effects']['send_email'] ) ) {

--- a/inc/core/moderation/actions.php
+++ b/inc/core/moderation/actions.php
@@ -66,10 +66,7 @@ function extrachill_users_apply_moderation_action( int $user_id, array $args = a
 		$dispatch_reason = $payload['reason'] ? $payload['reason'] : $reason_key;
 		$dispatch_result = ec_users_revoke_artist_dispatch_for_moderation( $user_id, $actor_id, $dispatch_reason );
 		if ( is_wp_error( $dispatch_result ) ) {
-			$results['artist_dispatch'] = array(
-				'error'   => $dispatch_result->get_error_code(),
-				'message' => $dispatch_result->get_error_message(),
-			);
+			return $dispatch_result;
 		}
 	}
 

--- a/tests/unit/ArtistDispatchAccessTest.php
+++ b/tests/unit/ArtistDispatchAccessTest.php
@@ -1,0 +1,414 @@
+<?php
+/**
+ * Artist Dispatch access lifecycle tests.
+ *
+ * @package ExtraChill\Users
+ */
+
+/**
+ * Verify the Artist Dispatch contract against WordPress multisite primitives.
+ */
+class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
+	// phpcs:disable Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
+
+	private int $main_blog_id;
+	private int $artist_blog_id;
+
+	protected function setUp(): void {
+		parent::setUp();
+		require_once dirname( __DIR__, 2 ) . '/inc/artist-dispatch-role.php';
+		require_once dirname( __DIR__, 2 ) . '/inc/artist-dispatch.php';
+		require_once dirname( __DIR__, 2 ) . '/inc/core/abilities/artist-dispatch.php';
+
+		$this->main_blog_id   = ec_users_get_artist_dispatch_blog_id();
+		$this->artist_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : 0;
+		if ( ! is_multisite() || ! $this->artist_blog_id ) {
+			$this->markTestSkipped( 'Artist Dispatch tests require the multisite artist-site map.' );
+		}
+
+		$this->ensure_blog_exists( $this->main_blog_id );
+		$this->ensure_blog_exists( $this->artist_blog_id );
+		delete_site_option( EC_USERS_ARTIST_DISPATCH_POLICY_OPTION );
+		wp_set_current_user( 0 );
+
+		switch_to_blog( $this->main_blog_id );
+		remove_role( EC_USERS_ARTIST_DISPATCH_ROLE );
+		ec_users_register_artist_dispatch_role();
+		restore_current_blog();
+	}
+
+	protected function tearDown(): void {
+		delete_site_option( EC_USERS_ARTIST_DISPATCH_POLICY_OPTION );
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	private function ensure_blog_exists( int $blog_id ): void {
+		while ( ! get_blog_details( $blog_id ) ) {
+			$created = self::factory()->blog->create();
+			if ( $created > $blog_id ) {
+				$this->fail( 'Could not create expected mapped blog ID.' );
+			}
+		}
+	}
+
+	private function configure_policy( float $minimum_points = 10 ): void {
+		ec_users_update_artist_dispatch_policy(
+			array(
+				'minimum_points'           => $minimum_points,
+				'minimum_account_age_days' => 1,
+				'pilot_enabled'            => true,
+			)
+		);
+	}
+
+	private function create_eligible_user(): array {
+		$user_id = self::factory()->user->create(
+			array(
+				'role'            => '',
+				'user_registered' => gmdate( 'Y-m-d H:i:s', time() - ( 10 * DAY_IN_SECONDS ) ),
+			)
+		);
+		update_user_meta( $user_id, 'onboarding_completed', '1' );
+		set_transient( 'user_points_' . $user_id, 25, HOUR_IN_SECONDS );
+
+		switch_to_blog( $this->artist_blog_id );
+		register_post_type( 'artist_profile', array( 'public' => true ) );
+		$artist_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'artist_profile',
+				'post_status' => 'publish',
+				'post_title'  => 'Lifecycle Artist',
+			)
+		);
+		restore_current_blog();
+		update_user_meta( $user_id, '_artist_profile_ids', array( $artist_id ) );
+
+		return array( $user_id, $artist_id );
+	}
+
+	private function request_access( int $user_id, int $artist_id ): array {
+		wp_set_current_user( $user_id );
+		$result = ec_users_request_artist_dispatch_access(
+			$user_id,
+			array(
+				'artist_id'       => $artist_id,
+				'description'     => str_repeat( 'A focused first-person dispatch proposal. ', 3 ),
+				'sample_url'      => 'https://example.com/sample',
+				'acknowledgement' => true,
+				'terms_version'   => EC_USERS_ARTIST_DISPATCH_TERMS_VERSION,
+			)
+		);
+		$this->assertNotWPError( $result );
+		return $result;
+	}
+
+	private function create_network_admin(): int {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $admin_id );
+		wp_set_current_user( $admin_id );
+		return $admin_id;
+	}
+
+	public function test_policy_is_disabled_and_unconfigured_by_default(): void {
+		$user_id     = self::factory()->user->create();
+		$eligibility = ec_users_get_artist_dispatch_eligibility( $user_id );
+
+		$this->assertFalse( $eligibility['eligible'] );
+		$this->assertFalse( $eligibility['criteria']['policy_configured']['passed'] );
+		$this->assertFalse( $eligibility['criteria']['pilot_enabled']['passed'] );
+		$this->assertNull( $eligibility['criteria']['points']['minimum'] );
+	}
+
+	public function test_eligibility_reports_each_input_and_canonical_artist_relationship(): void {
+		$this->configure_policy();
+		list( $user_id, $artist_id ) = $this->create_eligible_user();
+		$eligibility                 = ec_users_get_artist_dispatch_eligibility( $user_id );
+
+		$this->assertTrue( $eligibility['eligible'] );
+		$this->assertSame( 25.0, $eligibility['criteria']['points']['value'] );
+		$this->assertTrue( $eligibility['criteria']['onboarding']['value'] );
+		$this->assertGreaterThanOrEqual( 1, $eligibility['criteria']['account_age']['value_days'] );
+		$this->assertTrue( $eligibility['criteria']['claimed_account']['value'] );
+		$this->assertTrue( $eligibility['criteria']['active_moderation']['value'] );
+		$this->assertSame( array( $artist_id ), $eligibility['criteria']['claimed_artist']['artist_ids'] );
+
+		update_user_meta( $user_id, '_artist_profile_ids', array() );
+		$this->assertFalse( ec_users_get_artist_dispatch_eligibility( $user_id )['criteria']['claimed_artist']['passed'] );
+	}
+
+	public function test_request_is_self_only_and_server_validates_selected_artist(): void {
+		$this->configure_policy();
+		list( $user_id, $artist_id ) = $this->create_eligible_user();
+		$other_id                    = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+
+		$invalid = extrachill_users_ability_request_artist_dispatch_access(
+			array(
+				'user_id'         => $other_id,
+				'artist_id'       => $artist_id + 999,
+				'description'     => str_repeat( 'Valid length, invalid ownership. ', 3 ),
+				'acknowledgement' => true,
+				'terms_version'   => EC_USERS_ARTIST_DISPATCH_TERMS_VERSION,
+			)
+		);
+		$this->assertWPError( $invalid );
+		$this->assertSame( array(), ec_users_get_artist_dispatch_state( $other_id ) );
+
+		$valid = extrachill_users_ability_request_artist_dispatch_access(
+			array(
+				'user_id'         => $other_id,
+				'artist_id'       => $artist_id,
+				'description'     => str_repeat( 'A valid proposal from the authenticated member. ', 3 ),
+				'acknowledgement' => true,
+				'terms_version'   => EC_USERS_ARTIST_DISPATCH_TERMS_VERSION,
+			)
+		);
+		$this->assertNotWPError( $valid );
+		$this->assertSame( 'pending', ec_users_get_artist_dispatch_state( $user_id )['status'] );
+		$this->assertSame( array(), ec_users_get_artist_dispatch_state( $other_id ) );
+		$this->assertArrayNotHasKey( 'description', $valid );
+		$this->assertTrue( $valid['terms_acknowledged'] );
+		$this->assertSame( EC_USERS_ARTIST_DISPATCH_TERMS_VERSION, $valid['terms_version'] );
+	}
+
+	public function test_request_requires_and_immutably_persists_current_terms_acceptance(): void {
+		$this->configure_policy();
+		list( $user_id, $artist_id ) = $this->create_eligible_user();
+		$base_input                  = array(
+			'artist_id'   => $artist_id,
+			'description' => str_repeat( 'A proposal with an explicit affiliation disclosure. ', 3 ),
+		);
+
+		$this->assertWPError( ec_users_request_artist_dispatch_access( $user_id, $base_input ) );
+		$this->assertWPError(
+			ec_users_request_artist_dispatch_access(
+				$user_id,
+				array_merge(
+					$base_input,
+					array(
+						'acknowledgement' => false,
+						'terms_version'   => EC_USERS_ARTIST_DISPATCH_TERMS_VERSION,
+					)
+				)
+			)
+		);
+		$this->assertWPError( ec_users_request_artist_dispatch_access( $user_id, array_merge( $base_input, array( 'acknowledgement' => true ) ) ) );
+		$this->assertWPError(
+			ec_users_request_artist_dispatch_access(
+				$user_id,
+				array_merge(
+					$base_input,
+					array(
+						'acknowledgement' => true,
+						'terms_version'   => 'v1',
+					)
+				)
+			)
+		);
+
+		$request = ec_users_request_artist_dispatch_access(
+			$user_id,
+			array_merge(
+				$base_input,
+				array(
+					'acknowledgement' => true,
+					'terms_version'   => EC_USERS_ARTIST_DISPATCH_TERMS_VERSION,
+				)
+			)
+		);
+		$this->assertNotWPError( $request );
+		$this->assertTrue( $request['terms_acknowledged'] );
+		$this->assertSame( EC_USERS_ARTIST_DISPATCH_TERMS_VERSION, $request['terms_version'] );
+		$this->assertGreaterThan( 0, $request['terms_accepted_at'] );
+		$events = get_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_AUDIT_META, false );
+		$this->assertSame( EC_USERS_ARTIST_DISPATCH_TERMS_VERSION, $events[0]['details']['terms_version'] );
+
+		$retry = ec_users_request_artist_dispatch_access(
+			$user_id,
+			array_merge(
+				$base_input,
+				array(
+					'acknowledgement' => true,
+					'terms_version'   => EC_USERS_ARTIST_DISPATCH_TERMS_VERSION,
+				)
+			)
+		);
+		$this->assertSame( $request['request_id'], $retry['request_id'] );
+		$this->assertSame( $request['terms_accepted_at'], $retry['terms_accepted_at'] );
+		$this->assertWPError(
+			ec_users_request_artist_dispatch_access(
+				$user_id,
+				array_merge(
+					$base_input,
+					array(
+						'acknowledgement' => true,
+						'terms_version'   => 'changed-client-value',
+					)
+				)
+			)
+		);
+		$this->assertSame( EC_USERS_ARTIST_DISPATCH_TERMS_VERSION, ec_users_get_artist_dispatch_state( $user_id )['terms_version'] );
+	}
+
+	public function test_request_analytics_payload_is_bounded_and_contains_no_application_text(): void {
+		$payload = ec_users_get_artist_dispatch_requested_event_payload( 12, 34, EC_USERS_ARTIST_DISPATCH_TERMS_VERSION );
+		$this->assertSame( array( 'user_id', 'artist_id', 'terms_version', 'surface' ), array_keys( $payload ) );
+		$this->assertSame( 12, $payload['user_id'] );
+		$this->assertSame( 34, $payload['artist_id'] );
+		$this->assertSame( EC_USERS_ARTIST_DISPATCH_TERMS_VERSION, $payload['terms_version'] );
+		$this->assertSame( 'artist_dispatch', $payload['surface'] );
+		$this->assertArrayNotHasKey( 'description', $payload );
+		$this->assertArrayNotHasKey( 'sample_url', $payload );
+	}
+
+	public function test_role_capabilities_are_exact_and_main_site_only(): void {
+		$this->assertSame(
+			array( 'read', 'edit_posts', 'delete_posts', 'submit_for_review' ),
+			array_keys( ec_users_get_artist_dispatch_role_caps() )
+		);
+
+		$other_blog_id = self::factory()->blog->create();
+		switch_to_blog( $other_blog_id );
+		ec_users_register_artist_dispatch_role();
+		$this->assertNull( get_role( EC_USERS_ARTIST_DISPATCH_ROLE ) );
+		restore_current_blog();
+	}
+
+	public function test_approval_is_additive_and_native_post_authorization_is_bounded(): void {
+		$this->configure_policy();
+		list( $user_id, $artist_id ) = $this->create_eligible_user();
+		add_user_to_blog( $this->main_blog_id, $user_id, 'subscriber' );
+		$request  = $this->request_access( $user_id, $artist_id );
+		$admin_id = $this->create_network_admin();
+		$approved = ec_users_approve_artist_dispatch_access( $user_id, $request['request_id'], '', $admin_id );
+		$this->assertNotWPError( $approved );
+
+		switch_to_blog( $this->main_blog_id );
+		$user = new WP_User( $user_id );
+		$this->assertContains( 'subscriber', $user->roles );
+		$this->assertContains( EC_USERS_ARTIST_DISPATCH_ROLE, $user->roles );
+		wp_set_current_user( $user_id );
+		$own_draft  = self::factory()->post->create(
+			array(
+				'post_author' => $user_id,
+				'post_status' => 'draft',
+			)
+		);
+		$other      = self::factory()->user->create();
+		$other_post = self::factory()->post->create(
+			array(
+				'post_author' => $other,
+				'post_status' => 'draft',
+			)
+		);
+		$this->assertTrue( current_user_can( 'edit_post', $own_draft ), 'Core autosaves use this edit_post authorization.' );
+		$this->assertFalse( current_user_can( 'edit_post', $other_post ) );
+		$this->assertFalse( current_user_can( 'publish_posts' ) );
+		$this->assertFalse( current_user_can( 'upload_files' ) );
+		$this->assertFalse( current_user_can( 'edit_others_posts' ) );
+		$this->assertFalse( current_user_can( 'edit_published_posts' ) );
+		$this->assertFalse( current_user_can( 'manage_categories' ) );
+		restore_current_blog();
+	}
+
+	public function test_retries_do_not_duplicate_audit_or_notification_markers(): void {
+		$this->configure_policy();
+		list( $user_id, $artist_id ) = $this->create_eligible_user();
+		$request                     = $this->request_access( $user_id, $artist_id );
+		$duplicate_request           = $this->request_access( $user_id, $artist_id );
+		$this->assertSame( $request['request_id'], $duplicate_request['request_id'] );
+		$this->assertCount( 1, get_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_AUDIT_META, false ) );
+
+		$admin_id = $this->create_network_admin();
+		$first    = ec_users_approve_artist_dispatch_access( $user_id, $request['request_id'], '', $admin_id );
+		$second   = ec_users_approve_artist_dispatch_access( $user_id, $request['request_id'], '', $admin_id );
+		$this->assertNotWPError( $first );
+		$this->assertNotWPError( $second );
+		$this->assertCount( 2, get_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_AUDIT_META, false ) );
+		$this->assertCount( 1, $second['notifications'] );
+	}
+
+	public function test_revocation_removes_only_product_grant_and_cleans_grant_created_membership(): void {
+		$this->configure_policy();
+		list( $user_id, $artist_id ) = $this->create_eligible_user();
+		remove_user_from_blog( $user_id, $this->main_blog_id );
+		$request  = $this->request_access( $user_id, $artist_id );
+		$admin_id = $this->create_network_admin();
+		ec_users_approve_artist_dispatch_access( $user_id, $request['request_id'], '', $admin_id );
+		$this->assertTrue( is_user_member_of_blog( $user_id, $this->main_blog_id ) );
+
+		$revoked = ec_users_revoke_artist_dispatch_access( $user_id, $request['request_id'], 'Pilot access ended.', $admin_id );
+		$this->assertNotWPError( $revoked );
+		$this->assertFalse( is_user_member_of_blog( $user_id, $this->main_blog_id ) );
+		$this->assertSame( 'revoked', $revoked['status'] );
+	}
+
+	public function test_moderation_blocks_request_and_revokes_without_automatic_restore(): void {
+		$this->configure_policy();
+		list( $user_id, $artist_id ) = $this->create_eligible_user();
+		$admin_id                    = $this->create_network_admin();
+		extrachill_users_apply_moderation_action(
+			$user_id,
+			array(
+				'reason_key' => 'other',
+				'reason'     => 'Review hold',
+				'acted_by'   => $admin_id,
+			)
+		);
+		$this->assertFalse( ec_users_get_artist_dispatch_eligibility( $user_id )['eligible'] );
+		$this->assertWPError(
+			ec_users_request_artist_dispatch_access(
+				$user_id,
+				array(
+					'artist_id'       => $artist_id,
+					'description'     => str_repeat( 'Blocked request text. ', 4 ),
+					'acknowledgement' => true,
+					'terms_version'   => EC_USERS_ARTIST_DISPATCH_TERMS_VERSION,
+				)
+			)
+		);
+
+		extrachill_users_clear_moderation_action( $user_id );
+		$request = $this->request_access( $user_id, $artist_id );
+		ec_users_approve_artist_dispatch_access( $user_id, $request['request_id'], '', $admin_id );
+		extrachill_users_apply_moderation_action(
+			$user_id,
+			array(
+				'reason_key' => 'other',
+				'reason'     => 'Second hold',
+				'acted_by'   => $admin_id,
+			)
+		);
+		$this->assertSame( 'revoked', ec_users_get_artist_dispatch_state( $user_id )['status'] );
+		extrachill_users_clear_moderation_action( $user_id );
+		$this->assertSame( 'revoked', ec_users_get_artist_dispatch_state( $user_id )['status'] );
+	}
+
+	public function test_threshold_change_after_approval_does_not_remove_native_access(): void {
+		$this->configure_policy();
+		list( $user_id, $artist_id ) = $this->create_eligible_user();
+		$request                     = $this->request_access( $user_id, $artist_id );
+		$admin_id                    = $this->create_network_admin();
+		ec_users_approve_artist_dispatch_access( $user_id, $request['request_id'], '', $admin_id );
+
+		ec_users_update_artist_dispatch_policy( array( 'minimum_points' => 500 ) );
+		$this->assertFalse( ec_users_get_artist_dispatch_eligibility( $user_id )['eligible'] );
+		switch_to_blog( $this->main_blog_id );
+		$this->assertContains( EC_USERS_ARTIST_DISPATCH_ROLE, ( new WP_User( $user_id ) )->roles );
+		restore_current_blog();
+	}
+
+	public function test_administrative_callbacks_self_defend(): void {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+		$this->assertWPError( extrachill_users_ability_list_artist_dispatch_access_requests( array() ) );
+		$this->assertWPError(
+			extrachill_users_ability_approve_artist_dispatch_access(
+				array(
+					'user_id'    => 1,
+					'request_id' => wp_generate_uuid4(),
+				)
+			)
+		);
+	}
+}

--- a/tests/unit/ArtistDispatchAccessTest.php
+++ b/tests/unit/ArtistDispatchAccessTest.php
@@ -396,11 +396,10 @@ class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
 		$state = ec_users_maybe_emit_artist_dispatch_event( $user_id, 'requested', $state );
 		ec_users_release_artist_dispatch_lock( $user_id, $lock );
 		$this->assertCount( 4, $state['deliveries']['analytics'] );
-		if ( $this->registered_fake_analytics ) {
-			$this->assertCount( 4, $GLOBALS['ec_artist_dispatch_test_analytics'] );
-			foreach ( $GLOBALS['ec_artist_dispatch_test_analytics'] as $event ) {
-				$this->assertSame( array( 'user_id', 'request_id' ), array_keys( $event['event_data'] ) );
-			}
+		$this->assertTrue( $this->registered_fake_analytics, 'The isolated test suite must own the analytics ability.' );
+		$this->assertCount( 4, $GLOBALS['ec_artist_dispatch_test_analytics'] );
+		foreach ( $GLOBALS['ec_artist_dispatch_test_analytics'] as $event ) {
+			$this->assertSame( array( 'user_id', 'request_id' ), array_keys( $event['event_data'] ) );
 		}
 	}
 
@@ -488,19 +487,20 @@ class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
 		$this->assertCount( 2, $second['deliveries']['analytics'] );
 	}
 
-	public function test_lock_is_bounded_owned_and_supports_safe_expiry_takeover(): void {
+	public function test_lock_is_bounded_owned_and_expiry_fails_closed(): void {
 		$user_id = self::factory()->user->create();
 		$first   = ec_users_acquire_artist_dispatch_lock( $user_id, 'first' );
 		$this->assertNotWPError( $first );
 		$this->assertWPError( ec_users_acquire_artist_dispatch_lock( $user_id, 'concurrent' ) );
 		$expired               = $first;
 		$expired['expires_at'] = time() - 1;
-		$this->assertNotFalse( update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_LOCK_META, $expired, $first ) );
+		switch_to_blog( $this->main_blog_id );
+		$this->assertTrue( update_option( EC_USERS_ARTIST_DISPATCH_LOCK_META . '_' . $user_id, $expired, false ) );
+		restore_current_blog();
 		$takeover = ec_users_acquire_artist_dispatch_lock( $user_id, 'takeover' );
-		$this->assertNotWPError( $takeover );
-		$this->assertNotSame( $first['owner_token'], $takeover['owner_token'] );
-		$this->assertFalse( ec_users_release_artist_dispatch_lock( $user_id, $first ) );
-		$this->assertTrue( ec_users_release_artist_dispatch_lock( $user_id, $takeover ) );
+		$this->assertWPError( $takeover );
+		$this->assertSame( 'artist_dispatch_lock_reconciliation_required', $takeover->get_error_code() );
+		$this->assertTrue( ec_users_release_artist_dispatch_lock( $user_id, $expired ) );
 	}
 
 	public function test_failed_state_writes_fail_closed_and_roll_back_role_changes(): void {

--- a/tests/unit/ArtistDispatchAccessTest.php
+++ b/tests/unit/ArtistDispatchAccessTest.php
@@ -13,6 +13,7 @@ class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
 
 	private int $main_blog_id;
 	private int $artist_blog_id;
+	private bool $registered_fake_analytics = false;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -22,14 +23,15 @@ class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
 
 		$this->main_blog_id   = ec_users_get_artist_dispatch_blog_id();
 		$this->artist_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : 0;
-		if ( ! is_multisite() || ! $this->artist_blog_id ) {
-			$this->markTestSkipped( 'Artist Dispatch tests require the multisite artist-site map.' );
-		}
+		$this->assertTrue( is_multisite(), 'Artist Dispatch tests require multisite.' );
+		$this->assertGreaterThan( 0, $this->artist_blog_id, 'The canonical artist-site map must be loaded.' );
 
 		$this->ensure_blog_exists( $this->main_blog_id );
 		$this->ensure_blog_exists( $this->artist_blog_id );
 		delete_site_option( EC_USERS_ARTIST_DISPATCH_POLICY_OPTION );
 		wp_set_current_user( 0 );
+		$GLOBALS['ec_artist_dispatch_test_analytics'] = array();
+		$this->register_fake_analytics_ability();
 
 		switch_to_blog( $this->main_blog_id );
 		remove_role( EC_USERS_ARTIST_DISPATCH_ROLE );
@@ -39,6 +41,10 @@ class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
 
 	protected function tearDown(): void {
 		delete_site_option( EC_USERS_ARTIST_DISPATCH_POLICY_OPTION );
+		if ( $this->registered_fake_analytics ) {
+			wp_unregister_ability( 'extrachill/track-analytics-event' );
+		}
+		unset( $GLOBALS['ec_artist_dispatch_test_analytics'] );
 		wp_set_current_user( 0 );
 		parent::tearDown();
 	}
@@ -62,6 +68,40 @@ class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
 		);
 	}
 
+	private function register_fake_analytics_ability(): void {
+		foreach (
+			array(
+				'EC_ANALYTICS_EVENT_ARTIST_DISPATCH_ACCESS_REQUESTED' => 'artist_dispatch_access_requested',
+				'EC_ANALYTICS_EVENT_ARTIST_DISPATCH_ACCESS_APPROVED'  => 'artist_dispatch_access_approved',
+				'EC_ANALYTICS_EVENT_ARTIST_DISPATCH_ACCESS_REJECTED'  => 'artist_dispatch_access_rejected',
+				'EC_ANALYTICS_EVENT_ARTIST_DISPATCH_ACCESS_REVOKED'   => 'artist_dispatch_access_revoked',
+			) as $constant => $value
+		) {
+			if ( ! defined( $constant ) ) {
+				define( $constant, $value );
+			}
+		}
+		if ( wp_has_ability( 'extrachill/track-analytics-event' ) ) {
+			return;
+		}
+		wp_register_ability(
+			'extrachill/track-analytics-event',
+			array(
+				'label'               => 'Test analytics',
+				'description'         => 'Captures bounded Artist Dispatch events.',
+				'category'            => 'extrachill-users',
+				'input_schema'        => array( 'type' => 'object' ),
+				'output_schema'       => array( 'type' => 'integer' ),
+				'permission_callback' => '__return_true',
+				'execute_callback'    => static function ( $input ) {
+					$GLOBALS['ec_artist_dispatch_test_analytics'][] = $input;
+					return count( $GLOBALS['ec_artist_dispatch_test_analytics'] );
+				},
+			)
+		);
+		$this->registered_fake_analytics = true;
+	}
+
 	private function create_eligible_user(): array {
 		$user_id = self::factory()->user->create(
 			array(
@@ -81,6 +121,7 @@ class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
 				'post_title'  => 'Lifecycle Artist',
 			)
 		);
+		update_post_meta( $artist_id, '_artist_member_ids', array( $user_id ) );
 		restore_current_blog();
 		update_user_meta( $user_id, '_artist_profile_ids', array( $artist_id ) );
 
@@ -135,6 +176,80 @@ class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
 
 		update_user_meta( $user_id, '_artist_profile_ids', array() );
 		$this->assertFalse( ec_users_get_artist_dispatch_eligibility( $user_id )['criteria']['claimed_artist']['passed'] );
+	}
+
+	public function test_canonical_artist_reads_require_valid_bidirectional_published_memberships(): void {
+		$user_id = self::factory()->user->create();
+		switch_to_blog( $this->artist_blog_id );
+		register_post_type( 'artist_profile', array( 'public' => true ) );
+		$valid_one  = self::factory()->post->create(
+			array(
+				'post_type'   => 'artist_profile',
+				'post_status' => 'publish',
+			)
+		);
+		$valid_two  = self::factory()->post->create(
+			array(
+				'post_type'   => 'artist_profile',
+				'post_status' => 'publish',
+			)
+		);
+		$one_sided  = self::factory()->post->create(
+			array(
+				'post_type'   => 'artist_profile',
+				'post_status' => 'publish',
+			)
+		);
+		$wrong_type = self::factory()->post->create(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			)
+		);
+		$private    = self::factory()->post->create(
+			array(
+				'post_type'   => 'artist_profile',
+				'post_status' => 'private',
+			)
+		);
+		$deleted    = self::factory()->post->create(
+			array(
+				'post_type'   => 'artist_profile',
+				'post_status' => 'publish',
+			)
+		);
+		update_post_meta( $valid_one, '_artist_member_ids', array( $user_id ) );
+		update_post_meta( $valid_two, '_artist_member_ids', array( (string) $user_id ) );
+		update_post_meta( $wrong_type, '_artist_member_ids', array( $user_id ) );
+		update_post_meta( $private, '_artist_member_ids', array( $user_id ) );
+		update_post_meta( $deleted, '_artist_member_ids', array( $user_id ) );
+		wp_delete_post( $deleted, true );
+		restore_current_blog();
+
+		update_user_meta( $user_id, '_artist_profile_ids', array( $valid_one, $one_sided, $wrong_type, $private, $deleted, $valid_two ) );
+		$this->assertSame( array( $valid_one, $valid_two ), ec_get_artists_for_user( $user_id ) );
+	}
+
+	public function test_artist_admin_override_still_returns_all_published_profiles(): void {
+		$admin_id = $this->create_network_admin();
+		switch_to_blog( $this->artist_blog_id );
+		register_post_type( 'artist_profile', array( 'public' => true ) );
+		$published = self::factory()->post->create(
+			array(
+				'post_type'   => 'artist_profile',
+				'post_status' => 'publish',
+			)
+		);
+		$private   = self::factory()->post->create(
+			array(
+				'post_type'   => 'artist_profile',
+				'post_status' => 'private',
+			)
+		);
+		restore_current_blog();
+		$result = ec_get_artists_for_user( $admin_id, true );
+		$this->assertContains( $published, $result );
+		$this->assertNotContains( $private, $result );
 	}
 
 	public function test_request_is_self_only_and_server_validates_selected_artist(): void {
@@ -218,6 +333,7 @@ class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
 			)
 		);
 		$this->assertNotWPError( $request );
+		$this->assertTrue( ec_users_is_artist_dispatch_request_id( $request['request_id'] ) );
 		$this->assertTrue( $request['terms_acknowledged'] );
 		$this->assertSame( EC_USERS_ARTIST_DISPATCH_TERMS_VERSION, $request['terms_version'] );
 		$this->assertGreaterThan( 0, $request['terms_accepted_at'] );
@@ -251,15 +367,57 @@ class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
 		$this->assertSame( EC_USERS_ARTIST_DISPATCH_TERMS_VERSION, ec_users_get_artist_dispatch_state( $user_id )['terms_version'] );
 	}
 
-	public function test_request_analytics_payload_is_bounded_and_contains_no_application_text(): void {
-		$payload = ec_users_get_artist_dispatch_requested_event_payload( 12, 34, EC_USERS_ARTIST_DISPATCH_TERMS_VERSION );
-		$this->assertSame( array( 'user_id', 'artist_id', 'terms_version', 'surface' ), array_keys( $payload ) );
-		$this->assertSame( 12, $payload['user_id'] );
-		$this->assertSame( 34, $payload['artist_id'] );
-		$this->assertSame( EC_USERS_ARTIST_DISPATCH_TERMS_VERSION, $payload['terms_version'] );
-		$this->assertSame( 'artist_dispatch', $payload['surface'] );
-		$this->assertArrayNotHasKey( 'description', $payload );
-		$this->assertArrayNotHasKey( 'sample_url', $payload );
+	public function test_all_lifecycle_analytics_payloads_match_owner_contract(): void {
+		$request_id = wp_generate_uuid4();
+		$this->assertMatchesRegularExpression( '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/', $request_id );
+		foreach ( array( 'requested', 'approved', 'rejected', 'revoked' ) as $event_type ) {
+			$this->assertNotSame( '', ec_users_get_artist_dispatch_analytics_event( $event_type ) );
+			$payload = ec_users_get_artist_dispatch_event_payload( 12, $request_id );
+			$this->assertSame( array( 'user_id', 'request_id' ), array_keys( $payload ) );
+			$this->assertSame( 12, $payload['user_id'] );
+			$this->assertSame( $request_id, $payload['request_id'] );
+		}
+		$this->assertSame( array(), ec_users_get_artist_dispatch_event_payload( 0, $request_id ) );
+		$this->assertSame( array( 'user_id' => 12 ), ec_users_get_artist_dispatch_event_payload( 12, 'not-a-uuid' ) );
+		$this->assertSame( array( 'user_id' => 12 ), ec_users_get_artist_dispatch_event_payload( 12, $request_id, 'free-text' ) );
+
+		$user_id = self::factory()->user->create();
+		$state   = array(
+			'status'     => 'pending',
+			'request_id' => $request_id,
+		);
+		$this->assertTrue( ec_users_write_artist_dispatch_state( $user_id, $state, array() ) );
+		$lock = ec_users_acquire_artist_dispatch_lock( $user_id, $request_id );
+		$this->assertNotWPError( $lock );
+		foreach ( array( 'requested', 'approved', 'rejected', 'revoked' ) as $event_type ) {
+			$state = ec_users_maybe_emit_artist_dispatch_event( $user_id, $event_type, $state );
+			$this->assertNotWPError( $state );
+		}
+		$state = ec_users_maybe_emit_artist_dispatch_event( $user_id, 'requested', $state );
+		ec_users_release_artist_dispatch_lock( $user_id, $lock );
+		$this->assertCount( 4, $state['deliveries']['analytics'] );
+		if ( $this->registered_fake_analytics ) {
+			$this->assertCount( 4, $GLOBALS['ec_artist_dispatch_test_analytics'] );
+			foreach ( $GLOBALS['ec_artist_dispatch_test_analytics'] as $event ) {
+				$this->assertSame( array( 'user_id', 'request_id' ), array_keys( $event['event_data'] ) );
+			}
+		}
+	}
+
+	public function test_ability_schemas_and_permissions_are_self_defending(): void {
+		$request = wp_get_ability( 'extrachill/request-artist-dispatch-access' );
+		$approve = wp_get_ability( 'extrachill/approve-artist-dispatch-access' );
+		$this->assertContains( 'acknowledgement', $request->get_input_schema()['required'] );
+		$this->assertContains( 'terms_version', $request->get_input_schema()['required'] );
+		$this->assertNotContains( 'user_id', array_keys( $request->get_input_schema()['properties'] ) );
+		wp_set_current_user( 0 );
+		$this->assertFalse( $request->check_permissions( array() ) );
+		$this->assertFalse( $approve->check_permissions( array() ) );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+		$this->assertTrue( $request->check_permissions( array() ) );
+		$this->assertFalse( $approve->check_permissions( array() ) );
+		$this->create_network_admin();
+		$this->assertTrue( $approve->check_permissions( array() ) );
 	}
 
 	public function test_role_capabilities_are_exact_and_main_site_only(): void {
@@ -326,7 +484,166 @@ class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
 		$this->assertNotWPError( $first );
 		$this->assertNotWPError( $second );
 		$this->assertCount( 2, get_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_AUDIT_META, false ) );
-		$this->assertCount( 1, $second['notifications'] );
+		$this->assertCount( 1, $second['deliveries']['notifications'] );
+		$this->assertCount( 2, $second['deliveries']['analytics'] );
+	}
+
+	public function test_lock_is_bounded_owned_and_supports_safe_expiry_takeover(): void {
+		$user_id = self::factory()->user->create();
+		$first   = ec_users_acquire_artist_dispatch_lock( $user_id, 'first' );
+		$this->assertNotWPError( $first );
+		$this->assertWPError( ec_users_acquire_artist_dispatch_lock( $user_id, 'concurrent' ) );
+		$expired               = $first;
+		$expired['expires_at'] = time() - 1;
+		$this->assertNotFalse( update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_LOCK_META, $expired, $first ) );
+		$takeover = ec_users_acquire_artist_dispatch_lock( $user_id, 'takeover' );
+		$this->assertNotWPError( $takeover );
+		$this->assertNotSame( $first['owner_token'], $takeover['owner_token'] );
+		$this->assertFalse( ec_users_release_artist_dispatch_lock( $user_id, $first ) );
+		$this->assertTrue( ec_users_release_artist_dispatch_lock( $user_id, $takeover ) );
+	}
+
+	public function test_failed_state_writes_fail_closed_and_roll_back_role_changes(): void {
+		$this->configure_policy();
+		list( $user_id, $artist_id ) = $this->create_eligible_user();
+		$block_add                   = static function ( $check, $object_id, $meta_key ) {
+			return EC_USERS_ARTIST_DISPATCH_STATE_META === $meta_key ? false : $check;
+		};
+		add_filter( 'add_user_metadata', $block_add, 10, 3 );
+		$failed_request = ec_users_request_artist_dispatch_access(
+			$user_id,
+			array(
+				'artist_id'       => $artist_id,
+				'description'     => str_repeat( 'A request whose state write must fail closed. ', 3 ),
+				'acknowledgement' => true,
+				'terms_version'   => EC_USERS_ARTIST_DISPATCH_TERMS_VERSION,
+			)
+		);
+		remove_filter( 'add_user_metadata', $block_add, 10 );
+		$this->assertWPError( $failed_request );
+		$this->assertSame( array(), ec_users_get_artist_dispatch_state( $user_id ) );
+
+		$request      = $this->request_access( $user_id, $artist_id );
+		$admin_id     = $this->create_network_admin();
+		$block_update = static function ( $check, $object_id, $meta_key ) {
+			return EC_USERS_ARTIST_DISPATCH_STATE_META === $meta_key ? false : $check;
+		};
+		add_filter( 'update_user_metadata', $block_update, 10, 3 );
+		$failed_approval = ec_users_approve_artist_dispatch_access( $user_id, $request['request_id'], '', $admin_id );
+		remove_filter( 'update_user_metadata', $block_update, 10 );
+		$this->assertWPError( $failed_approval );
+		$this->assertSame( 'pending', ec_users_get_artist_dispatch_state( $user_id )['status'] );
+		switch_to_blog( $this->main_blog_id );
+		$this->assertNotContains( EC_USERS_ARTIST_DISPATCH_ROLE, ( new WP_User( $user_id ) )->roles );
+		restore_current_blog();
+	}
+
+	public function test_pending_stale_terms_are_rejected_and_approved_access_can_renew(): void {
+		$this->configure_policy();
+		list( $user_id, $artist_id ) = $this->create_eligible_user();
+		$request                     = $this->request_access( $user_id, $artist_id );
+		$admin_id                    = $this->create_network_admin();
+		$stale                       = $request;
+		$stale['terms_version']      = '2026-01-01';
+		update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_STATE_META, $stale );
+		$this->assertWPError( ec_users_approve_artist_dispatch_access( $user_id, $request['request_id'], '', $admin_id ) );
+		switch_to_blog( $this->main_blog_id );
+		$this->assertNotContains( EC_USERS_ARTIST_DISPATCH_ROLE, ( new WP_User( $user_id ) )->roles );
+		restore_current_blog();
+
+		update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_STATE_META, $request );
+		$approved = ec_users_approve_artist_dispatch_access( $user_id, $request['request_id'], '', $admin_id );
+		$this->assertNotWPError( $approved );
+		$approved['terms_version'] = '2026-01-01';
+		update_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_STATE_META, $approved );
+		$safe = ec_users_get_artist_dispatch_safe_state( $user_id );
+		$this->assertTrue( $safe['terms_renewal_required'] );
+		$this->assertSame( '', $safe['terms_version'] );
+
+		wp_set_current_user( $user_id );
+		$renewed = extrachill_users_ability_request_artist_dispatch_access(
+			array(
+				'acknowledgement' => true,
+				'terms_version'   => EC_USERS_ARTIST_DISPATCH_TERMS_VERSION,
+			)
+		);
+		$this->assertNotWPError( $renewed );
+		$this->assertSame( 'approved', $renewed['status'] );
+		$this->assertSame( EC_USERS_ARTIST_DISPATCH_TERMS_VERSION, $renewed['terms_version'] );
+		$this->assertNotSame( $request['request_id'], $renewed['request_id'] );
+		switch_to_blog( $this->main_blog_id );
+		$this->assertContains( EC_USERS_ARTIST_DISPATCH_ROLE, ( new WP_User( $user_id ) )->roles );
+		restore_current_blog();
+		$this->assertContains( 'terms_renewed', wp_list_pluck( get_user_meta( $user_id, EC_USERS_ARTIST_DISPATCH_AUDIT_META, false ), 'event' ) );
+	}
+
+	public function test_failed_revocation_state_write_restores_role_and_approved_state(): void {
+		$this->configure_policy();
+		list( $user_id, $artist_id ) = $this->create_eligible_user();
+		$request                     = $this->request_access( $user_id, $artist_id );
+		$admin_id                    = $this->create_network_admin();
+		$this->assertNotWPError( ec_users_approve_artist_dispatch_access( $user_id, $request['request_id'], '', $admin_id ) );
+		$block_update = static function ( $check, $object_id, $meta_key ) {
+			return EC_USERS_ARTIST_DISPATCH_STATE_META === $meta_key ? false : $check;
+		};
+		add_filter( 'update_user_metadata', $block_update, 10, 3 );
+		$failed = ec_users_revoke_artist_dispatch_access( $user_id, $request['request_id'], 'Rollback test.', $admin_id );
+		remove_filter( 'update_user_metadata', $block_update, 10 );
+		$this->assertWPError( $failed );
+		$this->assertSame( 'approved', ec_users_get_artist_dispatch_state( $user_id )['status'] );
+		switch_to_blog( $this->main_blog_id );
+		$this->assertContains( EC_USERS_ARTIST_DISPATCH_ROLE, ( new WP_User( $user_id ) )->roles );
+		restore_current_blog();
+	}
+
+	public function test_actorless_notification_resolves_canonical_network_bot(): void {
+		$bot_id    = self::factory()->user->create();
+		$recipient = self::factory()->user->create();
+		$filter    = static fn() => $bot_id;
+		add_filter( 'extrachill_network_bot_user_id', $filter );
+		$this->assertSame( $bot_id, ec_users_resolve_artist_dispatch_notification_actor( 0 ) );
+		$state = array(
+			'status'     => 'approved',
+			'request_id' => wp_generate_uuid4(),
+			'artist_id'  => 123,
+		);
+		$this->assertTrue( ec_users_write_artist_dispatch_state( $recipient, $state, array() ) );
+		$lock = ec_users_acquire_artist_dispatch_lock( $recipient, $state['request_id'] );
+		$this->assertNotWPError( $lock );
+		$notified = ec_users_maybe_notify_artist_dispatch_transition( $recipient, 'approved', 0, $state );
+		$this->assertNotWPError( $notified );
+		$this->assertNotEmpty( $notified['deliveries']['notifications']['approved'] );
+		$retry = ec_users_maybe_notify_artist_dispatch_transition( $recipient, 'approved', 0, $notified );
+		$this->assertSame( $notified, $retry );
+		$without_marker = $notified;
+		unset( $without_marker['deliveries']['notifications']['approved'] );
+		$this->assertNotFalse( update_user_meta( $recipient, EC_USERS_ARTIST_DISPATCH_STATE_META, $without_marker, $notified ) );
+		$repaired = ec_users_maybe_notify_artist_dispatch_transition( $recipient, 'approved', 0, $without_marker );
+		$this->assertNotWPError( $repaired );
+		$this->assertNotEmpty( $repaired['deliveries']['notifications']['approved'] );
+		ec_users_release_artist_dispatch_lock( $recipient, $lock );
+		$notifications = ec_users_get_notifications( $recipient );
+		$this->assertSame( 1, $notifications['total'] );
+		$this->assertSame( $bot_id, $notifications['notifications'][0]['actor_id'] );
+		remove_filter( 'extrachill_network_bot_user_id', $filter );
+	}
+
+	public function test_failed_notification_does_not_write_delivery_marker(): void {
+		$recipient = self::factory()->user->create();
+		$state     = array(
+			'status'     => 'approved',
+			'request_id' => wp_generate_uuid4(),
+		);
+		$this->assertTrue( ec_users_write_artist_dispatch_state( $recipient, $state, array() ) );
+		$no_bot = static fn() => 0;
+		add_filter( 'extrachill_network_bot_user_id', $no_bot );
+		$lock   = ec_users_acquire_artist_dispatch_lock( $recipient, $state['request_id'] );
+		$this->assertNotWPError( $lock );
+		$result = ec_users_maybe_notify_artist_dispatch_transition( $recipient, 'approved', 0, $state );
+		$this->assertWPError( $result );
+		$this->assertArrayNotHasKey( 'deliveries', ec_users_get_artist_dispatch_state( $recipient ) );
+		ec_users_release_artist_dispatch_lock( $recipient, $lock );
+		remove_filter( 'extrachill_network_bot_user_id', $no_bot );
 	}
 
 	public function test_revocation_removes_only_product_grant_and_cleans_grant_created_membership(): void {
@@ -346,6 +663,10 @@ class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
 
 	public function test_moderation_blocks_request_and_revokes_without_automatic_restore(): void {
 		$this->configure_policy();
+		update_site_option(
+			EC_USERS_ARTIST_DISPATCH_POLICY_OPTION,
+			array_merge( ec_users_get_artist_dispatch_policy(), array( 'require_active_moderation' => false ) )
+		);
 		list( $user_id, $artist_id ) = $this->create_eligible_user();
 		$admin_id                    = $this->create_network_admin();
 		extrachill_users_apply_moderation_action(
@@ -357,6 +678,7 @@ class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
 			)
 		);
 		$this->assertFalse( ec_users_get_artist_dispatch_eligibility( $user_id )['eligible'] );
+		$this->assertArrayNotHasKey( 'require_active_moderation', ec_users_get_artist_dispatch_policy() );
 		$this->assertWPError(
 			ec_users_request_artist_dispatch_access(
 				$user_id,
@@ -371,7 +693,17 @@ class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
 
 		extrachill_users_clear_moderation_action( $user_id );
 		$request = $this->request_access( $user_id, $artist_id );
-		ec_users_approve_artist_dispatch_access( $user_id, $request['request_id'], '', $admin_id );
+		extrachill_users_apply_moderation_action(
+			$user_id,
+			array(
+				'reason_key' => 'other',
+				'reason'     => 'Approval hold',
+				'acted_by'   => $admin_id,
+			)
+		);
+		$this->assertWPError( ec_users_approve_artist_dispatch_access( $user_id, $request['request_id'], '', $admin_id ) );
+		extrachill_users_clear_moderation_action( $user_id );
+		$this->assertNotWPError( ec_users_approve_artist_dispatch_access( $user_id, $request['request_id'], '', $admin_id ) );
 		extrachill_users_apply_moderation_action(
 			$user_id,
 			array(


### PR DESCRIPTION
## Summary
- add the main-site-only Artist Dispatch contributor role and audited request, approval, rejection, revocation, and terms-renewal lifecycle
- enforce points as request eligibility while native WordPress capabilities remain the post authorization boundary
- harden the network-owned artist membership reader to require published artist profiles with bidirectional membership
- add self-service abilities, protected operator abilities, network-admin policy UI, moderation revocation, notifications, and canonical analytics events

## Security and consistency
- self operations derive the current user and administrative callbacks repeat their authorization checks
- active moderation unconditionally blocks requests and approvals; moderation revocation failures propagate
- terms acknowledgement and exact version are audited; stale approved access can re-acknowledge without role churn
- role grants are additive on blog 1 and scoped revocation preserves unrelated roles and posts
- transition locks and delivery reservations use unique main-site option keys with atomic INSERT IGNORE ownership
- expired or ambiguous operations fail closed for operator reconciliation instead of risking duplicate side effects
- analytics payloads contain only bounded user ID and canonical request UUID values from Analytics PR #209
- notifications and analytics reserve, finalize, and reconcile durable delivery receipts

## Verification
- PHP syntax checks passed for all changed production and test files
- git diff --check passed
- Homeboy changed-file lint passed with zero findings after final corrections
- focused PHPUnit coverage was added for eligibility, membership integrity, role isolation, ability authorization, terms renewal, moderation, lock ownership, failed writes, notification behavior, and analytics contracts
- the WP Codebox PHPUnit backend previously stalled without artifacts, so full suite execution still requires CI confirmation

Closes #210