### PR TITLE
fix: validate attendance event targets

### DIFF
--- a/inc/concert-tracking/import/EventMatcher.php
+++ b/inc/concert-tracking/import/EventMatcher.php
@@ -51,6 +51,7 @@ final class EventMatcher {
 	public function __construct( int $blog_id = 0, int $threshold = self::DEFAULT_THRESHOLD ) {
 		if ( ! $blog_id ) {
 			$blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'events' ) : 7;
+			$blog_id = (int) apply_filters( 'extrachill_users_events_blog_id', $blog_id );
 		}
 		$this->blog_id   = $blog_id;
 		$this->threshold = $threshold;

--- a/inc/concert-tracking/import/ImportOrchestrator.php
+++ b/inc/concert-tracking/import/ImportOrchestrator.php
@@ -198,11 +198,13 @@ final class ImportOrchestrator {
 		$events_blog  = $matcher->blog_id();
 		$source_slug  = (string) $run['source_slug'];
 
-		$seen      = 0;
-		$matched   = 0;
-		$created   = 0;
-		$unmatched = 0;
-		$skipped   = 0;
+		$seen             = 0;
+		$matched          = 0;
+		$created          = 0;
+		$unmatched        = 0;
+		$skipped          = 0;
+		$attendance_error = null;
+		$rejected_event   = null;
 
 		// Suppress per-event IndexNow pings for the duration of this import
 		// batch. Each created event would otherwise trigger a synchronous
@@ -268,7 +270,13 @@ final class ImportOrchestrator {
 					$was_created = true;
 				}
 
-				ec_users_mark_event( (int) $run['user_id'], $resolved_id, $events_blog );
+				$mark_result = ec_users_mark_event( (int) $run['user_id'], $resolved_id, $events_blog );
+				if ( is_wp_error( $mark_result ) ) {
+					++$unmatched;
+					$attendance_error = $mark_result;
+					$rejected_event   = $external;
+					break;
+				}
 
 				if ( $was_created ) {
 					++$created;
@@ -290,6 +298,18 @@ final class ImportOrchestrator {
 				'total_pages' => $total_pages,
 			)
 		);
+		if ( $attendance_error ) {
+			self::mark_failed(
+				$run_id,
+				sprintf(
+					'Attendance import rejected %s (%s): %s',
+					$rejected_event instanceof ExternalEvent ? $rejected_event->label() : 'event',
+					$attendance_error->get_error_code(),
+					$attendance_error->get_error_message()
+				)
+			);
+			return;
+		}
 
 		if ( $page >= $total_pages ) {
 			self::mark_complete( $run_id );

--- a/inc/concert-tracking/service.php
+++ b/inc/concert-tracking/service.php
@@ -87,36 +87,22 @@ function ec_users_mark_event( int $user_id, int $event_id, int $blog_id = 0 ) {
 	}
 	$blog_id = $validated_blog_id;
 
-	$table = extrachill_users_concert_tracking_table_name();
-
-	// Check if already marked.
-	$exists = $wpdb->get_var(
+	$table    = extrachill_users_concert_tracking_table_name();
+	$inserted = $wpdb->query(
 		$wpdb->prepare(
-			"SELECT id FROM {$table} WHERE user_id = %d AND event_id = %d AND blog_id = %d LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+			"INSERT IGNORE INTO {$table} (user_id, event_id, blog_id, created_at) VALUES (%d, %d, %d, %s)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper; the unique key is the idempotence primitive.
 			$user_id,
 			$event_id,
-			$blog_id
+			$blog_id,
+			current_time( 'mysql', true )
 		)
 	);
 
-	if ( $exists ) {
-		return false;
+	if ( false === $inserted ) {
+		return new WP_Error( 'event_mark_database_error', __( 'Attendance could not be marked.', 'extrachill-users' ), array( 'status' => 500 ) );
 	}
 
-	$wpdb->insert(
-		$table,
-		array(
-			'user_id'    => $user_id,
-			'event_id'   => $event_id,
-			'blog_id'    => $blog_id,
-			'created_at' => current_time( 'mysql', true ),
-		),
-		array( '%d', '%d', '%d', '%s' )
-	);
-
-	$inserted = (bool) $wpdb->insert_id;
-
-	if ( $inserted ) {
+	if ( 1 === $inserted ) {
 		/**
 		 * Fires when a user newly marks an event (not on no-op re-marks).
 		 *
@@ -131,7 +117,7 @@ function ec_users_mark_event( int $user_id, int $event_id, int $blog_id = 0 ) {
 		do_action( 'ec_users_event_marked', $user_id, $event_id, $blog_id );
 	}
 
-	return $inserted;
+	return 1 === $inserted;
 }
 
 /**
@@ -161,8 +147,11 @@ function ec_users_unmark_event( int $user_id, int $event_id, int $blog_id = 0 ) 
 		),
 		array( '%d', '%d', '%d' )
 	);
+	if ( false === $deleted ) {
+		return new WP_Error( 'event_unmark_database_error', __( 'Attendance could not be unmarked.', 'extrachill-users' ), array( 'status' => 500 ) );
+	}
 
-	$removed = false !== $deleted && $deleted > 0;
+	$removed = $deleted > 0;
 
 	if ( $removed ) {
 		/**
@@ -192,25 +181,48 @@ function ec_users_unmark_event( int $user_id, int $event_id, int $blog_id = 0 ) 
  * @return array{ marked: bool }|WP_Error New state or a validation error.
  */
 function ec_users_toggle_event( int $user_id, int $event_id, int $blog_id = 0 ) {
+	global $wpdb;
+
 	$validated_blog_id = ec_users_validate_event_target( $event_id, $blog_id );
 	if ( is_wp_error( $validated_blog_id ) ) {
 		return $validated_blog_id;
 	}
 	$blog_id = $validated_blog_id;
 
-	if ( ec_users_is_event_marked( $user_id, $event_id, $blog_id ) ) {
-		$result = ec_users_unmark_event( $user_id, $event_id, $blog_id );
+	$lock_name = 'ec_attendance_' . md5( $user_id . ':' . $event_id . ':' . $blog_id );
+	$acquired  = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, 5)', $lock_name ) );
+	if ( null === $acquired && '' !== $wpdb->last_error ) {
+		return new WP_Error( 'event_toggle_lock_database_error', __( 'Attendance could not be updated.', 'extrachill-users' ), array( 'status' => 500 ) );
+	}
+	if ( 1 !== (int) $acquired ) {
+		return new WP_Error( 'event_toggle_lock_timeout', __( 'Attendance is busy. Please try again.', 'extrachill-users' ), array( 'status' => 409 ) );
+	}
+
+	try {
+		if ( ec_users_is_event_marked( $user_id, $event_id, $blog_id ) ) {
+			$result = ec_users_unmark_event( $user_id, $event_id, $blog_id );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			if ( $result || ! ec_users_is_event_marked( $user_id, $event_id, $blog_id ) ) {
+				return array( 'marked' => false );
+			}
+
+			return new WP_Error( 'event_toggle_state_error', __( 'Attendance could not be updated.', 'extrachill-users' ), array( 'status' => 500 ) );
+		}
+
+		$result = ec_users_mark_event( $user_id, $event_id, $blog_id );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
-		return array( 'marked' => false );
-	}
+		if ( $result || ec_users_is_event_marked( $user_id, $event_id, $blog_id ) ) {
+			return array( 'marked' => true );
+		}
 
-	$result = ec_users_mark_event( $user_id, $event_id, $blog_id );
-	if ( is_wp_error( $result ) ) {
-		return $result;
+		return new WP_Error( 'event_toggle_state_error', __( 'Attendance could not be updated.', 'extrachill-users' ), array( 'status' => 500 ) );
+	} finally {
+		$wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) );
 	}
-	return array( 'marked' => true );
 }
 
 /**

--- a/inc/concert-tracking/service.php
+++ b/inc/concert-tracking/service.php
@@ -19,21 +19,73 @@ require_once __DIR__ . '/db.php';
 // ─── Core CRUD ───────────────────────────────────────────────────────────────
 
 /**
+ * Validate an attendance target against the canonical Events site.
+ *
+ * @param int $event_id Event post ID.
+ * @param int $blog_id Requested blog ID, or zero to use the canonical site.
+ * @return int|WP_Error Canonical Events blog ID, or a validation error.
+ */
+function ec_users_validate_event_target( int $event_id, int $blog_id = 0 ) {
+	$events_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'events' ) : 0;
+	$events_blog_id = (int) apply_filters( 'extrachill_users_events_blog_id', $events_blog_id );
+
+	if ( $events_blog_id <= 0 || ( is_multisite() && ! get_site( $events_blog_id ) ) ) {
+		return new WP_Error( 'events_site_unavailable', __( 'The canonical Events site is unavailable.', 'extrachill-users' ), array( 'status' => 500 ) );
+	}
+
+	if ( $blog_id > 0 && is_multisite() && ! get_site( $blog_id ) ) {
+		return new WP_Error( 'event_site_not_found', __( 'The requested event site does not exist.', 'extrachill-users' ), array( 'status' => 404 ) );
+	}
+
+	if ( $blog_id > 0 && $blog_id !== $events_blog_id ) {
+		return new WP_Error( 'noncanonical_event_site', __( 'Attendance can only be recorded for events on the canonical Events site.', 'extrachill-users' ), array( 'status' => 400 ) );
+	}
+
+	$switched = get_current_blog_id() !== $events_blog_id;
+	if ( $switched && ! switch_to_blog( $events_blog_id ) ) {
+		return new WP_Error( 'events_site_unavailable', __( 'The canonical Events site is unavailable.', 'extrachill-users' ), array( 'status' => 500 ) );
+	}
+
+	try {
+		$post = get_post( $event_id );
+		if ( ! $post ) {
+			return new WP_Error( 'event_not_found', __( 'The requested event does not exist.', 'extrachill-users' ), array( 'status' => 404 ) );
+		}
+
+		if ( 'data_machine_events' !== $post->post_type ) {
+			return new WP_Error( 'invalid_event_post_type', __( 'The requested post is not an event.', 'extrachill-users' ), array( 'status' => 400 ) );
+		}
+
+		if ( 'publish' !== $post->post_status ) {
+			return new WP_Error( 'event_not_published', __( 'Attendance can only be recorded for published events.', 'extrachill-users' ), array( 'status' => 400 ) );
+		}
+	} finally {
+		if ( $switched ) {
+			restore_current_blog();
+		}
+	}
+
+	return $events_blog_id;
+}
+
+/**
  * Mark an event for a user.
  *
  * Inserts a record if it doesn't exist. No-op if already marked.
  *
  * @param int $user_id User ID.
  * @param int $event_id Event post ID.
- * @param int $blog_id Blog ID (default: current blog).
- * @return bool True if newly marked, false if already existed.
+ * @param int $blog_id Blog ID (default: canonical Events site).
+ * @return bool|WP_Error True if newly marked, false if already existed, or a validation error.
  */
-function ec_users_mark_event( int $user_id, int $event_id, int $blog_id = 0 ): bool {
+function ec_users_mark_event( int $user_id, int $event_id, int $blog_id = 0 ) {
 	global $wpdb;
 
-	if ( ! $blog_id ) {
-		$blog_id = get_current_blog_id();
+	$validated_blog_id = ec_users_validate_event_target( $event_id, $blog_id );
+	if ( is_wp_error( $validated_blog_id ) ) {
+		return $validated_blog_id;
 	}
+	$blog_id = $validated_blog_id;
 
 	$table = extrachill_users_concert_tracking_table_name();
 
@@ -87,15 +139,17 @@ function ec_users_mark_event( int $user_id, int $event_id, int $blog_id = 0 ): b
  *
  * @param int $user_id User ID.
  * @param int $event_id Event post ID.
- * @param int $blog_id Blog ID (default: current blog).
- * @return bool True if removed, false if didn't exist.
+ * @param int $blog_id Blog ID (default: canonical Events site).
+ * @return bool|WP_Error True if removed, false if it did not exist, or a validation error.
  */
-function ec_users_unmark_event( int $user_id, int $event_id, int $blog_id = 0 ): bool {
+function ec_users_unmark_event( int $user_id, int $event_id, int $blog_id = 0 ) {
 	global $wpdb;
 
-	if ( ! $blog_id ) {
-		$blog_id = get_current_blog_id();
+	$validated_blog_id = ec_users_validate_event_target( $event_id, $blog_id );
+	if ( is_wp_error( $validated_blog_id ) ) {
+		return $validated_blog_id;
 	}
+	$blog_id = $validated_blog_id;
 
 	$table   = extrachill_users_concert_tracking_table_name();
 	$deleted = $wpdb->delete(
@@ -134,20 +188,28 @@ function ec_users_unmark_event( int $user_id, int $event_id, int $blog_id = 0 ):
  *
  * @param int $user_id User ID.
  * @param int $event_id Event post ID.
- * @param int $blog_id Blog ID (default: current blog).
- * @return array{ marked: bool } New state.
+ * @param int $blog_id Blog ID (default: canonical Events site).
+ * @return array{ marked: bool }|WP_Error New state or a validation error.
  */
-function ec_users_toggle_event( int $user_id, int $event_id, int $blog_id = 0 ): array {
-	if ( ! $blog_id ) {
-		$blog_id = get_current_blog_id();
+function ec_users_toggle_event( int $user_id, int $event_id, int $blog_id = 0 ) {
+	$validated_blog_id = ec_users_validate_event_target( $event_id, $blog_id );
+	if ( is_wp_error( $validated_blog_id ) ) {
+		return $validated_blog_id;
 	}
+	$blog_id = $validated_blog_id;
 
 	if ( ec_users_is_event_marked( $user_id, $event_id, $blog_id ) ) {
-		ec_users_unmark_event( $user_id, $event_id, $blog_id );
+		$result = ec_users_unmark_event( $user_id, $event_id, $blog_id );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
 		return array( 'marked' => false );
 	}
 
-	ec_users_mark_event( $user_id, $event_id, $blog_id );
+	$result = ec_users_mark_event( $user_id, $event_id, $blog_id );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
 	return array( 'marked' => true );
 }
 
@@ -271,7 +333,7 @@ function ec_users_get_user_dated_event_checks( int $user_id ): array {
 /**
  * Determine the timing state of an event.
  *
- * extrachill-users is network-activated and runs on every site, but the
+ * Extra Chill Users is network-activated and runs on every site, but the
  * data-machine-events plugin that owns datamachine_get_event_timing() is
  * Network: false and only active on the events site. Delegating to that
  * function therefore fails (or silently returns 'past') on every other site.

--- a/inc/core/abilities/concert-tracking.php
+++ b/inc/core/abilities/concert-tracking.php
@@ -311,13 +311,22 @@ function extrachill_users_register_concert_tracking_abilities() {
 function extrachill_users_ability_toggle_event_mark( array $input ) {
 	$user_id  = get_current_user_id();
 	$event_id = (int) $input['event_id'];
-	$blog_id  = ! empty( $input['blog_id'] ) ? (int) $input['blog_id'] : ( function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : get_current_blog_id() );
+	$blog_id  = ! empty( $input['blog_id'] ) ? (int) $input['blog_id'] : 0;
 
 	if ( ! $user_id ) {
 		return new WP_Error( 'not_logged_in', 'You must be logged in to mark events.', array( 'status' => 401 ) );
 	}
 
+	$blog_id = ec_users_validate_event_target( $event_id, $blog_id );
+	if ( is_wp_error( $blog_id ) ) {
+		return $blog_id;
+	}
+
 	$result = ec_users_toggle_event( $user_id, $event_id, $blog_id );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
 	$count  = ec_users_get_event_mark_count( $event_id, $blog_id );
 	$timing = ec_users_get_event_timing( $event_id );
 

--- a/tests/unit/ConcertImportAttendanceValidationTest.php
+++ b/tests/unit/ConcertImportAttendanceValidationTest.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Tests for attendance failures during concert imports.
+ *
+ * @package ExtraChill\Users
+ */
+
+use ExtraChill\Users\Concert_Import\ExternalEvent;
+use ExtraChill\Users\Concert_Import\EventCreator;
+use ExtraChill\Users\Concert_Import\ImportOrchestrator;
+use ExtraChill\Users\Concert_Import\ImportSource;
+
+/**
+ * Verifies import runs truthfully expose rejected attendance writes.
+ */
+class Test_Concert_Import_Attendance_Validation extends WP_UnitTestCase {
+
+	/**
+	 * Canonical Events site fixture ID.
+	 *
+	 * @var int
+	 */
+	private int $events_blog_id;
+
+	/**
+	 * Authenticated import user ID.
+	 *
+	 * @var int
+	 */
+	private int $user_id;
+
+	/**
+	 * Controlled external event fixture.
+	 *
+	 * @var ExternalEvent
+	 */
+	private ExternalEvent $external_event;
+
+	/**
+	 * Create import tables, source, user, and Events site fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->events_blog_id = self::factory()->blog->create();
+		$this->user_id        = self::factory()->user->create();
+		$this->external_event = new ExternalEvent(
+			array(
+				'date'       => '2025-01-15',
+				'venue_name' => 'Fixture Room',
+				'headliner'  => 'Fixture Band',
+				'source_id'  => 'draft-external-id',
+			)
+		);
+
+		wp_set_current_user( $this->user_id );
+		add_filter( 'extrachill_users_events_blog_id', array( $this, 'filter_events_blog_id' ) );
+		add_filter( 'extrachill_concert_import_sources', array( $this, 'replace_sources' ), 999 );
+		if ( ! post_type_exists( 'data_machine_events' ) ) {
+			register_post_type( 'data_machine_events', array( 'public' => true ) );
+		}
+
+		extrachill_users_install_concert_tracking_table();
+		extrachill_users_install_concert_import_runs_table();
+		$this->clear_tables();
+	}
+
+	/**
+	 * Remove shared rows and test filters.
+	 */
+	protected function tearDown(): void {
+		$this->clear_tables();
+		remove_filter( 'extrachill_concert_import_sources', array( $this, 'replace_sources' ), 999 );
+		remove_filter( 'extrachill_users_events_blog_id', array( $this, 'filter_events_blog_id' ) );
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	/**
+	 * Return the Events site fixture ID.
+	 */
+	public function filter_events_blog_id(): int {
+		return $this->events_blog_id;
+	}
+
+	/**
+	 * Replace production sources with the controlled source.
+	 *
+	 * @param array $sources Registered sources.
+	 * @return ImportSource[]
+	 */
+	public function replace_sources( array $sources ): array {
+		return array(
+			new class( $this->external_event ) implements ImportSource {
+
+				/**
+				 * Event returned by the source.
+				 *
+				 * @var ExternalEvent
+				 */
+				private ExternalEvent $event;
+
+				/**
+				 * Initialize the controlled source.
+				 *
+				 * @param ExternalEvent $event Event fixture.
+				 */
+				public function __construct( ExternalEvent $event ) {
+					$this->event = $event;
+				}
+
+				/** Return the fixture source slug. */
+				public function slug(): string {
+					return 'attendance-validation';
+				}
+
+				/** Return the fixture source label. */
+				public function label(): string {
+					return 'Attendance Validation';
+				}
+
+				/** Return an unrestricted rate limit. */
+				public function rate_limit(): array {
+					return array();
+				}
+
+				/** Report that the fixture is configured. */
+				public function is_configured(): bool {
+					return true;
+				}
+
+				/**
+				 * Return a successful preview.
+				 *
+				 * @param string $username External username.
+				 * @return array<string, mixed>
+				 */
+				public function preview( string $username ) {
+					return array(
+						'total'    => 1,
+						'username' => $username,
+					);
+				}
+
+				/**
+				 * Return the controlled event page.
+				 *
+				 * @param string $username External username.
+				 * @param int    $page Page number.
+				 * @return array<string, mixed>
+				 */
+				public function fetch_page( string $username, int $page ) {
+					return array(
+						'events'      => array( $this->event ),
+						'total_pages' => 1,
+						'total'       => 1,
+						'page'        => $page,
+					);
+				}
+			},
+		);
+	}
+
+	/**
+	 * An unpublished external-ID match fails instead of claiming attendance.
+	 */
+	public function test_unpublished_external_id_match_fails_run_truthfully(): void {
+		$original_blog_id = get_current_blog_id();
+		$event_id         = $this->create_imported_event( 'draft' );
+		$start            = ImportOrchestrator::start( $this->user_id, 'attendance-validation', 'fixture-user' );
+		$this->assertFalse( is_wp_error( $start ) );
+
+		ImportOrchestrator::process( (int) $start['run_id'] );
+
+		$this->assertSame( $original_blog_id, get_current_blog_id() );
+		$this->assertFalse( ec_users_is_event_marked( $this->user_id, $event_id, $this->events_blog_id ) );
+
+		$status_ability = wp_get_ability( 'extrachill/get-concert-import-status' );
+		$this->assertNotNull( $status_ability );
+		$status = $status_ability->execute( array( 'limit' => 1 ) );
+		$run    = $status['runs'][0];
+
+		$this->assertSame( ImportOrchestrator::STATUS_FAILED, $run['status'] );
+		$this->assertSame( 1, $run['total_events_seen'] );
+		$this->assertSame( 0, $run['total_events_matched'] );
+		$this->assertSame( 0, $run['total_events_created'] );
+		$this->assertSame( 1, $run['total_events_unmatched'] );
+		$this->assertStringContainsString( 'event_not_published', $run['error_message'] );
+		$this->assertStringContainsString( $this->external_event->label(), $run['error_message'] );
+	}
+
+	/**
+	 * Create an event carrying the source's stable import identifiers.
+	 *
+	 * @param string $status Event post status.
+	 * @return int
+	 */
+	private function create_imported_event( string $status ): int {
+		switch_to_blog( $this->events_blog_id );
+		try {
+			$event_id = self::factory()->post->create(
+				array(
+					'post_type'   => 'data_machine_events',
+					'post_status' => $status,
+				)
+			);
+			update_post_meta( $event_id, EventCreator::META_IMPORT_SOURCE, 'attendance-validation' );
+			update_post_meta( $event_id, EventCreator::META_IMPORT_EXTERNAL_ID, $this->external_event->source_id );
+			return $event_id;
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	/**
+	 * Clear network import and attendance tables between tests.
+	 */
+	private function clear_tables(): void {
+		global $wpdb;
+		$tracking_table = extrachill_users_concert_tracking_table_name();
+		$imports_table  = extrachill_users_concert_import_runs_table_name();
+		$wpdb->query( "DELETE FROM {$tracking_table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- trusted table helper.
+		$wpdb->query( "DELETE FROM {$imports_table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- trusted table helper.
+	}
+}

--- a/tests/unit/ConcertTrackingValidationTest.php
+++ b/tests/unit/ConcertTrackingValidationTest.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * Tests for canonical event validation on attendance writes.
+ *
+ * @package ExtraChill\Users
+ */
+
+/**
+ * Verifies attendance writes only accept published canonical Events posts.
+ */
+class Test_Concert_Tracking_Validation extends WP_UnitTestCase {
+
+	/**
+	 * Canonical Events site fixture ID.
+	 *
+	 * @var int
+	 */
+	private int $events_blog_id;
+
+	/**
+	 * Noncanonical site fixture ID.
+	 *
+	 * @var int
+	 */
+	private int $other_blog_id;
+
+	/**
+	 * Authenticated test user ID.
+	 *
+	 * @var int
+	 */
+	private int $user_id;
+
+	/**
+	 * Create isolated multisite fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->events_blog_id = self::factory()->blog->create();
+		$this->other_blog_id  = self::factory()->blog->create();
+		$this->user_id        = self::factory()->user->create();
+		wp_set_current_user( $this->user_id );
+
+		add_filter( 'extrachill_users_events_blog_id', array( $this, 'filter_events_blog_id' ) );
+		if ( ! post_type_exists( 'data_machine_events' ) ) {
+			register_post_type( 'data_machine_events', array( 'public' => true ) );
+		}
+		extrachill_users_install_concert_tracking_table();
+		$this->clear_tracking_table();
+	}
+
+	/**
+	 * Remove shared table rows and test filters.
+	 */
+	protected function tearDown(): void {
+		$this->clear_tracking_table();
+		remove_filter( 'extrachill_users_events_blog_id', array( $this, 'filter_events_blog_id' ) );
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	/**
+	 * Return the Events site fixture ID.
+	 */
+	public function filter_events_blog_id(): int {
+		return $this->events_blog_id;
+	}
+
+	/**
+	 * A requested site must exist.
+	 */
+	public function test_rejects_nonexistent_site_without_mutation(): void {
+		$this->assert_rejected_without_mutation(
+			array(
+				'event_id' => 123,
+				'blog_id'  => 999999,
+			),
+			'event_site_not_found',
+			'The requested event site does not exist.',
+			404
+		);
+	}
+
+	/**
+	 * The canonical Events site must resolve before writes.
+	 */
+	public function test_rejects_unavailable_canonical_site_without_mutation(): void {
+		add_filter( 'extrachill_users_events_blog_id', '__return_zero', 20 );
+		try {
+			$this->assert_rejected_without_mutation(
+				array( 'event_id' => 123 ),
+				'events_site_unavailable',
+				'The canonical Events site is unavailable.',
+				500
+			);
+		} finally {
+			remove_filter( 'extrachill_users_events_blog_id', '__return_zero', 20 );
+		}
+	}
+
+	/**
+	 * A requested post must exist on the canonical site.
+	 */
+	public function test_rejects_missing_post_without_mutation(): void {
+		$this->assert_rejected_without_mutation(
+			array( 'event_id' => 999999 ),
+			'event_not_found',
+			'The requested event does not exist.',
+			404
+		);
+	}
+
+	/**
+	 * A blog-local post ID cannot select another site.
+	 */
+	public function test_rejects_same_id_from_noncanonical_site(): void {
+		$event_id          = $this->create_post_on_blog( $this->other_blog_id, 'data_machine_events', 'publish' );
+		$canonical_post_id = $this->create_post_on_blog( $this->events_blog_id, 'data_machine_events', 'publish' );
+		$this->assertSame( $canonical_post_id, $event_id, 'The fixture must prove blog-local IDs cannot select a noncanonical site.' );
+
+		$this->assert_rejected_without_mutation(
+			array(
+				'event_id' => $event_id,
+				'blog_id'  => $this->other_blog_id,
+			),
+			'noncanonical_event_site',
+			'Attendance can only be recorded for events on the canonical Events site.',
+			400
+		);
+	}
+
+	/**
+	 * A canonical-site post must use the event post type.
+	 */
+	public function test_rejects_wrong_post_type_without_mutation(): void {
+		$post_id = $this->create_post_on_blog( $this->events_blog_id, 'post', 'publish' );
+		$this->assert_rejected_without_mutation(
+			array( 'event_id' => $post_id ),
+			'invalid_event_post_type',
+			'The requested post is not an event.',
+			400
+		);
+	}
+
+	/**
+	 * The lower-level service protects non-ability callers such as imports.
+	 */
+	public function test_direct_mark_rejects_invalid_target_without_mutation(): void {
+		$rows_before   = $this->tracking_row_count();
+		$marked_before = did_action( 'ec_users_event_marked' );
+
+		$result = ec_users_mark_event( $this->user_id, 999999, $this->events_blog_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'event_not_found', $result->get_error_code() );
+		$this->assertSame( $rows_before, $this->tracking_row_count() );
+		$this->assertSame( $marked_before, did_action( 'ec_users_event_marked' ) );
+	}
+
+	/**
+	 * Only published event posts can be marked.
+	 *
+	 * @param string $status Event post status.
+	 *
+	 * @dataProvider unpublished_status_provider
+	 */
+	public function test_rejects_unpublished_events_without_mutation( string $status ): void {
+		$event_id = $this->create_post_on_blog( $this->events_blog_id, 'data_machine_events', $status );
+		$this->assert_rejected_without_mutation(
+			array( 'event_id' => $event_id ),
+			'event_not_published',
+			'Attendance can only be recorded for published events.',
+			400
+		);
+	}
+
+	/**
+	 * Provide all rejected unpublished statuses.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public function unpublished_status_provider(): array {
+		return array(
+			'draft'   => array( 'draft' ),
+			'private' => array( 'private' ),
+			'trash'   => array( 'trash' ),
+		);
+	}
+
+	/**
+	 * Valid events retain mark idempotence and toggle behavior.
+	 */
+	public function test_valid_event_toggles_and_preserves_idempotent_marks(): void {
+		$event_id = $this->create_post_on_blog( $this->events_blog_id, 'data_machine_events', 'publish' );
+
+		$this->assertTrue( ec_users_mark_event( $this->user_id, $event_id ) );
+		$this->assertFalse( ec_users_mark_event( $this->user_id, $event_id ) );
+		$this->assertSame( 1, ec_users_get_event_mark_count( $event_id, $this->events_blog_id ) );
+
+		$unmarked = extrachill_users_ability_toggle_event_mark( array( 'event_id' => $event_id ) );
+		$this->assertFalse( $unmarked['marked'] );
+		$this->assertSame( 0, $unmarked['count'] );
+
+		$marked = extrachill_users_ability_toggle_event_mark( array( 'event_id' => $event_id ) );
+		$this->assertTrue( $marked['marked'] );
+		$this->assertSame( 1, $marked['count'] );
+	}
+
+	/**
+	 * Validation restores the caller's multisite context.
+	 */
+	public function test_validation_restores_multisite_context(): void {
+		$event_id = $this->create_post_on_blog( $this->events_blog_id, 'data_machine_events', 'publish' );
+		switch_to_blog( $this->other_blog_id );
+		$original_blog_id = get_current_blog_id();
+
+		$result = extrachill_users_ability_toggle_event_mark( array( 'event_id' => $event_id ) );
+
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertSame( $original_blog_id, get_current_blog_id() );
+		restore_current_blog();
+	}
+
+	/**
+	 * Assert a stable error and no write-side effects.
+	 *
+	 * @param array  $input Ability input.
+	 * @param string $code Expected error code.
+	 * @param string $message Expected error message.
+	 * @param int    $status Expected HTTP status.
+	 */
+	private function assert_rejected_without_mutation( array $input, string $code, string $message, int $status ): void {
+		$rows_before     = $this->tracking_row_count();
+		$marked_before   = did_action( 'ec_users_event_marked' );
+		$unmarked_before = did_action( 'ec_users_event_unmarked' );
+		$original_blog   = get_current_blog_id();
+
+		$result = extrachill_users_ability_toggle_event_mark( $input );
+
+		$this->assertWPError( $result );
+		$this->assertSame( $code, $result->get_error_code() );
+		$this->assertSame( $message, $result->get_error_message() );
+		$this->assertSame( $status, $result->get_error_data()['status'] );
+		$this->assertSame( $rows_before, $this->tracking_row_count() );
+		$this->assertSame( $marked_before, did_action( 'ec_users_event_marked' ) );
+		$this->assertSame( $unmarked_before, did_action( 'ec_users_event_unmarked' ) );
+		$this->assertSame( $original_blog, get_current_blog_id() );
+	}
+
+	/**
+	 * Create a post on a specific test site.
+	 *
+	 * @param int    $blog_id Site ID.
+	 * @param string $post_type Post type.
+	 * @param string $post_status Post status.
+	 */
+	private function create_post_on_blog( int $blog_id, string $post_type, string $post_status ): int {
+		switch_to_blog( $blog_id );
+		try {
+			return self::factory()->post->create(
+				array(
+					'post_type'   => $post_type,
+					'post_status' => $post_status,
+				)
+			);
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	/**
+	 * Count all rows in the network attendance table.
+	 */
+	private function tracking_row_count(): int {
+		global $wpdb;
+		$table = extrachill_users_concert_tracking_table_name();
+		return (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- trusted table helper.
+	}
+
+	/**
+	 * Clear the network attendance table between tests.
+	 */
+	private function clear_tracking_table(): void {
+		global $wpdb;
+		$table = extrachill_users_concert_tracking_table_name();
+		$wpdb->query( "DELETE FROM {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- trusted table helper.
+	}
+}

--- a/tests/unit/ConcertTrackingValidationTest.php
+++ b/tests/unit/ConcertTrackingValidationTest.php
@@ -32,6 +32,20 @@ class Test_Concert_Tracking_Validation extends WP_UnitTestCase {
 	private int $user_id;
 
 	/**
+	 * Tracking-table operation to replace with invalid SQL.
+	 *
+	 * @var string
+	 */
+	private string $failed_operation = '';
+
+	/**
+	 * Captured advisory-lock queries.
+	 *
+	 * @var string[]
+	 */
+	private array $lock_queries = array();
+
+	/**
 	 * Create isolated multisite fixtures.
 	 */
 	protected function setUp(): void {
@@ -64,6 +78,46 @@ class Test_Concert_Tracking_Validation extends WP_UnitTestCase {
 	 */
 	public function filter_events_blog_id(): int {
 		return $this->events_blog_id;
+	}
+
+	/**
+	 * Replace one tracking-table mutation with a deterministic database error.
+	 *
+	 * @param string $query SQL query.
+	 * @return string
+	 */
+	public function fail_tracking_mutation( string $query ): string {
+		$table = extrachill_users_concert_tracking_table_name();
+		if ( 'insert' === $this->failed_operation && str_starts_with( ltrim( $query ), "INSERT IGNORE INTO {$table}" ) ) {
+			return 'INSERT INTO ec_missing_attendance_table (id) VALUES (1)';
+		}
+		if ( 'delete' === $this->failed_operation && str_starts_with( ltrim( $query ), "DELETE FROM {$table}" ) ) {
+			return 'DELETE FROM ec_missing_attendance_table WHERE id = 1';
+		}
+		return $query;
+	}
+
+	/**
+	 * Capture advisory-lock acquisition and release queries.
+	 *
+	 * @param string $query SQL query.
+	 * @return string
+	 */
+	public function capture_lock_queries( string $query ): string {
+		if ( false !== strpos( $query, 'GET_LOCK(' ) || false !== strpos( $query, 'RELEASE_LOCK(' ) ) {
+			$this->lock_queries[] = $query;
+		}
+		return $query;
+	}
+
+	/**
+	 * Force advisory-lock acquisition to time out.
+	 *
+	 * @param string $query SQL query.
+	 * @return string
+	 */
+	public function timeout_toggle_lock( string $query ): string {
+		return false !== strpos( $query, 'GET_LOCK(' ) ? 'SELECT 0' : $query;
 	}
 
 	/**
@@ -182,9 +236,117 @@ class Test_Concert_Tracking_Validation extends WP_UnitTestCase {
 	public function unpublished_status_provider(): array {
 		return array(
 			'draft'   => array( 'draft' ),
+			'pending' => array( 'pending' ),
+			'future'  => array( 'future' ),
 			'private' => array( 'private' ),
 			'trash'   => array( 'trash' ),
 		);
+	}
+
+	/**
+	 * Mark database errors are not reported as idempotent no-ops.
+	 */
+	public function test_mark_distinguishes_noop_from_database_failure(): void {
+		$event_id = $this->create_post_on_blog( $this->events_blog_id, 'data_machine_events', 'publish' );
+		$this->assertTrue( ec_users_mark_event( $this->user_id, $event_id ) );
+		$this->assertFalse( ec_users_mark_event( $this->user_id, $event_id ) );
+		$this->assertTrue( ec_users_unmark_event( $this->user_id, $event_id ) );
+
+		$this->failed_operation = 'insert';
+		add_filter( 'query', array( $this, 'fail_tracking_mutation' ) );
+		try {
+			$result = ec_users_mark_event( $this->user_id, $event_id );
+		} finally {
+			remove_filter( 'query', array( $this, 'fail_tracking_mutation' ) );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'event_mark_database_error', $result->get_error_code() );
+		$this->assertFalse( ec_users_is_event_marked( $this->user_id, $event_id, $this->events_blog_id ) );
+	}
+
+	/**
+	 * Unmark database errors are not reported as idempotent no-ops.
+	 */
+	public function test_unmark_distinguishes_noop_from_database_failure(): void {
+		$event_id = $this->create_post_on_blog( $this->events_blog_id, 'data_machine_events', 'publish' );
+		$this->assertFalse( ec_users_unmark_event( $this->user_id, $event_id ) );
+		$this->assertTrue( ec_users_mark_event( $this->user_id, $event_id ) );
+
+		$this->failed_operation = 'delete';
+		add_filter( 'query', array( $this, 'fail_tracking_mutation' ) );
+		try {
+			$result = ec_users_unmark_event( $this->user_id, $event_id );
+		} finally {
+			remove_filter( 'query', array( $this, 'fail_tracking_mutation' ) );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'event_unmark_database_error', $result->get_error_code() );
+		$this->assertTrue( ec_users_is_event_marked( $this->user_id, $event_id, $this->events_blog_id ) );
+	}
+
+	/**
+	 * Registered ability execution preserves service database errors.
+	 */
+	public function test_registered_ability_propagates_database_failure(): void {
+		$event_id = $this->create_post_on_blog( $this->events_blog_id, 'data_machine_events', 'publish' );
+		$ability  = wp_get_ability( 'extrachill/toggle-event-mark' );
+		$this->assertNotNull( $ability );
+
+		$this->failed_operation = 'insert';
+		add_filter( 'query', array( $this, 'fail_tracking_mutation' ) );
+		try {
+			$result = $ability->execute( array( 'event_id' => $event_id ) );
+		} finally {
+			remove_filter( 'query', array( $this, 'fail_tracking_mutation' ) );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'event_mark_database_error', $result->get_error_code() );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+		$this->assertSame( 0, ec_users_get_event_mark_count( $event_id, $this->events_blog_id ) );
+	}
+
+	/**
+	 * Every toggle holds the per-key lock through its mutation.
+	 */
+	public function test_toggle_serializes_two_transitions_through_advisory_lock(): void {
+		$event_id = $this->create_post_on_blog( $this->events_blog_id, 'data_machine_events', 'publish' );
+		add_filter( 'query', array( $this, 'capture_lock_queries' ) );
+		try {
+			$marked   = ec_users_toggle_event( $this->user_id, $event_id );
+			$unmarked = ec_users_toggle_event( $this->user_id, $event_id );
+		} finally {
+			remove_filter( 'query', array( $this, 'capture_lock_queries' ) );
+		}
+
+		$this->assertSame( array( 'marked' => true ), $marked );
+		$this->assertSame( array( 'marked' => false ), $unmarked );
+		$this->assertCount( 4, $this->lock_queries );
+		$this->assertStringContainsString( 'GET_LOCK(', $this->lock_queries[0] );
+		$this->assertStringContainsString( 'RELEASE_LOCK(', $this->lock_queries[1] );
+		$this->assertStringContainsString( 'GET_LOCK(', $this->lock_queries[2] );
+		$this->assertStringContainsString( 'RELEASE_LOCK(', $this->lock_queries[3] );
+		$this->assertFalse( ec_users_is_event_marked( $this->user_id, $event_id, $this->events_blog_id ) );
+	}
+
+	/**
+	 * Lock contention returns a stable ability-facing error without mutation.
+	 */
+	public function test_toggle_lock_timeout_does_not_report_unstored_state(): void {
+		$event_id = $this->create_post_on_blog( $this->events_blog_id, 'data_machine_events', 'publish' );
+		add_filter( 'query', array( $this, 'timeout_toggle_lock' ) );
+		try {
+			$result = extrachill_users_ability_toggle_event_mark( array( 'event_id' => $event_id ) );
+		} finally {
+			remove_filter( 'query', array( $this, 'timeout_toggle_lock' ) );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'event_toggle_lock_timeout', $result->get_error_code() );
+		$this->assertSame( 409, $result->get_error_data()['status'] );
+		$this->assertSame( 0, ec_users_get_event_mark_count( $event_id, $this->events_blog_id ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- validate every attendance write against a published `data_machine_events` post on the canonical Events site
- make mark/unmark outcomes truthful and race-safe through the table's unique key
- serialize each toggle under a per-user/event/blog advisory lock and verify stored state before responding
- fail concert-import runs when attendance validation/storage rejects an item instead of inflating matched/created counters
- cover canonical validation, database failures, registered abilities, lock acquisition/release, imports, idempotence, and multisite context restoration

## Stable service contract
- `ec_users_mark_event()` returns `true` only when it inserts a new mark, `false` only when the unique mark already exists, and `WP_Error` for target validation or database failure.
- `ec_users_unmark_event()` returns `true` only when it removes a mark, `false` only when no mark exists, and `WP_Error` for target validation or database failure.
- `ec_users_toggle_event()` returns `{ marked: bool }` only after that state is stored. Validation, lock timeout/database failure, mutation failure, or state verification failure returns a stable `WP_Error` that the ability/REST adapter propagates unchanged.
- Concurrent toggles for the same `(user_id,event_id,blog_id)` serialize through a bounded MySQL advisory lock, yielding the same transitions as sequential toggles.
- Import attendance rejection increments `seen`/`unmatched`, never `matched`/`created`, marks the run `failed`, and exposes the event label plus stable error code/message through import status.

## Verification
- `vendor/bin/phpcs -n --standard=WordPress --extensions=php inc/concert-tracking/service.php inc/core/abilities/concert-tracking.php tests/unit/ConcertTrackingValidationTest.php tests/unit/ConcertImportAttendanceValidationTest.php`
- `php -l` passed for all six changed PHP files
- `git diff --check origin/main...HEAD`
- Homeboy PR audit passed: `485b8811-b3c2-4969-85dc-6e1367b05ca8`
- Homeboy PR lint passed: `636d6792-7c45-4785-870a-6b5c3ea9e8bc` (PHPStan skipped because the installed Homeboy WordPress extension binary is corrupt; tracked upstream as `homeboy-extensions#2233`)
- Focused PHPUnit attempted with `--filter 'Concert_(Tracking|Import_Attendance)'`, but WP Codebox stalled before PHPUnit output and exceeded the 20-minute harness timeout: `2bee16ce-ad1d-42f1-99d2-68829ca5e0ab`. A full run was not repeated because the focused harness never started.

Closes #217