### PR TITLE
fix: align concert history with canonical timing

### DIFF
--- a/inc/concert-tracking/service.php
+++ b/inc/concert-tracking/service.php
@@ -388,7 +388,8 @@ function ec_users_get_events_now( int $blog_id ): string {
  *
  * The two history tabs map states explicitly: Past contains only `past`, while
  * Upcoming uses `active` and therefore contains both `upcoming` and `ongoing`.
- * Column names remain bare so MySQL can use the event date indexes.
+ * Past leads with the indexed start range and uses COALESCE only for the
+ * residual end check, avoiding an OR that prevents index condition pushdown.
  *
  * @param string $timing `upcoming`, `ongoing`, `past`, or `active`.
  * @param string $now    MySQL datetime in the Events site's timezone.
@@ -412,7 +413,7 @@ function ec_users_build_event_timing_condition( string $timing, string $now, str
 			);
 		case 'past':
 			return array(
-				'where'   => "({$start} < %s AND ({$end} < %s OR {$end} IS NULL))",
+				'where'   => "({$start} < %s AND COALESCE({$end}, {$start}) < %s)",
 				'prepare' => array( $now, $now ),
 			);
 		case 'active':
@@ -785,9 +786,6 @@ function ec_users_get_user_concert_stats( int $user_id, array $args = array() ):
 	// Base WHERE for this user + blog.
 	$where   = array( 'ct.user_id = %d', 'ct.blog_id = %d', 'p.post_type = %s', 'p.post_status = %s' );
 	$prepare = array( $user_id, $blog_id, 'data_machine_events', 'publish' );
-	$past    = ec_users_build_event_timing_condition( 'past', ec_users_get_events_now( $blog_id ) );
-	$where[] = $past['where'];
-	$prepare = array_merge( $prepare, $past['prepare'] );
 
 	if ( ! empty( $args['year'] ) ) {
 		$where[]   = 'YEAR(ed.start_datetime) = %d';
@@ -798,6 +796,9 @@ function ec_users_get_user_concert_stats( int $user_id, array $args = array() ):
 		$prepare[] = sanitize_text_field( $args['date_from'] );
 	}
 	if ( ! empty( $args['date_to'] ) ) {
+		$past      = ec_users_build_event_timing_condition( 'past', ec_users_get_events_now( $blog_id ) );
+		$where[]   = $past['where'];
+		$prepare   = array_merge( $prepare, $past['prepare'] );
 		$where[]   = 'DATE(ed.start_datetime) <= %s';
 		$prepare[] = sanitize_text_field( $args['date_to'] );
 	}

--- a/inc/concert-tracking/service.php
+++ b/inc/concert-tracking/service.php
@@ -343,6 +343,105 @@ function ec_users_get_user_dated_event_checks( int $user_id ): array {
 // ─── Event Timing ────────────────────────────────────────────────────────────
 
 /**
+ * Resolve the Events site blog ID.
+ *
+ * @return int Events site blog ID.
+ */
+function ec_users_get_events_blog_id(): int {
+	$blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : 7;
+
+	return (int) apply_filters( 'extrachill_users_events_blog_id', $blog_id );
+}
+
+/**
+ * Capture the current time in the Events site's local timezone.
+ *
+ * @param int $blog_id Events site blog ID.
+ * @return string MySQL datetime in the Events site's timezone.
+ */
+function ec_users_get_events_now( int $blog_id ): string {
+	$switched = false;
+	if ( get_current_blog_id() !== $blog_id ) {
+		switch_to_blog( $blog_id );
+		$switched = true;
+	}
+
+	try {
+		$now = current_time( 'mysql' );
+	} finally {
+		if ( $switched ) {
+			restore_current_blog();
+		}
+	}
+
+	/**
+	 * Filters the captured Events-site time used for timing comparisons.
+	 *
+	 * @param string $now     MySQL datetime in the Events site's timezone.
+	 * @param int    $blog_id Events site blog ID.
+	 */
+	return (string) apply_filters( 'extrachill_users_event_timing_now', $now, $blog_id );
+}
+
+/**
+ * Build a canonical event timing SQL condition.
+ *
+ * The two history tabs map states explicitly: Past contains only `past`, while
+ * Upcoming uses `active` and therefore contains both `upcoming` and `ongoing`.
+ * Column names remain bare so MySQL can use the event date indexes.
+ *
+ * @param string $timing `upcoming`, `ongoing`, `past`, or `active`.
+ * @param string $now    MySQL datetime in the Events site's timezone.
+ * @param string $alias  Trusted event dates table alias.
+ * @return array{where: string, prepare: array}
+ */
+function ec_users_build_event_timing_condition( string $timing, string $now, string $alias = 'ed' ): array {
+	$start = $alias . '.start_datetime';
+	$end   = $alias . '.end_datetime';
+
+	switch ( $timing ) {
+		case 'upcoming':
+			return array(
+				'where'   => "{$start} >= %s",
+				'prepare' => array( $now ),
+			);
+		case 'ongoing':
+			return array(
+				'where'   => "({$start} < %s AND {$end} >= %s)",
+				'prepare' => array( $now, $now ),
+			);
+		case 'past':
+			return array(
+				'where'   => "({$start} < %s AND ({$end} < %s OR {$end} IS NULL))",
+				'prepare' => array( $now, $now ),
+			);
+		case 'active':
+		default:
+			return array(
+				'where'   => "({$start} >= %s OR {$end} >= %s)",
+				'prepare' => array( $now, $now ),
+			);
+	}
+}
+
+/**
+ * Build a CASE expression that returns canonical event timing.
+ *
+ * @param string $now   MySQL datetime in the Events site's timezone.
+ * @param string $alias Trusted event dates table alias.
+ * @return array{sql: string, prepare: array}
+ */
+function ec_users_build_event_timing_case( string $now, string $alias = 'ed' ): array {
+	$upcoming = ec_users_build_event_timing_condition( 'upcoming', $now, $alias );
+	$ongoing  = ec_users_build_event_timing_condition( 'ongoing', $now, $alias );
+
+	return array(
+		'sql'     => "CASE WHEN {$upcoming['where']} THEN 'upcoming' WHEN {$ongoing['where']} THEN 'ongoing' ELSE 'past' END",
+		'prepare' => array_merge( $upcoming['prepare'], $ongoing['prepare'] ),
+	);
+}
+
+/**
  * Determine the timing state of an event.
  *
  * Extra Chill Users is network-activated and runs on every site, but the
@@ -359,40 +458,27 @@ function ec_users_get_user_dated_event_checks( int $user_id ): array {
  *   past     = start < now AND (end < now OR end IS NULL), or no start date.
  *
  * @param int $event_id Event post ID.
+ * @param int $blog_id  Events site blog ID. Defaults to the canonical Events site.
  * @return string 'upcoming' | 'ongoing' | 'past'
  */
-function ec_users_get_event_timing( int $event_id ): string {
+function ec_users_get_event_timing( int $event_id, int $blog_id = 0 ): string {
 	global $wpdb;
 
-	$blog_id       = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : 7;
+	$blog_id       = $blog_id ? $blog_id : ec_users_get_events_blog_id();
 	$events_prefix = $wpdb->get_blog_prefix( $blog_id );
 	$dates_table   = $events_prefix . 'datamachine_event_dates';
+	$timing_case   = ec_users_build_event_timing_case( ec_users_get_events_now( $blog_id ) );
 
-	$dates = $wpdb->get_row(
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Trusted table name and shared prepared CASE fragment.
+	$timing = $wpdb->get_var(
 		$wpdb->prepare(
-			"SELECT start_datetime, end_datetime FROM {$dates_table} WHERE post_id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name built from trusted blog prefix.
-			$event_id
+			"SELECT {$timing_case['sql']} FROM {$dates_table} ed WHERE ed.post_id = %d",
+			...array_merge( $timing_case['prepare'], array( $event_id ) )
 		)
 	);
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
-	if ( ! $dates || empty( $dates->start_datetime ) ) {
-		return 'past';
-	}
-
-	// Event datetimes are stored in site-local time; compare against the same.
-	$now         = current_time( 'mysql' );
-	$event_start = $dates->start_datetime;
-	$event_end   = $dates->end_datetime ?? null;
-
-	if ( $event_start >= $now ) {
-		return 'upcoming';
-	}
-
-	if ( $event_end && $event_end >= $now ) {
-		return 'ongoing';
-	}
-
-	return 'past';
+	return in_array( $timing, array( 'upcoming', 'ongoing', 'past' ), true ) ? $timing : 'past';
 }
 
 /**
@@ -464,7 +550,7 @@ function ec_users_get_user_events( int $user_id, array $args = array() ): array 
 	}
 
 	$table         = extrachill_users_concert_tracking_table_name();
-	$blog_id       = $args['blog_id'] ? $args['blog_id'] : ( function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : 7 );
+	$blog_id       = $args['blog_id'] ? (int) $args['blog_id'] : ec_users_get_events_blog_id();
 	$events_prefix = $wpdb->get_blog_prefix( $blog_id );
 	$posts_table   = $events_prefix . 'posts';
 
@@ -474,15 +560,18 @@ function ec_users_get_user_events( int $user_id, array $args = array() ): array 
 
 	$dates_table = $events_prefix . 'datamachine_event_dates';
 
-	// Date filtering via datamachine_event_dates table.
-	$now_date = current_time( 'Y-m-d' );
+	// Timing uses one Events-site snapshot for filtering, totals, and row labels.
+	$now         = ec_users_get_events_now( $blog_id );
+	$timing_case = ec_users_build_event_timing_case( $now );
 
 	if ( 'upcoming' === $args['period'] ) {
-		$where[]   = 'DATE(ed.start_datetime) >= %s';
-		$prepare[] = $now_date;
+		$timing  = ec_users_build_event_timing_condition( 'active', $now );
+		$where[] = $timing['where'];
+		$prepare = array_merge( $prepare, $timing['prepare'] );
 	} elseif ( 'past' === $args['period'] ) {
-		$where[]   = 'DATE(ed.start_datetime) < %s';
-		$prepare[] = $now_date;
+		$timing  = ec_users_build_event_timing_condition( 'past', $now );
+		$where[] = $timing['where'];
+		$prepare = array_merge( $prepare, $timing['prepare'] );
 	}
 
 	if ( $args['year'] ) {
@@ -524,14 +613,14 @@ function ec_users_get_user_events( int $user_id, array $args = array() ): array 
 	// Fetch event IDs with date ordering.
 	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- table names from trusted helpers, $where_sql carries additional placeholders matched by $prepare; $order_sql validated to ASC/DESC above.
 	$query = $wpdb->prepare(
-		"SELECT ct.event_id, ct.created_at AS marked_at, DATE(ed.start_datetime) AS event_date
+		"SELECT ct.event_id, ct.created_at AS marked_at, DATE(ed.start_datetime) AS event_date, {$timing_case['sql']} AS timing
 		FROM {$table} ct
 		INNER JOIN {$dates_table} ed ON ct.event_id = ed.post_id
 		INNER JOIN {$posts_table} p ON ct.event_id = p.ID
 		WHERE {$where_sql}
 		ORDER BY ed.start_datetime {$order_sql}
 		LIMIT %d OFFSET %d",
-		...array_merge( $prepare, array( $args['per_page'], $offset ) )
+		...array_merge( $timing_case['prepare'], $prepare, array( $args['per_page'], $offset ) )
 	);
 	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
@@ -661,7 +750,7 @@ function ec_users_build_show_data( WP_Post $post, array $row ): array {
 		'venue'      => $venue,
 		'city'       => $city,
 		'artists'    => $artists,
-		'timing'     => ec_users_get_event_timing( $event_id ),
+		'timing'     => isset( $row['timing'] ) ? (string) $row['timing'] : ec_users_get_event_timing( $event_id, $blog_id ),
 		'marked_at'  => $row['marked_at'] ?? '',
 		'permalink'  => get_permalink( $event_id ),
 		'thumbnail'  => get_the_post_thumbnail_url( $event_id, 'medium' ),
@@ -686,7 +775,7 @@ function ec_users_build_show_data( WP_Post $post, array $row ): array {
 function ec_users_get_user_concert_stats( int $user_id, array $args = array() ): array {
 	global $wpdb;
 
-	$blog_id       = ! empty( $args['blog_id'] ) ? (int) $args['blog_id'] : ( function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : 7 );
+	$blog_id       = ! empty( $args['blog_id'] ) ? (int) $args['blog_id'] : ec_users_get_events_blog_id();
 	$table         = extrachill_users_concert_tracking_table_name();
 	$events_prefix = $wpdb->get_blog_prefix( $blog_id );
 	$posts_table   = $events_prefix . 'posts';
@@ -696,6 +785,9 @@ function ec_users_get_user_concert_stats( int $user_id, array $args = array() ):
 	// Base WHERE for this user + blog.
 	$where   = array( 'ct.user_id = %d', 'ct.blog_id = %d', 'p.post_type = %s', 'p.post_status = %s' );
 	$prepare = array( $user_id, $blog_id, 'data_machine_events', 'publish' );
+	$past    = ec_users_build_event_timing_condition( 'past', ec_users_get_events_now( $blog_id ) );
+	$where[] = $past['where'];
+	$prepare = array_merge( $prepare, $past['prepare'] );
 
 	if ( ! empty( $args['year'] ) ) {
 		$where[]   = 'YEAR(ed.start_datetime) = %d';
@@ -1106,7 +1198,7 @@ function ec_users_get_event_attendees( int $event_id, int $blog_id = 0, int $lim
 /**
  * Search past events for the "Add Past Shows" My Shows feature.
  *
- * Returns past events (start_datetime < NOW()) matching the query against:
+ * Returns canonically past events matching the query against:
  *   - event post title
  *   - artist taxonomy term names
  *   - venue taxonomy term names
@@ -1159,7 +1251,7 @@ function ec_users_search_events_for_marking( int $user_id, array $args = array()
 	}
 
 	$per_page = max( 1, min( 100, (int) $args['per_page'] ) );
-	$blog_id  = $args['blog_id'] ? (int) $args['blog_id'] : ( function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : 7 );
+	$blog_id  = $args['blog_id'] ? (int) $args['blog_id'] : ec_users_get_events_blog_id();
 
 	$events_prefix = $wpdb->get_blog_prefix( $blog_id );
 	$posts_table   = $events_prefix . 'posts';
@@ -1168,14 +1260,16 @@ function ec_users_search_events_for_marking( int $user_id, array $args = array()
 	$tt_table      = $events_prefix . 'term_taxonomy';
 	$terms_table   = $events_prefix . 'terms';
 
-	$now_mysql = current_time( 'mysql' );
+	$now_mysql   = ec_users_get_events_now( $blog_id );
+	$past        = ec_users_build_event_timing_condition( 'past', $now_mysql );
+	$timing_case = ec_users_build_event_timing_case( $now_mysql );
 
 	$where   = array(
 		"p.post_type = 'data_machine_events'",
 		"p.post_status = 'publish'",
-		'ed.start_datetime < %s',
+		$past['where'],
 	);
-	$prepare = array( $now_mysql );
+	$prepare = $past['prepare'];
 
 	// Build search clause if query provided.
 	if ( '' !== $query ) {
@@ -1206,7 +1300,7 @@ function ec_users_search_events_for_marking( int $user_id, array $args = array()
 		WHERE {$where_sql}",
 		...$prepare
 	);
-	$total = (int) $wpdb->get_var( $count_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- prepared above.
+	$total     = (int) $wpdb->get_var( $count_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- prepared above.
 	// phpcs:enable
 
 	$pages  = $per_page > 0 ? (int) ceil( $total / $per_page ) : 1;
@@ -1224,16 +1318,16 @@ function ec_users_search_events_for_marking( int $user_id, array $args = array()
 
 	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- table names from trusted prefix; placeholders inside $where_sql matched in $prepare.
 	$rows_sql = $wpdb->prepare(
-		"SELECT p.ID AS post_id, p.post_title, DATE(ed.start_datetime) AS event_date
+		"SELECT p.ID AS post_id, p.post_title, DATE(ed.start_datetime) AS event_date, {$timing_case['sql']} AS timing
 		FROM {$posts_table} p
 		INNER JOIN {$dates_table} ed ON p.ID = ed.post_id
 		WHERE {$where_sql}
 		GROUP BY p.ID
 		ORDER BY ed.start_datetime DESC
 		LIMIT %d OFFSET %d",
-		...array_merge( $prepare, array( $per_page, $offset ) )
+		...array_merge( $timing_case['prepare'], $prepare, array( $per_page, $offset ) )
 	);
-	$rows = $wpdb->get_results( $rows_sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- prepared above.
+	$rows     = $wpdb->get_results( $rows_sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- prepared above.
 	// phpcs:enable
 
 	if ( empty( $rows ) ) {

--- a/inc/core/abilities/concert-tracking.php
+++ b/inc/core/abilities/concert-tracking.php
@@ -157,7 +157,7 @@ function extrachill_users_register_concert_tracking_abilities() {
 		'extrachill/get-user-shows',
 		array(
 			'label'               => __( 'Get User Shows', 'extrachill-users' ),
-			'description'         => __( 'Get paginated concert history for a user with enriched event details.', 'extrachill-users' ),
+			'description'         => __( 'Get paginated concert history for a user with enriched event details. Public non-owner reads expose past shows only.', 'extrachill-users' ),
 			'category'            => 'extrachill-users',
 			'input_schema'        => array(
 				'type'       => 'object',
@@ -499,6 +499,20 @@ function extrachill_users_ability_get_user_shows( array $input ) {
 
 	if ( ! $user_id ) {
 		return new WP_Error( 'no_user', 'User ID required.', array( 'status' => 400 ) );
+	}
+
+	$is_owner = get_current_user_id() === $user_id || current_user_can( 'manage_network_options' );
+	if ( ! $is_owner ) {
+		if ( 'upcoming' === ( $input['period'] ?? 'all' ) ) {
+			return array(
+				'shows' => array(),
+				'total' => 0,
+				'pages' => 0,
+				'page'  => 1,
+			);
+		}
+
+		$input['period'] = 'past';
 	}
 
 	return ec_users_get_user_events( $user_id, $input );

--- a/tests/unit/ConcertHistoryTimingTest.php
+++ b/tests/unit/ConcertHistoryTimingTest.php
@@ -119,12 +119,79 @@ class Test_Concert_History_Timing extends WP_UnitTestCase {
 		$this->assertNotContains( $this->events['multi_day'], wp_list_pluck( $past['shows'], 'event_id' ) );
 
 		$stats = ec_users_get_user_concert_stats( $this->user_id );
-		$this->assertSame( 3, $stats['total_shows'] );
-		$this->assertSame( array( '2026' => 2, '2025' => 1 ), $stats['shows_by_year'] );
-		$this->assertSame( 2, ec_users_get_user_concert_stats( $this->user_id, array( 'year' => 2026 ) )['total_shows'] );
+		$this->assertSame( 8, $stats['total_shows'] );
+		$this->assertSame( array( '2026' => 7, '2025' => 1 ), $stats['shows_by_year'] );
+		$this->assertSame( 7, ec_users_get_user_concert_stats( $this->user_id, array( 'year' => 2026 ) )['total_shows'] );
+	}
+
+	public function test_upcoming_only_owner_stats_remain_nonzero_with_future_year_option(): void {
+		$owner_id = self::factory()->user->create();
+		$this->track_event( 'Future Owner Show', '2027-02-10 20:00:00', null, $owner_id );
+		wp_set_current_user( $owner_id );
+
+		$stats = wp_get_ability( 'extrachill/get-user-concert-stats' )->execute( array( 'user_id' => $owner_id ) );
+
+		$this->assertSame( 1, $stats['total_shows'] );
+		$this->assertSame( array( '2027' => 1 ), $stats['shows_by_year'] );
+		$this->assertSame( 1, wp_get_ability( 'extrachill/get-user-shows' )->execute( array( 'user_id' => $owner_id, 'period' => 'upcoming' ) )['total'] );
+	}
+
+	public function test_ongoing_only_owner_stats_remain_nonzero(): void {
+		$owner_id = self::factory()->user->create();
+		$this->track_event( 'Ongoing Owner Show', '2026-07-18 20:00:00', '2026-07-20 01:00:00', $owner_id );
+		wp_set_current_user( $owner_id );
+
+		$stats = wp_get_ability( 'extrachill/get-user-concert-stats' )->execute( array( 'user_id' => $owner_id ) );
+
+		$this->assertSame( 1, $stats['total_shows'] );
+		$this->assertSame( array( '2026' => 1 ), $stats['shows_by_year'] );
+		$this->assertSame( 1, wp_get_ability( 'extrachill/get-user-shows' )->execute( array( 'user_id' => $owner_id, 'period' => 'upcoming' ) )['total'] );
+	}
+
+	public function test_owner_stats_and_year_filter_include_mixed_past_and_future_years(): void {
+		$owner_id = self::factory()->user->create();
+		$this->track_event( 'Past Mixed Show', '2024-05-10 20:00:00', '2024-05-10 23:00:00', $owner_id );
+		$this->track_event( 'Future Mixed Show', '2027-05-10 20:00:00', null, $owner_id );
+		wp_set_current_user( $owner_id );
+
+		$stats        = wp_get_ability( 'extrachill/get-user-concert-stats' )->execute( array( 'user_id' => $owner_id ) );
+		$future_stats = wp_get_ability( 'extrachill/get-user-concert-stats' )->execute(
+			array(
+				'user_id' => $owner_id,
+				'year'    => 2027,
+			)
+		);
+
+		$this->assertSame( 2, $stats['total_shows'] );
+		$this->assertSame( array( '2027' => 1, '2024' => 1 ), $stats['shows_by_year'] );
+		$this->assertSame( 1, $future_stats['total_shows'] );
+		$this->assertSame( array( '2027' => 1 ), $future_stats['shows_by_year'] );
+	}
+
+	public function test_public_date_bounded_stats_remain_canonically_past_only(): void {
+		$owner_id = self::factory()->user->create();
+		$this->track_event( 'Public Past Show', '2025-05-10 20:00:00', '2025-05-10 23:00:00', $owner_id );
+		$this->track_event( 'Public Ongoing Show', '2026-07-18 20:00:00', '2026-07-20 01:00:00', $owner_id );
+		$this->track_event( 'Public Future Show', '2027-05-10 20:00:00', null, $owner_id );
+		wp_set_current_user( 0 );
+
+		$stats = wp_get_ability( 'extrachill/get-user-concert-stats' )->execute(
+			array(
+				'user_id' => $owner_id,
+				'date_to' => '2026-07-19',
+			)
+		);
+
+		$this->assertSame( 1, $stats['total_shows'] );
+		$this->assertSame( array( '2025' => 1 ), $stats['shows_by_year'] );
 	}
 
 	public function test_exact_boundaries_and_missing_end_match_canonical_states(): void {
+		$past_condition = ec_users_build_event_timing_condition( 'past', $this->now );
+		$this->assertStringContainsString( 'start_datetime < %s', $past_condition['where'] );
+		$this->assertStringContainsString( 'COALESCE(ed.end_datetime, ed.start_datetime) < %s', $past_condition['where'] );
+		$this->assertStringNotContainsString( ' OR ', $past_condition['where'] );
+
 		$this->assertSame( 'upcoming', ec_users_get_event_timing( $this->events['later_today'] ) );
 		$this->assertSame( 'past', ec_users_get_event_timing( $this->events['ended_today'] ) );
 		$this->assertSame( 'ongoing', ec_users_get_event_timing( $this->events['overnight'] ) );
@@ -203,7 +270,7 @@ class Test_Concert_History_Timing extends WP_UnitTestCase {
 		$this->assertNotContains( 'past', wp_list_pluck( $owner_upcoming['shows'], 'timing' ) );
 	}
 
-	private function track_event( string $title, string $start_datetime, ?string $end_datetime = null ): int {
+	private function track_event( string $title, string $start_datetime, ?string $end_datetime = null, ?int $user_id = null ): int {
 		global $wpdb;
 
 		switch_to_blog( $this->events_blog_id );
@@ -226,7 +293,7 @@ class Test_Concert_History_Timing extends WP_UnitTestCase {
 			),
 			array( '%d', '%s', '%s', '%s' )
 		);
-		ec_users_mark_event( $this->user_id, $post_id, $this->events_blog_id );
+		ec_users_mark_event( $user_id ? $user_id : $this->user_id, $post_id, $this->events_blog_id );
 
 		return $post_id;
 	}

--- a/tests/unit/ConcertHistoryTimingTest.php
+++ b/tests/unit/ConcertHistoryTimingTest.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Tests for canonical concert history timing.
+ *
+ * @package ExtraChill\Users
+ */
+
+class Test_Concert_History_Timing extends WP_UnitTestCase {
+
+	private int $events_blog_id;
+
+	private int $user_id;
+
+	private string $dates_table;
+
+	private string $now = '2026-07-19 12:00:00';
+
+	/** @var array<string, int> */
+	private array $events = array();
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		global $wpdb;
+
+		$this->events_blog_id = self::factory()->blog->create();
+		$this->user_id        = self::factory()->user->create();
+		$this->dates_table    = $wpdb->get_blog_prefix( $this->events_blog_id ) . 'datamachine_event_dates';
+
+		update_blog_option( $this->events_blog_id, 'timezone_string', 'America/New_York' );
+		add_filter( 'extrachill_users_events_blog_id', array( $this, 'filter_events_blog_id' ) );
+		add_filter( 'extrachill_users_event_timing_now', array( $this, 'filter_timing_now' ), 10, 2 );
+
+		extrachill_users_install_concert_tracking_table();
+		$wpdb->query(
+			"CREATE TABLE {$this->dates_table} (
+				post_id BIGINT UNSIGNED NOT NULL,
+				start_datetime DATETIME NOT NULL,
+				end_datetime DATETIME DEFAULT NULL,
+				post_status VARCHAR(20) NOT NULL DEFAULT 'publish',
+				PRIMARY KEY (post_id),
+				KEY start_datetime (start_datetime),
+				KEY end_datetime (end_datetime)
+			) {$wpdb->get_charset_collate()}"
+		); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test-only table name and schema.
+
+		switch_to_blog( $this->events_blog_id );
+		register_post_type( 'data_machine_events', array( 'public' => true ) );
+		register_taxonomy( 'artist', 'data_machine_events', array( 'public' => true ) );
+		register_taxonomy( 'venue', 'data_machine_events', array( 'public' => true ) );
+		register_taxonomy( 'location', 'data_machine_events', array( 'public' => true ) );
+		restore_current_blog();
+
+		$this->events = array(
+			'later_today'  => $this->track_event( 'Later Today', '2026-07-19 18:00:00' ),
+			'ended_today'  => $this->track_event( 'Ended Today', '2026-07-19 08:00:00', '2026-07-19 10:00:00' ),
+			'overnight'    => $this->track_event( 'Overnight', '2026-07-18 23:00:00', '2026-07-19 13:00:00' ),
+			'multi_day'    => $this->track_event( 'Multi-day', '2026-07-17 18:00:00', '2026-07-20 01:00:00' ),
+			'missing_end'  => $this->track_event( 'Missing End', '2026-07-19 10:00:00' ),
+			'exact_start'  => $this->track_event( 'Exact Start', '2026-07-19 12:00:00' ),
+			'exact_end'    => $this->track_event( 'Exact End', '2026-07-19 11:00:00', '2026-07-19 12:00:00' ),
+			'previous_year' => $this->track_event( 'Previous Year', '2025-06-01 20:00:00', '2025-06-01 23:00:00' ),
+		);
+	}
+
+	protected function tearDown(): void {
+		global $wpdb;
+
+		remove_filter( 'extrachill_users_events_blog_id', array( $this, 'filter_events_blog_id' ) );
+		remove_filter( 'extrachill_users_event_timing_now', array( $this, 'filter_timing_now' ), 10 );
+		wp_set_current_user( 0 );
+		$wpdb->query( "DROP TABLE IF EXISTS {$this->dates_table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test-only table name.
+
+		parent::tearDown();
+	}
+
+	public function filter_events_blog_id(): int {
+		return $this->events_blog_id;
+	}
+
+	public function filter_timing_now( string $now, int $blog_id ): string {
+		$this->assertSame( $this->events_blog_id, $blog_id );
+
+		return $this->now;
+	}
+
+	public function test_tabs_use_canonical_timing_for_rows_totals_pages_and_years(): void {
+		$upcoming_page_one = ec_users_get_user_events(
+			$this->user_id,
+			array(
+				'period'   => 'upcoming',
+				'page'     => 1,
+				'per_page' => 2,
+			)
+		);
+		$upcoming_page_three = ec_users_get_user_events(
+			$this->user_id,
+			array(
+				'period'   => 'upcoming',
+				'page'     => 3,
+				'per_page' => 2,
+			)
+		);
+		$upcoming_all        = ec_users_get_user_events( $this->user_id, array( 'period' => 'upcoming' ) );
+		$past                = ec_users_get_user_events( $this->user_id, array( 'period' => 'past' ) );
+
+		$this->assertSame( 5, $upcoming_page_one['total'] );
+		$this->assertSame( 3, $upcoming_page_one['pages'] );
+		$this->assertCount( 2, $upcoming_page_one['shows'] );
+		$this->assertSame( 5, $upcoming_page_three['total'] );
+		$this->assertSame( 3, $upcoming_page_three['pages'] );
+		$this->assertCount( 1, $upcoming_page_three['shows'] );
+		$this->assertNotContains( 'past', wp_list_pluck( $upcoming_all['shows'], 'timing' ) );
+		$this->assertContains( 'ongoing', wp_list_pluck( $upcoming_all['shows'], 'timing' ) );
+
+		$this->assertSame( 3, $past['total'] );
+		$this->assertSame( array( 'past' ), array_values( array_unique( wp_list_pluck( $past['shows'], 'timing' ) ) ) );
+		$this->assertNotContains( $this->events['overnight'], wp_list_pluck( $past['shows'], 'event_id' ) );
+		$this->assertNotContains( $this->events['multi_day'], wp_list_pluck( $past['shows'], 'event_id' ) );
+
+		$stats = ec_users_get_user_concert_stats( $this->user_id );
+		$this->assertSame( 3, $stats['total_shows'] );
+		$this->assertSame( array( '2026' => 2, '2025' => 1 ), $stats['shows_by_year'] );
+		$this->assertSame( 2, ec_users_get_user_concert_stats( $this->user_id, array( 'year' => 2026 ) )['total_shows'] );
+	}
+
+	public function test_exact_boundaries_and_missing_end_match_canonical_states(): void {
+		$this->assertSame( 'upcoming', ec_users_get_event_timing( $this->events['later_today'] ) );
+		$this->assertSame( 'past', ec_users_get_event_timing( $this->events['ended_today'] ) );
+		$this->assertSame( 'ongoing', ec_users_get_event_timing( $this->events['overnight'] ) );
+		$this->assertSame( 'ongoing', ec_users_get_event_timing( $this->events['multi_day'] ) );
+		$this->assertSame( 'past', ec_users_get_event_timing( $this->events['missing_end'] ) );
+		$this->assertSame( 'upcoming', ec_users_get_event_timing( $this->events['exact_start'] ) );
+		$this->assertSame( 'ongoing', ec_users_get_event_timing( $this->events['exact_end'] ) );
+
+		$this->assertSame( 0, ec_users_search_events_for_marking( $this->user_id, array( 'query' => 'Overnight' ) )['total'] );
+		$past_search = ec_users_search_events_for_marking( $this->user_id, array( 'query' => 'Ended Today' ) );
+		$this->assertSame( 1, $past_search['total'] );
+		$this->assertSame( 'past', $past_search['events'][0]['timing'] );
+	}
+
+	public function test_dst_boundary_uses_events_site_local_time(): void {
+		$this->now = '2026-03-08 03:00:00';
+		$event_id  = $this->track_event( 'DST Boundary', '2026-03-08 01:30:00', '2026-03-08 03:30:00' );
+
+		$this->assertSame( 'ongoing', ec_users_get_event_timing( $event_id ) );
+		$this->assertContains(
+			$event_id,
+			wp_list_pluck( ec_users_get_user_events( $this->user_id, array( 'period' => 'upcoming' ) )['shows'], 'event_id' )
+		);
+		$this->assertNotContains(
+			$event_id,
+			wp_list_pluck( ec_users_get_user_events( $this->user_id, array( 'period' => 'past' ) )['shows'], 'event_id' )
+		);
+	}
+
+	public function test_events_now_uses_events_timezone_and_restores_calling_blog(): void {
+		remove_filter( 'extrachill_users_event_timing_now', array( $this, 'filter_timing_now' ), 10 );
+		$original_blog_id = get_current_blog_id();
+		$before           = time();
+		$events_now       = ec_users_get_events_now( $this->events_blog_id );
+		$after            = time();
+		$timezone         = new DateTimeZone( 'America/New_York' );
+		$parsed           = DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $events_now, $timezone );
+
+		$this->assertSame( $original_blog_id, get_current_blog_id() );
+		$this->assertInstanceOf( DateTimeImmutable::class, $parsed );
+		$this->assertGreaterThanOrEqual( $before, $parsed->getTimestamp() );
+		$this->assertLessThanOrEqual( $after, $parsed->getTimestamp() );
+
+		add_filter( 'extrachill_users_event_timing_now', array( $this, 'filter_timing_now' ), 10, 2 );
+	}
+
+	public function test_public_non_owner_ability_remains_past_only(): void {
+		$ability = wp_get_ability( 'extrachill/get-user-shows' );
+		wp_set_current_user( 0 );
+
+		$public_upcoming = $ability->execute(
+			array(
+				'user_id' => $this->user_id,
+				'period'  => 'upcoming',
+			)
+		);
+		$public_all      = $ability->execute(
+			array(
+				'user_id' => $this->user_id,
+				'period'  => 'all',
+			)
+		);
+
+		$this->assertSame( 0, $public_upcoming['total'] );
+		$this->assertSame( 3, $public_all['total'] );
+		$this->assertSame( array( 'past' ), array_values( array_unique( wp_list_pluck( $public_all['shows'], 'timing' ) ) ) );
+
+		wp_set_current_user( $this->user_id );
+		$owner_upcoming = $ability->execute(
+			array(
+				'user_id' => $this->user_id,
+				'period'  => 'upcoming',
+			)
+		);
+		$this->assertSame( 5, $owner_upcoming['total'] );
+		$this->assertNotContains( 'past', wp_list_pluck( $owner_upcoming['shows'], 'timing' ) );
+	}
+
+	private function track_event( string $title, string $start_datetime, ?string $end_datetime = null ): int {
+		global $wpdb;
+
+		switch_to_blog( $this->events_blog_id );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => $title,
+				'post_status' => 'publish',
+				'post_type'   => 'data_machine_events',
+			)
+		);
+		restore_current_blog();
+
+		$wpdb->replace(
+			$this->dates_table,
+			array(
+				'post_id'        => $post_id,
+				'start_datetime' => $start_datetime,
+				'end_datetime'   => $end_datetime,
+				'post_status'    => 'publish',
+			),
+			array( '%d', '%s', '%s', '%s' )
+		);
+		ec_users_mark_event( $this->user_id, $post_id, $this->events_blog_id );
+
+		return $post_id;
+	}
+}


