### PR TITLE
feat: add idempotent concert attendance contract

### DIFF
--- a/inc/core/abilities/concert-tracking.php
+++ b/inc/core/abilities/concert-tracking.php
@@ -14,6 +14,37 @@ defined( 'ABSPATH' ) || exit;
 add_action( 'wp_abilities_api_init', 'extrachill_users_register_concert_tracking_abilities' );
 
 /**
+ * Check whether the current user may set attendance for the requested user.
+ *
+ * @param array $input Validated ability input.
+ * @return bool
+ */
+function extrachill_users_can_set_event_mark( array $input ): bool {
+	$current_user_id = get_current_user_id();
+	if ( ! $current_user_id ) {
+		return false;
+	}
+
+	$target_user_id = ! empty( $input['user_id'] ) ? (int) $input['user_id'] : $current_user_id;
+
+	return $target_user_id === $current_user_id || current_user_can( 'manage_network_options' );
+}
+
+/**
+ * Keep untargeted event attendance public while authorizing targeted reads.
+ *
+ * @param array $input Validated ability input.
+ * @return bool
+ */
+function extrachill_users_can_get_event_attendance( array $input ): bool {
+	if ( empty( $input['user_id'] ) ) {
+		return true;
+	}
+
+	return extrachill_users_can_set_event_mark( $input );
+}
+
+/**
  * Register concert tracking abilities.
  */
 function extrachill_users_register_concert_tracking_abilities() {
@@ -60,9 +91,10 @@ function extrachill_users_register_concert_tracking_abilities() {
 					'count_label' => array( 'type' => 'string' ),
 					'timing'      => array( 'type' => 'string' ),
 				),
+				'required'   => array( 'user_id', 'marked', 'changed', 'count', 'count_label', 'timing' ),
 			),
 			'execute_callback'    => 'extrachill_users_ability_set_event_mark',
-			'permission_callback' => 'is_user_logged_in',
+			'permission_callback' => 'extrachill_users_can_set_event_mark',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -346,9 +378,10 @@ function extrachill_users_register_concert_tracking_abilities() {
 					'user_marked' => array( 'type' => 'boolean' ),
 					'attendees'   => array( 'type' => 'array' ),
 				),
+				'required'   => array( 'count', 'count_label', 'timing', 'user_marked', 'attendees' ),
 			),
 			'execute_callback'    => 'extrachill_users_ability_get_event_attendance',
-			'permission_callback' => '__return_true',
+			'permission_callback' => 'extrachill_users_can_get_event_attendance',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -396,19 +429,28 @@ function extrachill_users_ability_set_event_mark( array $input ) {
 		return $user_id;
 	}
 
-	$event_id = (int) $input['event_id'];
-	$blog_id  = ! empty( $input['blog_id'] ) ? (int) $input['blog_id'] : ( function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : get_current_blog_id() );
-	$marked   = (bool) $input['marked'];
-	$changed  = $marked
+	$event_id     = (int) $input['event_id'];
+	$blog_id      = ! empty( $input['blog_id'] ) ? (int) $input['blog_id'] : ( function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : get_current_blog_id() );
+	$marked       = (bool) $input['marked'];
+	$write_result = $marked
 		? ec_users_mark_event( $user_id, $event_id, $blog_id )
 		: ec_users_unmark_event( $user_id, $event_id, $blog_id );
