### PR TITLE
fix: declare compiled block release scope

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -6,6 +6,13 @@
   },
   "id": "extrachill-users",
   "remote_path": "wp-content/plugins/extrachill-users",
+  "scopes": {
+    "release": {
+      "exclude": [
+        "blocks/**"
+      ]
+    }
+  },
   "version_targets": [
     {
       "file": "extrachill-users.php",


### PR DESCRIPTION
## Summary
- exclude tracked block source trees from release completeness because the package ships their compiled build outputs
- retain package validation for the rest of the runtime artifact

Closes #213