### PR DESCRIPTION
## Summary
- centralize canonical full-datetime SQL predicates for upcoming, ongoing, active, and past event states
- map ongoing events into Upcoming while keeping Past rows, totals, pages, and search canonically past-only
- preserve complete owner aggregate stats and future year options; apply canonical Past to stats only when the public-history `date_to` cutoff is supplied
- capture one Events-site timezone snapshot for filtering and row labels, with exact-boundary, DST, owner/public, and mixed-year coverage
- lead canonical Past with indexed `start_datetime < cutoff` and use `COALESCE(end_datetime, start_datetime) < cutoff` as the null-safe residual

## Query Plan Evidence
Production Events table: 100,443 rows.

Predicate equivalence at `2026-07-20 12:00:00`:
- original OR predicate: 68,753 rows
- indexed COALESCE predicate: 68,753 rows
- rows with `end_datetime == cutoff` admitted as Past: 0

Realistic production search EXPLAIN (title plus artist/venue term search, ordered and limited to 20):

```text
table  type   key             rows   Extra
ed     range  start_datetime  49086  Using index condition; Using where; Using temporary; Using filesort
p      eq_ref PRIMARY              1  Using where
```

The range starts on the indexed `start_datetime` column; the null-safe end test remains a residual while preserving exact canonical boundaries.

## Verification
- changed files passed WordPress PHPCS with zero findings (`364d663a-9109-40e1-8ad7-63d50ef2d8a9`)
- PHP syntax passed for all changed production/test files
- `git diff --check` passed
- PR-scoped safe audit passed with zero findings
- focused PHPUnit attempted (`5693e12e-f15e-4b39-8c0c-4d739d9ffb16`), but WP Codebox booted single-site and the plugin correctly aborted with `requires a WordPress multisite installation`; no tests executed
- full PHPUnit was not attempted because it uses the same unsupported single-site backend (runner defect already tracked in `Extra-Chill/homeboy-extensions#2305`)
- later PHPCS reruns were blocked by the installed Homeboy WordPress extension's corrupt Ruleset/PHPStan binaries; the successful zero-finding run above preceded that infrastructure failure

Closes #221