### PR TITLE
fix: bound public concert queries

### DIFF
--- a/inc/concert-tracking/service.php
+++ b/inc/concert-tracking/service.php
@@ -1070,7 +1070,7 @@ function ec_users_events_term_archive_url( string $slug, string $taxonomy, int $
  * @param int $event_id Event post ID.
  * @param int $blog_id Blog ID (default: current blog).
  * @param mixed $limit Max users to return (1-100). Default 10.
- * @return array Array of user data.
+ * @return array<int, array{user_id: int, display_name: string, avatar_url: string, profile_url: string}> Attendee data, newest mark first.
  */
 function ec_users_get_event_attendees( int $event_id, int $blog_id = 0, $limit = EC_USERS_EVENT_ATTENDEE_LIMIT_DEFAULT ): array {
 	global $wpdb;
@@ -1107,8 +1107,8 @@ function ec_users_get_event_attendees( int $event_id, int $blog_id = 0, $limit =
 
 		$attendees[] = array(
 			'user_id'      => (int) $user->ID,
-			'display_name' => $user->display_name,
-			'avatar_url'   => get_avatar_url( $user->ID, array( 'size' => 48 ) ),
+			'display_name' => (string) $user->display_name,
+			'avatar_url'   => (string) get_avatar_url( $user->ID, array( 'size' => 48 ) ),
 			'profile_url'  => $profile_url,
 		);
 	}

--- a/inc/concert-tracking/service.php
+++ b/inc/concert-tracking/service.php
@@ -16,6 +16,13 @@ defined( 'ABSPATH' ) || exit;
 
 require_once __DIR__ . '/db.php';
 
+const EC_USERS_CONCERT_HISTORY_PER_PAGE_MIN     = 1;
+const EC_USERS_CONCERT_HISTORY_PER_PAGE_DEFAULT = 20;
+const EC_USERS_CONCERT_HISTORY_PER_PAGE_MAX     = 100;
+const EC_USERS_EVENT_ATTENDEE_LIMIT_MIN         = 1;
+const EC_USERS_EVENT_ATTENDEE_LIMIT_DEFAULT     = 10;
+const EC_USERS_EVENT_ATTENDEE_LIMIT_MAX         = 100;
+
 // ─── Core CRUD ───────────────────────────────────────────────────────────────
 
 /**
@@ -432,7 +439,7 @@ function ec_users_format_count_label( int $count, string $timing ): string {
  *     @type string $date_from Start date (Y-m-d).
  *     @type string $date_to   End date (Y-m-d).
  *     @type int    $page      Page number. Default 1.
- *     @type int    $per_page  Results per page. Default 20.
+ *     @type int    $per_page  Results per page (1-100). Default 20.
  *     @type string $order     'ASC' | 'DESC'. Default depends on period.
  * }
  * @return array{ shows: array, total: int, pages: int, page: int }
@@ -446,12 +453,16 @@ function ec_users_get_user_events( int $user_id, array $args = array() ): array 
 		'date_from' => '',
 		'date_to'   => '',
 		'page'      => 1,
-		'per_page'  => 20,
+		'per_page'  => EC_USERS_CONCERT_HISTORY_PER_PAGE_DEFAULT,
 		'order'     => '',
 		'blog_id'   => 0,
 	);
 
-	$args = wp_parse_args( $args, $defaults );
+	$args     = wp_parse_args( $args, $defaults );
+	$per_page = max(
+		EC_USERS_CONCERT_HISTORY_PER_PAGE_MIN,
+		min( EC_USERS_CONCERT_HISTORY_PER_PAGE_MAX, (int) $args['per_page'] )
+	);
 
 	// Default sort: upcoming ASC (soonest first), past DESC (most recent first).
 	if ( ! $args['order'] ) {
@@ -516,10 +527,10 @@ function ec_users_get_user_events( int $user_id, array $args = array() ): array 
 	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 
 	$total = (int) $wpdb->get_var( $count_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- prepared above.
-	$pages = $args['per_page'] > 0 ? (int) ceil( $total / $args['per_page'] ) : 1;
+	$pages = (int) ceil( $total / $per_page );
 	$page  = max( 1, min( (int) $args['page'], $pages ? $pages : 1 ) );
 
-	$offset = ( $page - 1 ) * $args['per_page'];
+	$offset = ( $page - 1 ) * $per_page;
 
 	// Fetch event IDs with date ordering.
 	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- table names from trusted helpers, $where_sql carries additional placeholders matched by $prepare; $order_sql validated to ASC/DESC above.
@@ -531,7 +542,7 @@ function ec_users_get_user_events( int $user_id, array $args = array() ): array 
 		WHERE {$where_sql}
 		ORDER BY ed.start_datetime {$order_sql}
 		LIMIT %d OFFSET %d",
-		...array_merge( $prepare, array( $args['per_page'], $offset ) )
+		...array_merge( $prepare, array( $per_page, $offset ) )
 	);
 	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
@@ -1058,11 +1069,15 @@ function ec_users_events_term_archive_url( string $slug, string $taxonomy, int $
  *
  * @param int $event_id Event post ID.
  * @param int $blog_id Blog ID (default: current blog).
- * @param int $limit Max users to return. Default 10.
+ * @param mixed $limit Max users to return (1-100). Default 10.
  * @return array Array of user data.
  */
-function ec_users_get_event_attendees( int $event_id, int $blog_id = 0, int $limit = 10 ): array {
+function ec_users_get_event_attendees( int $event_id, int $blog_id = 0, $limit = EC_USERS_EVENT_ATTENDEE_LIMIT_DEFAULT ): array {
 	global $wpdb;
+	$limit = max(
+		EC_USERS_EVENT_ATTENDEE_LIMIT_MIN,
+		min( EC_USERS_EVENT_ATTENDEE_LIMIT_MAX, (int) $limit )
+	);
 
 	if ( ! $blog_id ) {
 		$blog_id = get_current_blog_id();

--- a/inc/core/abilities/concert-tracking.php
+++ b/inc/core/abilities/concert-tracking.php
@@ -195,8 +195,10 @@ function extrachill_users_register_concert_tracking_abilities() {
 					),
 					'per_page'  => array(
 						'type'        => 'integer',
-						'description' => 'Results per page.',
-						'default'     => 20,
+						'description' => 'Results per page (1-100).',
+						'default'     => EC_USERS_CONCERT_HISTORY_PER_PAGE_DEFAULT,
+						'minimum'     => EC_USERS_CONCERT_HISTORY_PER_PAGE_MIN,
+						'maximum'     => EC_USERS_CONCERT_HISTORY_PER_PAGE_MAX,
 					),
 				),
 			),
@@ -363,8 +365,10 @@ function extrachill_users_register_concert_tracking_abilities() {
 					),
 					'limit'             => array(
 						'type'        => 'integer',
-						'description' => 'Max attendees to return.',
-						'default'     => 10,
+						'description' => 'Max attendees to return (1-100).',
+						'default'     => EC_USERS_EVENT_ATTENDEE_LIMIT_DEFAULT,
+						'minimum'     => EC_USERS_EVENT_ATTENDEE_LIMIT_MIN,
+						'maximum'     => EC_USERS_EVENT_ATTENDEE_LIMIT_MAX,
 					),
 				),
 				'required'   => array( 'event_id' ),
@@ -579,7 +583,7 @@ function extrachill_users_ability_get_event_attendance( array $input ) {
 	}
 
 	if ( ! empty( $input['include_attendees'] ) ) {
-		$limit               = ! empty( $input['limit'] ) ? (int) $input['limit'] : 10;
+		$limit               = $input['limit'] ?? EC_USERS_EVENT_ATTENDEE_LIMIT_DEFAULT;
 		$result['attendees'] = ec_users_get_event_attendees( $event_id, $blog_id, $limit );
 	}
 

--- a/inc/core/abilities/concert-tracking.php
+++ b/inc/core/abilities/concert-tracking.php
@@ -380,7 +380,19 @@ function extrachill_users_register_concert_tracking_abilities() {
 					'count_label' => array( 'type' => 'string' ),
 					'timing'      => array( 'type' => 'string' ),
 					'user_marked' => array( 'type' => 'boolean' ),
-					'attendees'   => array( 'type' => 'array' ),
+					'attendees'   => array(
+						'type'  => 'array',
+						'items' => array(
+							'type'       => 'object',
+							'properties' => array(
+								'user_id'      => array( 'type' => 'integer' ),
+								'display_name' => array( 'type' => 'string' ),
+								'avatar_url'   => array( 'type' => 'string' ),
+								'profile_url'  => array( 'type' => 'string' ),
+							),
+							'required'   => array( 'user_id', 'display_name', 'avatar_url', 'profile_url' ),
+						),
+					),
 				),
 				'required'   => array( 'count', 'count_label', 'timing', 'user_marked', 'attendees' ),
 			),

--- a/tests/unit/ConcertHistoryVisibilityTest.php
+++ b/tests/unit/ConcertHistoryVisibilityTest.php
@@ -16,6 +16,9 @@ class Test_Concert_History_Visibility extends WP_UnitTestCase {
 	/** @var string */
 	private $dates_table;
 
+	/** @var string[] */
+	private $history_queries = array();
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -123,6 +126,128 @@ class Test_Concert_History_Visibility extends WP_UnitTestCase {
 		$this->assertSame( 'Latest Public', $stats['latest_show']['title'] );
 	}
 
+	public function test_large_public_history_clamps_service_bounds_and_preserves_pagination(): void {
+		$event_ids = array();
+		for ( $index = 0; $index < 105; ++$index ) {
+			$event_ids[] = $this->track_event(
+				'Past Event ' . $index,
+				'publish',
+				'data_machine_events',
+				gmdate( 'Y-m-d H:i:s', strtotime( '2023-01-01 20:00:00 UTC' ) + ( $index * DAY_IN_SECONDS ) )
+			);
+		}
+		$future_event = $this->track_event( 'Future Event', 'publish', 'data_machine_events', '2099-01-01 20:00:00' );
+
+		$default = ec_users_get_user_events(
+			$this->user_id,
+			array(
+				'blog_id' => $this->events_blog_id,
+				'period'  => 'past',
+			)
+		);
+		$this->assertCount( EC_USERS_CONCERT_HISTORY_PER_PAGE_DEFAULT, $default['shows'] );
+		$this->assertSame( 105, $default['total'] );
+		$this->assertSame( 6, $default['pages'] );
+
+		foreach ( array( 0, -10, 'not-a-number' ) as $malformed_per_page ) {
+			$minimum = ec_users_get_user_events(
+				$this->user_id,
+				array(
+					'blog_id'  => $this->events_blog_id,
+					'period'   => 'past',
+					'per_page' => $malformed_per_page,
+				)
+			);
+			$this->assertCount( EC_USERS_CONCERT_HISTORY_PER_PAGE_MIN, $minimum['shows'] );
+			$this->assertSame( 105, $minimum['pages'] );
+		}
+
+		$maximum = ec_users_get_user_events(
+			$this->user_id,
+			array(
+				'blog_id'  => $this->events_blog_id,
+				'period'   => 'past',
+				'per_page' => EC_USERS_CONCERT_HISTORY_PER_PAGE_MAX,
+			)
+		);
+		$this->assertCount( 100, $maximum['shows'] );
+		$this->assertSame( 2, $maximum['pages'] );
+
+		$ability_default = wp_get_ability( 'extrachill/get-user-shows' )->execute(
+			array(
+				'user_id' => $this->user_id,
+				'blog_id' => $this->events_blog_id,
+				'period'  => 'past',
+			)
+		);
+		$this->assertFalse( is_wp_error( $ability_default ) );
+		$this->assertCount( 20, $ability_default['shows'] );
+
+		foreach ( array( 1, 100 ) as $valid_per_page ) {
+			$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/extrachill/get-user-shows/run' );
+			$request->set_query_params(
+				array(
+					'input' => array(
+						'user_id'  => $this->user_id,
+						'blog_id'  => $this->events_blog_id,
+						'period'   => 'past',
+						'per_page' => $valid_per_page,
+					),
+				)
+			);
+			$response = rest_do_request( $request );
+			$this->assertSame( 200, $response->get_status() );
+			$this->assertCount( $valid_per_page, $response->get_data()['shows'] );
+		}
+
+		foreach ( array( 0, -1, 101, 'all' ) as $invalid_per_page ) {
+			$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/extrachill/get-user-shows/run' );
+			$request->set_query_params(
+				array(
+					'input' => array(
+						'user_id'  => $this->user_id,
+						'blog_id'  => $this->events_blog_id,
+						'period'   => 'past',
+						'per_page' => $invalid_per_page,
+					),
+				)
+			);
+			$this->assertSame( 400, rest_do_request( $request )->get_status() );
+		}
+
+		add_filter( 'query', array( $this, 'capture_history_query' ) );
+		try {
+			$clamped = ec_users_get_user_events(
+				$this->user_id,
+				array(
+					'blog_id'  => $this->events_blog_id,
+					'period'   => 'past',
+					'page'     => PHP_INT_MAX,
+					'per_page' => (string) PHP_INT_MAX,
+				)
+			);
+		} finally {
+			remove_filter( 'query', array( $this, 'capture_history_query' ) );
+		}
+
+		$this->assertCount( 5, $clamped['shows'] );
+		$this->assertSame( 2, $clamped['page'] );
+		$this->assertSame( 2, $clamped['pages'] );
+		$this->assertNotContains( $future_event, wp_list_pluck( $clamped['shows'], 'event_id' ) );
+		$this->assertNotEmpty( $this->history_queries );
+		$this->assertStringContainsString( 'LIMIT 100 OFFSET 100', end( $this->history_queries ) );
+		$this->assertStringNotContainsString( '%d', end( $this->history_queries ) );
+		$this->assertSame( array_slice( $event_ids, 0, 5 ), array_reverse( wp_list_pluck( $clamped['shows'], 'event_id' ) ) );
+	}
+
+	public function capture_history_query( string $query ): string {
+		if ( false !== strpos( $query, 'SELECT ct.event_id' ) ) {
+			$this->history_queries[] = $query;
+		}
+
+		return $query;
+	}
+
 	private function track_event( string $title, string $status, string $post_type, string $start_datetime ): int {
 		switch_to_blog( $this->events_blog_id );
 		$post_id = self::factory()->post->create(
@@ -135,7 +260,17 @@ class Test_Concert_History_Visibility extends WP_UnitTestCase {
 		restore_current_blog();
 
 		$this->write_event_date( $post_id, $start_datetime, $status );
-		ec_users_mark_event( $this->user_id, $post_id, $this->events_blog_id );
+		global $wpdb;
+		$wpdb->insert(
+			extrachill_users_concert_tracking_table_name(),
+			array(
+				'user_id'    => $this->user_id,
+				'event_id'   => $post_id,
+				'blog_id'    => $this->events_blog_id,
+				'created_at' => current_time( 'mysql', true ),
+			),
+			array( '%d', '%d', '%d', '%s' )
+		);
 
 		return $post_id;
 	}

--- a/tests/unit/ConcertTrackingAbilitiesTest.php
+++ b/tests/unit/ConcertTrackingAbilitiesTest.php
@@ -265,14 +265,14 @@ class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
 
 	public function invalid_reader_input_provider(): array {
 		return array(
-			'history zero'         => array( 'extrachill/get-user-shows', 'per_page', 0 ),
-			'history negative'     => array( 'extrachill/get-user-shows', 'per_page', -1 ),
-			'history over maximum' => array( 'extrachill/get-user-shows', 'per_page', 101 ),
-			'history nonnumeric'   => array( 'extrachill/get-user-shows', 'per_page', 'all' ),
-			'attendee zero'        => array( 'extrachill/get-event-attendance', 'limit', 0 ),
-			'attendee negative'    => array( 'extrachill/get-event-attendance', 'limit', -1 ),
+			'history zero'          => array( 'extrachill/get-user-shows', 'per_page', 0 ),
+			'history negative'      => array( 'extrachill/get-user-shows', 'per_page', -1 ),
+			'history over maximum'  => array( 'extrachill/get-user-shows', 'per_page', 101 ),
+			'history nonnumeric'    => array( 'extrachill/get-user-shows', 'per_page', 'all' ),
+			'attendee zero'         => array( 'extrachill/get-event-attendance', 'limit', 0 ),
+			'attendee negative'     => array( 'extrachill/get-event-attendance', 'limit', -1 ),
 			'attendee over maximum' => array( 'extrachill/get-event-attendance', 'limit', 101 ),
-			'attendee nonnumeric'  => array( 'extrachill/get-event-attendance', 'limit', 'all' ),
+			'attendee nonnumeric'   => array( 'extrachill/get-event-attendance', 'limit', 'all' ),
 		);
 	}
 

--- a/tests/unit/ConcertTrackingAbilitiesTest.php
+++ b/tests/unit/ConcertTrackingAbilitiesTest.php
@@ -16,6 +16,9 @@ class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
 
 	private int $user_id;
 
+	/** @var string[] */
+	private array $attendee_queries = array();
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->events_blog_id = self::factory()->blog->create();
@@ -229,6 +232,129 @@ class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
 		revoke_super_admin( $administrator_id );
 	}
 
+	public function test_registered_reader_schemas_declare_shared_query_bounds(): void {
+		$history_schema = wp_get_ability( 'extrachill/get-user-shows' )->get_input_schema()['properties']['per_page'];
+		$this->assertSame( EC_USERS_CONCERT_HISTORY_PER_PAGE_MIN, $history_schema['minimum'] );
+		$this->assertSame( EC_USERS_CONCERT_HISTORY_PER_PAGE_DEFAULT, $history_schema['default'] );
+		$this->assertSame( EC_USERS_CONCERT_HISTORY_PER_PAGE_MAX, $history_schema['maximum'] );
+
+		$attendee_schema = wp_get_ability( 'extrachill/get-event-attendance' )->get_input_schema()['properties']['limit'];
+		$this->assertSame( EC_USERS_EVENT_ATTENDEE_LIMIT_MIN, $attendee_schema['minimum'] );
+		$this->assertSame( EC_USERS_EVENT_ATTENDEE_LIMIT_DEFAULT, $attendee_schema['default'] );
+		$this->assertSame( EC_USERS_EVENT_ATTENDEE_LIMIT_MAX, $attendee_schema['maximum'] );
+	}
+
+	/**
+	 * @dataProvider invalid_reader_input_provider
+	 */
+	public function test_registered_reader_abilities_reject_malformed_and_out_of_range_inputs( string $ability_name, string $field, $value ): void {
+		$input = 'extrachill/get-user-shows' === $ability_name
+			? array(
+				'user_id' => $this->user_id,
+				$field     => $value,
+			)
+			: array(
+				'event_id' => $this->event_id,
+				$field      => $value,
+			);
+		$result = wp_get_ability( $ability_name )->execute( $input );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'ability_invalid_input', $result->get_error_code() );
+	}
+
+	public function invalid_reader_input_provider(): array {
+		return array(
+			'history zero'         => array( 'extrachill/get-user-shows', 'per_page', 0 ),
+			'history negative'     => array( 'extrachill/get-user-shows', 'per_page', -1 ),
+			'history over maximum' => array( 'extrachill/get-user-shows', 'per_page', 101 ),
+			'history nonnumeric'   => array( 'extrachill/get-user-shows', 'per_page', 'all' ),
+			'attendee zero'        => array( 'extrachill/get-event-attendance', 'limit', 0 ),
+			'attendee negative'    => array( 'extrachill/get-event-attendance', 'limit', -1 ),
+			'attendee over maximum' => array( 'extrachill/get-event-attendance', 'limit', 101 ),
+			'attendee nonnumeric'  => array( 'extrachill/get-event-attendance', 'limit', 'all' ),
+		);
+	}
+
+	public function test_attendee_service_clamps_defaults_boundaries_and_malformed_values(): void {
+		$this->seed_attendees( 105 );
+
+		$this->assertCount( 10, ec_users_get_event_attendees( $this->event_id, $this->events_blog_id ) );
+		foreach ( array( 0, -10, 'not-a-number' ) as $malformed_limit ) {
+			$this->assertCount( 1, ec_users_get_event_attendees( $this->event_id, $this->events_blog_id, $malformed_limit ) );
+		}
+
+		add_filter( 'query', array( $this, 'capture_attendee_query' ) );
+		try {
+			$maximum = ec_users_get_event_attendees( $this->event_id, $this->events_blog_id, PHP_INT_MAX );
+		} finally {
+			remove_filter( 'query', array( $this, 'capture_attendee_query' ) );
+		}
+
+		$this->assertCount( 100, $maximum );
+		$this->assertNotEmpty( $this->attendee_queries );
+		$this->assertStringContainsString( 'LIMIT 100', end( $this->attendee_queries ) );
+		$this->assertStringNotContainsString( '%d', end( $this->attendee_queries ) );
+	}
+
+	public function test_registered_attendance_ability_and_rest_route_apply_defaults_and_bounds(): void {
+		$this->seed_attendees( 105 );
+		$ability = wp_get_ability( 'extrachill/get-event-attendance' );
+
+		$default = $ability->execute(
+			array(
+				'event_id'          => $this->event_id,
+				'blog_id'           => $this->events_blog_id,
+				'include_attendees' => true,
+			)
+		);
+		$this->assertCount( 10, $default['attendees'] );
+
+		$minimum = $ability->execute(
+			array(
+				'event_id'          => $this->event_id,
+				'blog_id'           => $this->events_blog_id,
+				'include_attendees' => true,
+				'limit'             => 1,
+			)
+		);
+		$this->assertCount( 1, $minimum['attendees'] );
+
+		$maximum = $ability->execute(
+			array(
+				'event_id'          => $this->event_id,
+				'blog_id'           => $this->events_blog_id,
+				'include_attendees' => true,
+				'limit'             => 100,
+			)
+		);
+		$this->assertCount( 100, $maximum['attendees'] );
+
+		wp_set_current_user( 0 );
+		foreach ( array( 0, -1, 101, 'all' ) as $invalid_limit ) {
+			$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/extrachill/get-event-attendance/run' );
+			$request->set_query_params(
+				array(
+					'input' => array(
+						'event_id'          => $this->event_id,
+						'blog_id'           => $this->events_blog_id,
+						'include_attendees' => true,
+						'limit'             => $invalid_limit,
+					),
+				)
+			);
+			$this->assertSame( 400, rest_do_request( $request )->get_status() );
+		}
+	}
+
+	public function capture_attendee_query( string $query ): string {
+		if ( false !== strpos( $query, 'SELECT user_id' ) && false !== strpos( $query, 'LIMIT' ) ) {
+			$this->attendee_queries[] = $query;
+		}
+
+		return $query;
+	}
+
 	public function test_registered_set_ability_reports_insert_and_delete_failures(): void {
 		global $wpdb;
 		$ability = wp_get_ability( 'extrachill/set-event-mark' );
@@ -295,5 +421,22 @@ class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
 		global $wpdb;
 		$table = extrachill_users_concert_tracking_table_name();
 		$wpdb->query( "DELETE FROM {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- trusted table helper.
+	}
+
+	private function seed_attendees( int $count ): void {
+		global $wpdb;
+		$table = extrachill_users_concert_tracking_table_name();
+		for ( $index = 0; $index < $count; ++$index ) {
+			$wpdb->insert(
+				$table,
+				array(
+					'user_id'    => self::factory()->user->create(),
+					'event_id'   => $this->event_id,
+					'blog_id'    => $this->events_blog_id,
+					'created_at' => gmdate( 'Y-m-d H:i:s', time() - $index ),
+				),
+				array( '%d', '%d', '%d', '%s' )
+			);
+		}
 	}
 }

--- a/tests/unit/ConcertTrackingAbilitiesTest.php
+++ b/tests/unit/ConcertTrackingAbilitiesTest.php
@@ -242,6 +242,10 @@ class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
 		$this->assertSame( EC_USERS_EVENT_ATTENDEE_LIMIT_MIN, $attendee_schema['minimum'] );
 		$this->assertSame( EC_USERS_EVENT_ATTENDEE_LIMIT_DEFAULT, $attendee_schema['default'] );
 		$this->assertSame( EC_USERS_EVENT_ATTENDEE_LIMIT_MAX, $attendee_schema['maximum'] );
+		$this->assertSame(
+			array( 'user_id', 'display_name', 'avatar_url', 'profile_url' ),
+			wp_get_ability( 'extrachill/get-event-attendance' )->get_output_schema()['properties']['attendees']['items']['required']
+		);
 	}
 
 	/**
@@ -277,9 +281,16 @@ class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
 	}
 
 	public function test_attendee_service_clamps_defaults_boundaries_and_malformed_values(): void {
-		$this->seed_attendees( 105 );
+		$seeded_user_ids = $this->seed_attendees( 105 );
 
-		$this->assertCount( 10, ec_users_get_event_attendees( $this->event_id, $this->events_blog_id ) );
+		$default = ec_users_get_event_attendees( $this->event_id, $this->events_blog_id );
+		$this->assertCount( 10, $default );
+		$this->assertSame( array_slice( $seeded_user_ids, 0, 10 ), wp_list_pluck( $default, 'user_id' ) );
+		$this->assertSame( array( 'user_id', 'display_name', 'avatar_url', 'profile_url' ), array_keys( $default[0] ) );
+		$this->assertIsInt( $default[0]['user_id'] );
+		$this->assertIsString( $default[0]['display_name'] );
+		$this->assertIsString( $default[0]['avatar_url'] );
+		$this->assertIsString( $default[0]['profile_url'] );
 		foreach ( array( 0, -10, 'not-a-number' ) as $malformed_limit ) {
 			$this->assertCount( 1, ec_users_get_event_attendees( $this->event_id, $this->events_blog_id, $malformed_limit ) );
 		}
@@ -423,14 +434,17 @@ class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
 		$wpdb->query( "DELETE FROM {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- trusted table helper.
 	}
 
-	private function seed_attendees( int $count ): void {
+	private function seed_attendees( int $count ): array {
 		global $wpdb;
-		$table = extrachill_users_concert_tracking_table_name();
+		$table    = extrachill_users_concert_tracking_table_name();
+		$user_ids = array();
 		for ( $index = 0; $index < $count; ++$index ) {
+			$user_id    = self::factory()->user->create();
+			$user_ids[] = $user_id;
 			$wpdb->insert(
 				$table,
 				array(
-					'user_id'    => self::factory()->user->create(),
+					'user_id'    => $user_id,
 					'event_id'   => $this->event_id,
 					'blog_id'    => $this->events_blog_id,
 					'created_at' => gmdate( 'Y-m-d H:i:s', time() - $index ),
@@ -438,5 +452,7 @@ class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
 				array( '%d', '%d', '%d', '%s' )
 			);
 		}
+
+		return $user_ids;
 	}
 }


### PR DESCRIPTION
## Summary
- enforce shared `1..100` history and attendee bounds in the canonical Users service while preserving shipped defaults (`20` history, `10` attendees)
- expose the same minimum/default/maximum contract through registered ability schemas and native ability REST validation
- document attendee item fields, normalize response scalar types, and verify newest-first `created_at` ordering
- cover malformed, zero, negative, oversized, boundary, prepared-SQL, pagination, public past-only, and realistic 105-record histories/attendee lists

## Companion transport PR
Extra-Chill/extrachill-api#119 mirrors these contracts in the shipped `/extrachill/v1` routes and removes coercive `absint` sanitization. Merge this canonical Users PR first, then merge API #119.

## Verification
- PHP syntax passed for all changed PHP files
- `git diff --check origin/main...HEAD` passed
- scoped Homeboy lint/PHPCS passed (`c27a8034-8fa6-47b7-ac3f-f02bc49812b8`); two pre-existing alignment warnings remain outside changed hunks
- focused PHPUnit attempted, but WP Codebox failed during multisite install before loading tests (`7700c630-0970-47cd-8aa6-ae1f08f318dd`)
- runner defects tracked in Extra-Chill/homeboy-extensions#2305

Closes #219