-	$count    = ec_users_get_event_mark_count( $event_id, $blog_id );
-	$timing   = ec_users_get_event_timing( $event_id );
+	if ( is_wp_error( $write_result ) ) {
+		return $write_result;
+	}
+
+	$stored_marked = ec_users_is_event_marked( $user_id, $event_id, $blog_id );
+	if ( $stored_marked !== $marked ) {
+		return new WP_Error( 'event_mark_write_failed', 'The requested concert attendance state could not be saved.', array( 'status' => 500 ) );
+	}
+
+	$count  = ec_users_get_event_mark_count( $event_id, $blog_id );
+	$timing = ec_users_get_event_timing( $event_id );
 
 	return array(
 		'user_id'     => $user_id,
 		'marked'      => $marked,
-		'changed'     => $changed,
+		'changed'     => (bool) $write_result,
 		'count'       => $count,
 		'count_label' => ec_users_format_count_label( $count, $timing ),
 		'timing'      => $timing,

--- a/inc/core/abilities/concert-tracking.php
+++ b/inc/core/abilities/concert-tracking.php
@@ -18,6 +18,62 @@ add_action( 'wp_abilities_api_init', 'extrachill_users_register_concert_tracking
  */
 function extrachill_users_register_concert_tracking_abilities() {
 
+	// ─── Set Event Mark ────────────────────────────────────────────────────────
+
+	wp_register_ability(
+		'extrachill/set-event-mark',
+		array(
+			'label'               => __( 'Set Event Mark', 'extrachill-users' ),
+			'description'         => __( 'Idempotently mark or unmark an event for the current user, or for another user when authorized.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id'  => array(
+						'type'        => 'integer',
+						'description' => 'User ID. Defaults to current user. Targeting another user requires network administration permission.',
+						'default'     => 0,
+					),
+					'event_id' => array(
+						'type'        => 'integer',
+						'description' => 'Event post ID.',
+					),
+					'blog_id'  => array(
+						'type'        => 'integer',
+						'description' => 'Blog ID. Defaults to events blog.',
+						'default'     => 0,
+					),
+					'marked'   => array(
+						'type'        => 'boolean',
+						'description' => 'Desired attendance state.',
+					),
+				),
+				'required'   => array( 'event_id', 'marked' ),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id'     => array( 'type' => 'integer' ),
+					'marked'      => array( 'type' => 'boolean' ),
+					'changed'     => array( 'type' => 'boolean' ),
+					'count'       => array( 'type' => 'integer' ),
+					'count_label' => array( 'type' => 'string' ),
+					'timing'      => array( 'type' => 'string' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_users_ability_set_event_mark',
+			'permission_callback' => 'is_user_logged_in',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+
 	// ─── Mark / Unmark Event ─────────────────────────────────────────────────
 
 	wp_register_ability(
@@ -254,6 +310,11 @@ function extrachill_users_register_concert_tracking_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
+					'user_id'           => array(
+						'type'        => 'integer',
+						'description' => 'User ID whose mark state to return. Defaults to current user. Targeting another user requires network administration permission.',
+						'default'     => 0,
+					),
 					'event_id'          => array(
 						'type'        => 'integer',
 						'description' => 'Event post ID.',
@@ -301,6 +362,58 @@ function extrachill_users_register_concert_tracking_abilities() {
 }
 
 // ─── Execute Callbacks ───────────────────────────────────────────────────────
+
+/**
+ * Resolve and authorize the user targeted by a concert tracking ability.
+ *
+ * @param array $input Ability input.
+ * @return int|WP_Error
+ */
+function extrachill_users_resolve_concert_tracking_user( array $input ) {
+	$current_user_id = get_current_user_id();
+	$user_id         = ! empty( $input['user_id'] ) ? (int) $input['user_id'] : $current_user_id;
+
+	if ( ! $user_id || ! get_userdata( $user_id ) ) {
+		return new WP_Error( 'no_user', 'A valid user ID is required.', array( 'status' => 400 ) );
+	}
+
+	if ( $user_id !== $current_user_id && ! current_user_can( 'manage_network_options' ) ) {
+		return new WP_Error( 'forbidden_user_target', 'You are not authorized to manage concert attendance for this user.', array( 'status' => 403 ) );
+	}
+
+	return $user_id;
+}
+
+/**
+ * Set event mark ability callback.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_set_event_mark( array $input ) {
+	$user_id = extrachill_users_resolve_concert_tracking_user( $input );
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
+
+	$event_id = (int) $input['event_id'];
+	$blog_id  = ! empty( $input['blog_id'] ) ? (int) $input['blog_id'] : ( function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : get_current_blog_id() );
+	$marked   = (bool) $input['marked'];
+	$changed  = $marked
+		? ec_users_mark_event( $user_id, $event_id, $blog_id )
+		: ec_users_unmark_event( $user_id, $event_id, $blog_id );
+	$count    = ec_users_get_event_mark_count( $event_id, $blog_id );
+	$timing   = ec_users_get_event_timing( $event_id );
+
+	return array(
+		'user_id'     => $user_id,
+		'marked'      => $marked,
+		'changed'     => $changed,
+		'count'       => $count,
+		'count_label' => ec_users_format_count_label( $count, $timing ),
+		'timing'      => $timing,
+	);
+}
 
 /**
  * Toggle event mark ability callback.
@@ -388,9 +501,19 @@ function extrachill_users_ability_search_events_for_marking( array $input ) {
  * Get event attendance ability callback.
  *
  * @param array $input Ability input.
- * @return array
+ * @return array|WP_Error
  */
 function extrachill_users_ability_get_event_attendance( array $input ) {
+	$user_id = 0;
+	if ( ! empty( $input['user_id'] ) ) {
+		$user_id = extrachill_users_resolve_concert_tracking_user( $input );
+		if ( is_wp_error( $user_id ) ) {
+			return $user_id;
+		}
+	} elseif ( is_user_logged_in() ) {
+		$user_id = get_current_user_id();
+	}
+
 	$event_id = (int) $input['event_id'];
 	$blog_id  = ! empty( $input['blog_id'] ) ? (int) $input['blog_id'] : ( function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : get_current_blog_id() );
 
@@ -405,8 +528,8 @@ function extrachill_users_ability_get_event_attendance( array $input ) {
 		'attendees'   => array(),
 	);
 
-	if ( is_user_logged_in() ) {
-		$result['user_marked'] = ec_users_is_event_marked( get_current_user_id(), $event_id, $blog_id );
+	if ( $user_id ) {
+		$result['user_marked'] = ec_users_is_event_marked( $user_id, $event_id, $blog_id );
 	}
 
 	if ( ! empty( $input['include_attendees'] ) ) {

--- a/inc/core/abilities/concert-tracking.php
+++ b/inc/core/abilities/concert-tracking.php
@@ -439,11 +439,6 @@ function extrachill_users_ability_set_event_mark( array $input ) {
 		return $write_result;
 	}
 
-	$stored_marked = ec_users_is_event_marked( $user_id, $event_id, $blog_id );
-	if ( $stored_marked !== $marked ) {
-		return new WP_Error( 'event_mark_write_failed', 'The requested concert attendance state could not be saved.', array( 'status' => 500 ) );
-	}
-
 	$count  = ec_users_get_event_mark_count( $event_id, $blog_id );
 	$timing = ec_users_get_event_timing( $event_id );
 

--- a/tests/unit/ConcertTrackingAbilitiesTest.php
+++ b/tests/unit/ConcertTrackingAbilitiesTest.php
@@ -5,102 +5,246 @@
  * @package ExtraChill\Users
  */
 
+/**
+ * Exercise concert attendance through registered WP_Ability contracts.
+ */
 class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
+
+	private int $events_blog_id;
+
+	private int $event_id;
+
+	private int $user_id;
 
 	protected function setUp(): void {
 		parent::setUp();
+		$this->events_blog_id = self::factory()->blog->create();
+		$this->user_id        = self::factory()->user->create();
+
+		add_filter( 'extrachill_users_events_blog_id', array( $this, 'filter_events_blog_id' ) );
+		if ( ! post_type_exists( 'data_machine_events' ) ) {
+			register_post_type( 'data_machine_events', array( 'public' => true ) );
+		}
+
+		switch_to_blog( $this->events_blog_id );
+		try {
+			$this->event_id = self::factory()->post->create(
+				array(
+					'post_type'   => 'data_machine_events',
+					'post_status' => 'publish',
+				)
+			);
+		} finally {
+			restore_current_blog();
+		}
+
 		extrachill_users_install_concert_tracking_table();
+		$this->clear_tracking_table();
+		wp_set_current_user( $this->user_id );
 	}
 
-	public function test_set_event_mark_is_idempotent_in_both_directions(): void {
-		$user_id = self::factory()->user->create();
-		wp_set_current_user( $user_id );
+	protected function tearDown(): void {
+		$this->clear_tracking_table();
+		remove_filter( 'extrachill_users_events_blog_id', array( $this, 'filter_events_blog_id' ) );
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
 
-		$first_mark  = extrachill_users_ability_set_event_mark( array( 'event_id' => 101, 'blog_id' => 7, 'marked' => true ) );
-		$second_mark = extrachill_users_ability_set_event_mark( array( 'event_id' => 101, 'blog_id' => 7, 'marked' => true ) );
+	public function filter_events_blog_id(): int {
+		return $this->events_blog_id;
+	}
 
+	public function test_registered_set_ability_validates_input_and_declares_stable_output(): void {
+		$ability = wp_get_ability( 'extrachill/set-event-mark' );
+
+		$this->assertInstanceOf( WP_Ability::class, $ability );
+		$this->assertSame(
+			array( 'user_id', 'marked', 'changed', 'count', 'count_label', 'timing' ),
+			$ability->get_output_schema()['required']
+		);
+		$this->assertSame( 0, $ability->get_input_schema()['properties']['user_id']['default'] );
+		$this->assertSame( 0, $ability->get_input_schema()['properties']['blog_id']['default'] );
+
+		$result = $ability->execute(
+			array(
+				'event_id' => $this->event_id,
+				'blog_id'  => $this->events_blog_id,
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'ability_invalid_input', $result->get_error_code() );
+	}
+
+	public function test_registered_set_ability_is_idempotent_in_both_directions(): void {
+		$ability = wp_get_ability( 'extrachill/set-event-mark' );
+		$input   = array(
+			'event_id' => $this->event_id,
+			'blog_id'  => $this->events_blog_id,
+			'marked'   => true,
+		);
+
+		$first_mark  = $ability->execute( $input );
+		$second_mark = $ability->execute( $input );
+
+		$this->assertFalse( is_wp_error( $first_mark ) );
+		$this->assertSame( $this->user_id, $first_mark['user_id'], 'Omitted user_id must default to the current user.' );
 		$this->assertTrue( $first_mark['changed'] );
 		$this->assertTrue( $first_mark['marked'] );
 		$this->assertFalse( $second_mark['changed'] );
 		$this->assertTrue( $second_mark['marked'] );
-		$this->assertTrue( ec_users_is_event_marked( $user_id, 101, 7 ) );
 
-		$first_unmark  = extrachill_users_ability_set_event_mark( array( 'event_id' => 101, 'blog_id' => 7, 'marked' => false ) );
-		$second_unmark = extrachill_users_ability_set_event_mark( array( 'event_id' => 101, 'blog_id' => 7, 'marked' => false ) );
+		$input['marked'] = false;
+		$first_unmark    = $ability->execute( $input );
+		$second_unmark   = $ability->execute( $input );
 
 		$this->assertTrue( $first_unmark['changed'] );
 		$this->assertFalse( $first_unmark['marked'] );
 		$this->assertFalse( $second_unmark['changed'] );
 		$this->assertFalse( $second_unmark['marked'] );
-		$this->assertFalse( ec_users_is_event_marked( $user_id, 101, 7 ) );
 	}
 
-	public function test_network_administrator_can_target_another_user(): void {
+	public function test_registered_set_ability_enforces_self_admin_and_unauthenticated_permissions(): void {
+		$ability        = wp_get_ability( 'extrachill/set-event-mark' );
+		$target_user_id = self::factory()->user->create();
+		$input          = array(
+			'user_id'  => $target_user_id,
+			'event_id' => $this->event_id,
+			'blog_id'  => $this->events_blog_id,
+			'marked'   => true,
+		);
+
+		$denied = $ability->execute( $input );
+		$this->assertWPError( $denied );
+		$this->assertSame( 'ability_invalid_permissions', $denied->get_error_code() );
+
 		$administrator_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
-		$target_user_id    = self::factory()->user->create();
 		grant_super_admin( $administrator_id );
 		wp_set_current_user( $administrator_id );
-
-		$result = extrachill_users_ability_set_event_mark(
-			array(
-				'user_id'  => $target_user_id,
-				'event_id' => 102,
-				'blog_id'  => 7,
-				'marked'   => true,
-			)
-		);
-
-		$this->assertFalse( is_wp_error( $result ) );
-		$this->assertSame( $target_user_id, $result['user_id'] );
-		$this->assertTrue( ec_users_is_event_marked( $target_user_id, 102, 7 ) );
+		$allowed = $ability->execute( $input );
+		$this->assertFalse( is_wp_error( $allowed ) );
+		$this->assertSame( $target_user_id, $allowed['user_id'] );
 		revoke_super_admin( $administrator_id );
-	}
 
-	public function test_regular_user_cannot_target_another_user(): void {
-		$current_user_id = self::factory()->user->create();
-		$target_user_id  = self::factory()->user->create();
-		wp_set_current_user( $current_user_id );
-
-		$result = extrachill_users_ability_set_event_mark(
-			array(
-				'user_id'  => $target_user_id,
-				'event_id' => 103,
-				'blog_id'  => 7,
-				'marked'   => true,
-			)
-		);
-
-		$this->assertWPError( $result );
-		$this->assertSame( 'forbidden_user_target', $result->get_error_code() );
-		$this->assertFalse( ec_users_is_event_marked( $target_user_id, 103, 7 ) );
-	}
-
-	public function test_targeted_attendance_check_is_read_only(): void {
-		$administrator_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
-		$target_user_id    = self::factory()->user->create();
-		grant_super_admin( $administrator_id );
-		ec_users_mark_event( $target_user_id, 104, 7 );
-		wp_set_current_user( $administrator_id );
-
-		$before = ec_users_get_event_mark_count( 104, 7 );
-		$result = extrachill_users_ability_get_event_attendance(
-			array(
-				'user_id'  => $target_user_id,
-				'event_id' => 104,
-				'blog_id'  => 7,
-			)
-		);
-
-		$this->assertTrue( $result['user_marked'] );
-		$this->assertSame( $before, ec_users_get_event_mark_count( 104, 7 ) );
-		revoke_super_admin( $administrator_id );
-	}
-
-	public function test_unauthenticated_set_requires_a_user(): void {
 		wp_set_current_user( 0 );
-		$result = extrachill_users_ability_set_event_mark( array( 'event_id' => 105, 'blog_id' => 7, 'marked' => true ) );
+		$unauthenticated = $ability->execute( $input );
+		$this->assertWPError( $unauthenticated );
+		$this->assertSame( 'ability_invalid_permissions', $unauthenticated->get_error_code() );
+	}
 
-		$this->assertWPError( $result );
-		$this->assertSame( 'no_user', $result->get_error_code() );
+	public function test_registered_attendance_ability_preserves_public_reads_and_authorizes_targets(): void {
+		$ability = wp_get_ability( 'extrachill/get-event-attendance' );
+		$this->assertSame(
+			array( 'count', 'count_label', 'timing', 'user_marked', 'attendees' ),
+			$ability->get_output_schema()['required']
+		);
+
+		wp_set_current_user( 0 );
+		$public = $ability->execute(
+			array(
+				'event_id' => $this->event_id,
+				'blog_id'  => $this->events_blog_id,
+			)
+		);
+		$this->assertFalse( is_wp_error( $public ) );
+		$this->assertFalse( $public['user_marked'] );
+
+		$targeted = $ability->execute(
+			array(
+				'user_id'  => $this->user_id,
+				'event_id' => $this->event_id,
+				'blog_id'  => $this->events_blog_id,
+			)
+		);
+		$this->assertWPError( $targeted );
+		$this->assertSame( 'ability_invalid_permissions', $targeted->get_error_code() );
+
+		wp_set_current_user( $this->user_id );
+		$other_user_id = self::factory()->user->create();
+		$denied        = $ability->execute(
+			array(
+				'user_id'  => $other_user_id,
+				'event_id' => $this->event_id,
+				'blog_id'  => $this->events_blog_id,
+			)
+		);
+		$this->assertWPError( $denied );
+		$this->assertSame( 'ability_invalid_permissions', $denied->get_error_code() );
+
+		$self = $ability->execute(
+			array(
+				'user_id'  => $this->user_id,
+				'event_id' => $this->event_id,
+				'blog_id'  => $this->events_blog_id,
+			)
+		);
+		$this->assertFalse( is_wp_error( $self ) );
+
+		$administrator_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $administrator_id );
+		wp_set_current_user( $administrator_id );
+		$admin = $ability->execute(
+			array(
+				'user_id'  => $other_user_id,
+				'event_id' => $this->event_id,
+				'blog_id'  => $this->events_blog_id,
+			)
+		);
+		$this->assertFalse( is_wp_error( $admin ) );
+		revoke_super_admin( $administrator_id );
+	}
+
+	public function test_registered_set_ability_reports_insert_and_delete_failures(): void {
+		global $wpdb;
+		$ability = wp_get_ability( 'extrachill/set-event-mark' );
+		$input   = array(
+			'event_id' => $this->event_id,
+			'blog_id'  => $this->events_blog_id,
+			'marked'   => true,
+		);
+		get_post( $this->event_id );
+
+		$previous_suppress = $wpdb->suppress_errors( true );
+		add_filter( 'query', array( $this, 'fail_tracking_writes' ) );
+		try {
+			$failed_insert = $ability->execute( $input );
+		} finally {
+			remove_filter( 'query', array( $this, 'fail_tracking_writes' ) );
+			$wpdb->suppress_errors( $previous_suppress );
+		}
+
+		$this->assertWPError( $failed_insert );
+		$this->assertSame( 'event_mark_write_failed', $failed_insert->get_error_code() );
+		$this->assertFalse( ec_users_is_event_marked( $this->user_id, $this->event_id, $this->events_blog_id ) );
+
+		$this->assertFalse( is_wp_error( $ability->execute( $input ) ) );
+		$input['marked']   = false;
+		$previous_suppress = $wpdb->suppress_errors( true );
+		add_filter( 'query', array( $this, 'fail_tracking_writes' ) );
+		try {
+			$failed_delete = $ability->execute( $input );
+		} finally {
+			remove_filter( 'query', array( $this, 'fail_tracking_writes' ) );
+			$wpdb->suppress_errors( $previous_suppress );
+		}
+
+		$this->assertWPError( $failed_delete );
+		$this->assertSame( 'event_mark_write_failed', $failed_delete->get_error_code() );
+		$this->assertTrue( ec_users_is_event_marked( $this->user_id, $this->event_id, $this->events_blog_id ) );
+	}
+
+	public function fail_tracking_writes( string $query ): string {
+		$table = extrachill_users_concert_tracking_table_name();
+		if ( preg_match( '/^(INSERT INTO|DELETE FROM)\s+`?' . preg_quote( $table, '/' ) . '`?/i', $query ) ) {
+			return str_replace( $table, $table . '_missing', $query );
+		}
+
+		return $query;
+	}
+
+	private function clear_tracking_table(): void {
+		global $wpdb;
+		$table = extrachill_users_concert_tracking_table_name();
+		$wpdb->query( "DELETE FROM {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- trusted table helper.
 	}
 }

--- a/tests/unit/ConcertTrackingAbilitiesTest.php
+++ b/tests/unit/ConcertTrackingAbilitiesTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Tests for explicit, idempotent concert attendance abilities.
+ *
+ * @package ExtraChill\Users
+ */
+
+class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		extrachill_users_install_concert_tracking_table();
+	}
+
+	public function test_set_event_mark_is_idempotent_in_both_directions(): void {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+
+		$first_mark  = extrachill_users_ability_set_event_mark( array( 'event_id' => 101, 'blog_id' => 7, 'marked' => true ) );
+		$second_mark = extrachill_users_ability_set_event_mark( array( 'event_id' => 101, 'blog_id' => 7, 'marked' => true ) );
+
+		$this->assertTrue( $first_mark['changed'] );
+		$this->assertTrue( $first_mark['marked'] );
+		$this->assertFalse( $second_mark['changed'] );
+		$this->assertTrue( $second_mark['marked'] );
+		$this->assertTrue( ec_users_is_event_marked( $user_id, 101, 7 ) );
+
+		$first_unmark  = extrachill_users_ability_set_event_mark( array( 'event_id' => 101, 'blog_id' => 7, 'marked' => false ) );
+		$second_unmark = extrachill_users_ability_set_event_mark( array( 'event_id' => 101, 'blog_id' => 7, 'marked' => false ) );
+
+		$this->assertTrue( $first_unmark['changed'] );
+		$this->assertFalse( $first_unmark['marked'] );
+		$this->assertFalse( $second_unmark['changed'] );
+		$this->assertFalse( $second_unmark['marked'] );
+		$this->assertFalse( ec_users_is_event_marked( $user_id, 101, 7 ) );
+	}
+
+	public function test_network_administrator_can_target_another_user(): void {
+		$administrator_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$target_user_id    = self::factory()->user->create();
+		grant_super_admin( $administrator_id );
+		wp_set_current_user( $administrator_id );
+
+		$result = extrachill_users_ability_set_event_mark(
+			array(
+				'user_id'  => $target_user_id,
+				'event_id' => 102,
+				'blog_id'  => 7,
+				'marked'   => true,
+			)
+		);
+
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertSame( $target_user_id, $result['user_id'] );
+		$this->assertTrue( ec_users_is_event_marked( $target_user_id, 102, 7 ) );
+		revoke_super_admin( $administrator_id );
+	}
+
+	public function test_regular_user_cannot_target_another_user(): void {
+		$current_user_id = self::factory()->user->create();
+		$target_user_id  = self::factory()->user->create();
+		wp_set_current_user( $current_user_id );
+
+		$result = extrachill_users_ability_set_event_mark(
+			array(
+				'user_id'  => $target_user_id,
+				'event_id' => 103,
+				'blog_id'  => 7,
+				'marked'   => true,
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'forbidden_user_target', $result->get_error_code() );
+		$this->assertFalse( ec_users_is_event_marked( $target_user_id, 103, 7 ) );
+	}
+
+	public function test_targeted_attendance_check_is_read_only(): void {
+		$administrator_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$target_user_id    = self::factory()->user->create();
+		grant_super_admin( $administrator_id );
+		ec_users_mark_event( $target_user_id, 104, 7 );
+		wp_set_current_user( $administrator_id );
+
+		$before = ec_users_get_event_mark_count( 104, 7 );
+		$result = extrachill_users_ability_get_event_attendance(
+			array(
+				'user_id'  => $target_user_id,
+				'event_id' => 104,
+				'blog_id'  => 7,
+			)
+		);
+
+		$this->assertTrue( $result['user_marked'] );
+		$this->assertSame( $before, ec_users_get_event_mark_count( 104, 7 ) );
+		revoke_super_admin( $administrator_id );
+	}
+
+	public function test_unauthenticated_set_requires_a_user(): void {
+		wp_set_current_user( 0 );
+		$result = extrachill_users_ability_set_event_mark( array( 'event_id' => 105, 'blog_id' => 7, 'marked' => true ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'no_user', $result->get_error_code() );
+	}
+}

--- a/tests/unit/ConcertTrackingAbilitiesTest.php
+++ b/tests/unit/ConcertTrackingAbilitiesTest.php
@@ -132,6 +132,41 @@ class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
 		$this->assertSame( 'ability_invalid_permissions', $unauthenticated->get_error_code() );
 	}
 
+	public function test_registered_set_ability_propagates_canonical_target_validation(): void {
+		$ability = wp_get_ability( 'extrachill/set-event-mark' );
+		$missing = $ability->execute(
+			array(
+				'event_id' => 999999,
+				'blog_id'  => $this->events_blog_id,
+				'marked'   => true,
+			)
+		);
+		$this->assertWPError( $missing );
+		$this->assertSame( 'event_not_found', $missing->get_error_code() );
+
+		$wrong_type_id = $this->create_event( 'post', 'publish' );
+		$wrong_type    = $ability->execute(
+			array(
+				'event_id' => $wrong_type_id,
+				'blog_id'  => $this->events_blog_id,
+				'marked'   => true,
+			)
+		);
+		$this->assertWPError( $wrong_type );
+		$this->assertSame( 'invalid_event_post_type', $wrong_type->get_error_code() );
+
+		$draft_event_id = $this->create_event( 'data_machine_events', 'draft' );
+		$unpublished    = $ability->execute(
+			array(
+				'event_id' => $draft_event_id,
+				'blog_id'  => $this->events_blog_id,
+				'marked'   => true,
+			)
+		);
+		$this->assertWPError( $unpublished );
+		$this->assertSame( 'event_not_published', $unpublished->get_error_code() );
+	}
+
 	public function test_registered_attendance_ability_preserves_public_reads_and_authorizes_targets(): void {
 		$ability = wp_get_ability( 'extrachill/get-event-attendance' );
 		$this->assertSame(
@@ -214,7 +249,7 @@ class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
 		}
 
 		$this->assertWPError( $failed_insert );
-		$this->assertSame( 'event_mark_write_failed', $failed_insert->get_error_code() );
+		$this->assertSame( 'event_mark_database_error', $failed_insert->get_error_code() );
 		$this->assertFalse( ec_users_is_event_marked( $this->user_id, $this->event_id, $this->events_blog_id ) );
 
 		$this->assertFalse( is_wp_error( $ability->execute( $input ) ) );
@@ -229,17 +264,31 @@ class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
 		}
 
 		$this->assertWPError( $failed_delete );
-		$this->assertSame( 'event_mark_write_failed', $failed_delete->get_error_code() );
+		$this->assertSame( 'event_unmark_database_error', $failed_delete->get_error_code() );
 		$this->assertTrue( ec_users_is_event_marked( $this->user_id, $this->event_id, $this->events_blog_id ) );
 	}
 
 	public function fail_tracking_writes( string $query ): string {
 		$table = extrachill_users_concert_tracking_table_name();
-		if ( preg_match( '/^(INSERT INTO|DELETE FROM)\s+`?' . preg_quote( $table, '/' ) . '`?/i', $query ) ) {
+		if ( preg_match( '/^(INSERT(?: IGNORE)? INTO|DELETE FROM)\s+`?' . preg_quote( $table, '/' ) . '`?/i', $query ) ) {
 			return str_replace( $table, $table . '_missing', $query );
 		}
 
 		return $query;
+	}
+
+	private function create_event( string $post_type, string $post_status ): int {
+		switch_to_blog( $this->events_blog_id );
+		try {
+			return self::factory()->post->create(
+				array(
+					'post_type'   => $post_type,
+					'post_status' => $post_status,
+				)
+			);
+		} finally {
+			restore_current_blog();
+		}
 	}
 
 	private function clear_tracking_table(): void {


### PR DESCRIPTION
## Summary
- add an explicit idempotent `extrachill/set-event-mark` ability backed by canonical mark/unmark service primitives
- enforce input-aware self versus network-administrator permissions for writes and targeted reads while preserving public untargeted attendance reads
- consume #224's atomic `true` changed / `false` no-op / `WP_Error` failure contract without a race-prone post-write state query
- declare required stable output fields and exercise the contract through registered `WP_Ability::execute()` calls
- cover schema/default/output validation, self/admin/unauthenticated permissions, repeated operations, canonical missing/wrong-type/unpublished targets, targeted reads, and forced insert/delete failures

## Dependency integration and release order
- Extra-Chill/extrachill-users#224 merged as `d635591`
- This branch merged updated `origin/main` in `01e9fab` without rebasing or force-pushing, then integrated the landed service contract in `3af02ff`
- Merge and release this Users PR before merging or releasing Extra-Chill/extrachill-cli#121
- Final order: Users #222 merge/release -> CLI #121 merge/release

## Cross-repo
- Required by Extra-Chill/extrachill-cli#120
- Companion CLI PR: Extra-Chill/extrachill-cli#121

## Verification
- `php -l inc/core/abilities/concert-tracking.php` passed
- `php -l tests/unit/ConcertTrackingAbilitiesTest.php` passed
- `git diff --check` passed
- Registered ability tests cover valid canonical events, missing/wrong-type/unpublished targets, database failures, permissions, schemas, and idempotence
- `homeboy review extrachill-users test` and `lint` were attempted after integration but refused by the hot-host resource policy at load average ~144 because no Lab runner was available; local override was not forced