### PR TITLE
feat: add concert privacy controls

### DIFF
--- a/inc/concert-tracking/service.php
+++ b/inc/concert-tracking/service.php
@@ -806,10 +806,12 @@ function ec_users_get_user_concert_stats( int $user_id, array $args = array() ):
 		$where[]   = 'DATE(ed.start_datetime) >= %s';
 		$prepare[] = sanitize_text_field( $args['date_from'] );
 	}
+	if ( ! empty( $args['past_only'] ) ) {
+		$past    = ec_users_build_event_timing_condition( 'past', ec_users_get_events_now( $blog_id ) );
+		$where[] = $past['where'];
+		$prepare = array_merge( $prepare, $past['prepare'] );
+	}
 	if ( ! empty( $args['date_to'] ) ) {
-		$past      = ec_users_build_event_timing_condition( 'past', ec_users_get_events_now( $blog_id ) );
-		$where[]   = $past['where'];
-		$prepare   = array_merge( $prepare, $past['prepare'] );
 		$where[]   = 'DATE(ed.start_datetime) <= %s';
 		$prepare[] = sanitize_text_field( $args['date_to'] );
 	}
@@ -1180,9 +1182,18 @@ function ec_users_get_event_attendees( int $event_id, int $blog_id = 0, $limit =
 
 	$user_ids = $wpdb->get_col(
 		$wpdb->prepare(
-			"SELECT user_id FROM {$table} WHERE event_id = %d AND blog_id = %d ORDER BY created_at DESC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+			"SELECT user_id FROM {$table} ct
+			WHERE event_id = %d AND blog_id = %d
+			AND NOT EXISTS (
+				SELECT 1 FROM {$wpdb->usermeta} um
+				WHERE um.user_id = ct.user_id
+				AND um.meta_key = %s
+				AND um.meta_value = 'private'
+			)
+			ORDER BY created_at DESC, id DESC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table names are trusted WordPress tables.
 			$event_id,
 			$blog_id,
+			EXTRACHILL_USERS_EVENT_ATTENDANCE_VISIBILITY_META_KEY,
 			$limit
 		)
 	);

--- a/inc/core/abilities/concert-tracking.php
+++ b/inc/core/abilities/concert-tracking.php
@@ -45,6 +45,37 @@ function extrachill_users_can_get_event_attendance( array $input ): bool {
 }
 
 /**
+ * Check whether the current reader has full owner/admin concert history access.
+ *
+ * @param int $user_id History owner ID.
+ * @return bool
+ */
+function extrachill_users_can_view_full_concert_history( int $user_id ): bool {
+	return get_current_user_id() === $user_id
+		|| current_user_can( 'manage_network_options' );
+}
+
+/**
+ * Check whether the current reader may read a user's concert history.
+ *
+ * @param int $user_id History owner ID.
+ * @return bool
+ */
+function extrachill_users_can_view_concert_history( int $user_id ): bool {
+	return extrachill_users_can_view_full_concert_history( $user_id )
+		|| 'public' === extrachill_users_get_concert_history_visibility( $user_id );
+}
+
+/**
+ * Build the canonical private-history response.
+ *
+ * @return WP_Error
+ */
+function extrachill_users_concert_history_private_error(): WP_Error {
+	return new WP_Error( 'concert_history_private', __( 'This concert history is private.', 'extrachill-users' ), array( 'status' => 403 ) );
+}
+
+/**
  * Register concert tracking abilities.
  */
 function extrachill_users_register_concert_tracking_abilities() {
@@ -517,8 +548,12 @@ function extrachill_users_ability_get_user_shows( array $input ) {
 		return new WP_Error( 'no_user', 'User ID required.', array( 'status' => 400 ) );
 	}
 
-	$is_owner = get_current_user_id() === $user_id || current_user_can( 'manage_network_options' );
+	$is_owner = extrachill_users_can_view_full_concert_history( $user_id );
 	if ( ! $is_owner ) {
+		if ( ! extrachill_users_can_view_concert_history( $user_id ) ) {
+			return extrachill_users_concert_history_private_error();
+		}
+
 		if ( 'upcoming' === ( $input['period'] ?? 'all' ) ) {
 			return array(
 				'shows' => array(),
@@ -545,6 +580,15 @@ function extrachill_users_ability_get_user_concert_stats( array $input ) {
 
 	if ( ! $user_id ) {
 		return new WP_Error( 'no_user', 'User ID required.', array( 'status' => 400 ) );
+	}
+
+	$is_owner = extrachill_users_can_view_full_concert_history( $user_id );
+	if ( ! $is_owner ) {
+		if ( ! extrachill_users_can_view_concert_history( $user_id ) ) {
+			return extrachill_users_concert_history_private_error();
+		}
+
+		$input['past_only'] = true;
 	}
 
 	return ec_users_get_user_concert_stats( $user_id, $input );

--- a/inc/core/abilities/user-settings.php
+++ b/inc/core/abilities/user-settings.php
@@ -16,8 +16,12 @@ const EXTRACHILL_USERS_DEFAULT_EVENT_LOCATION_META_KEY       = '_extrachill_defa
 const EXTRACHILL_USERS_LOCAL_SCENE_META_KEY                  = '_extrachill_local_scene';
 const EXTRACHILL_USERS_LOCAL_SCENE_VISIBILITY_META_KEY       = '_extrachill_local_scene_visibility';
 const EXTRACHILL_USERS_LOCAL_SCENE_PROMPT_DISMISSED_META_KEY = '_extrachill_local_scene_prompt_dismissed';
+const EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY   = '_extrachill_concert_history_visibility';
+const EXTRACHILL_USERS_EVENT_ATTENDANCE_VISIBILITY_META_KEY  = '_extrachill_event_attendance_visibility';
 
 add_action( 'wp_abilities_api_init', 'extrachill_users_register_settings_abilities' );
+add_action( 'user_register', 'extrachill_users_set_new_user_visibility_defaults' );
+add_action( 'extrachill_users_visibility_changed', 'extrachill_users_purge_visibility_caches', 10, 4 );
 
 /**
  * Register user settings abilities.
@@ -67,6 +71,14 @@ function extrachill_users_register_settings_abilities() {
 						'description' => __( 'Canonical Events location slug. Pass an empty string to clear it.', 'extrachill-users' ),
 					),
 					'local_scene_visibility'       => array(
+						'type' => 'string',
+						'enum' => array( 'public', 'private' ),
+					),
+					'concert_history_visibility'   => array(
+						'type' => 'string',
+						'enum' => array( 'public', 'private' ),
+					),
+					'event_attendance_visibility'  => array(
 						'type' => 'string',
 						'enum' => array( 'public', 'private' ),
 					),
@@ -209,6 +221,8 @@ function extrachill_users_ability_get_settings() {
 		'onboarding_completed'          => function_exists( 'ec_is_onboarding_complete' ) ? ec_is_onboarding_complete( $user_id ) : true,
 		'local_scene'                  => $local_scene,
 		'local_scene_visibility'       => extrachill_users_get_local_scene_visibility( $user_id ),
+		'concert_history_visibility'   => extrachill_users_get_concert_history_visibility( $user_id ),
+		'event_attendance_visibility'  => extrachill_users_get_event_attendance_visibility( $user_id ),
 		'local_scene_prompt_dismissed' => extrachill_users_get_local_scene_prompt_dismissed( $user_id ),
 		'default_event_location'       => $local_scene,
 	);
@@ -288,8 +302,24 @@ function extrachill_users_ability_update_settings( $input ) {
 		}
 	}
 
+	$visibility_setters = array(
+		'concert_history_visibility'  => 'extrachill_users_set_concert_history_visibility',
+		'event_attendance_visibility' => 'extrachill_users_set_event_attendance_visibility',
+	);
+	foreach ( $visibility_setters as $setting => $setter ) {
+		if ( ! array_key_exists( $setting, $input ) ) {
+			continue;
+		}
+
+		$result = $setter( $user_id, sanitize_key( (string) $input[ $setting ] ) );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		$changed = $result || $changed;
+	}
+
 	if ( ! $changed ) {
-		if ( $location_input_present || array_key_exists( 'local_scene_visibility', $input ) || array_key_exists( 'local_scene_prompt_dismissed', $input ) ) {
+		if ( $location_input_present || array_key_exists( 'local_scene_visibility', $input ) || array_key_exists( 'local_scene_prompt_dismissed', $input ) || array_intersect_key( $visibility_setters, $input ) ) {
 			return extrachill_users_ability_get_settings();
 		}
 
@@ -415,6 +445,165 @@ function extrachill_users_set_local_scene_visibility( int $user_id, string $visi
 
 	update_user_meta( $user_id, EXTRACHILL_USERS_LOCAL_SCENE_VISIBILITY_META_KEY, $visibility );
 	return true;
+}
+
+/**
+ * Get concert history visibility, defaulting missing legacy values to public.
+ *
+ * @param int $user_id User ID.
+ * @return string public|private.
+ */
+function extrachill_users_get_concert_history_visibility( int $user_id ): string {
+	return 'private' === get_user_meta( $user_id, EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY, true ) ? 'private' : 'public';
+}
+
+/**
+ * Get event attendance identity visibility, defaulting missing legacy values to public.
+ *
+ * @param int $user_id User ID.
+ * @return string public|private.
+ */
+function extrachill_users_get_event_attendance_visibility( int $user_id ): string {
+	return 'private' === get_user_meta( $user_id, EXTRACHILL_USERS_EVENT_ATTENDANCE_VISIBILITY_META_KEY, true ) ? 'private' : 'public';
+}
+
+/**
+ * Persist a visibility setting and publish its transition to downstream owners.
+ *
+ * @param int    $user_id   User ID.
+ * @param string $setting   Public setting name.
+ * @param string $meta_key  Canonical user meta key.
+ * @param string $visibility Public or private.
+ * @return bool|WP_Error Whether storage changed, or an error.
+ */
+function extrachill_users_set_visibility( int $user_id, string $setting, string $meta_key, string $visibility ) {
+	$visibility = sanitize_key( $visibility );
+	if ( ! in_array( $visibility, array( 'public', 'private' ), true ) ) {
+		return new WP_Error( 'invalid_' . $setting, __( 'Visibility must be public or private.', 'extrachill-users' ), array( 'status' => 400 ) );
+	}
+
+	$old_visibility = 'private' === get_user_meta( $user_id, $meta_key, true ) ? 'private' : 'public';
+	if ( $old_visibility === $visibility && metadata_exists( 'user', $user_id, $meta_key ) ) {
+		return false;
+	}
+
+	$updated = update_user_meta( $user_id, $meta_key, $visibility );
+	$stored  = (string) get_user_meta( $user_id, $meta_key, true );
+	if ( false === $updated || $visibility !== $stored ) {
+		return new WP_Error(
+			'visibility_update_failed',
+			__( 'Visibility could not be updated.', 'extrachill-users' ),
+			array(
+				'status'  => 500,
+				'user_id' => $user_id,
+				'setting' => $setting,
+			)
+		);
+	}
+
+	if ( $old_visibility !== $visibility ) {
+		/**
+		 * Fires after a Users-owned visibility setting changes effective value.
+		 *
+		 * @param int    $user_id       User ID.
+		 * @param string $setting       Public setting name.
+		 * @param string $old_visibility Previous public/private value.
+		 * @param string $visibility     New public/private value.
+		 */
+		do_action( 'extrachill_users_visibility_changed', $user_id, $setting, $old_visibility, $visibility );
+	}
+
+	return true;
+}
+
+/**
+ * Persist concert history visibility.
+ *
+ * @param int    $user_id User ID.
+ * @param string $visibility Public or private.
+ * @return bool|WP_Error Whether storage changed, or an error.
+ */
+function extrachill_users_set_concert_history_visibility( int $user_id, string $visibility ) {
+	return extrachill_users_set_visibility( $user_id, 'concert_history_visibility', EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY, $visibility );
+}
+
+/**
+ * Persist event attendance identity visibility.
+ *
+ * @param int    $user_id User ID.
+ * @param string $visibility Public or private.
+ * @return bool|WP_Error Whether storage changed, or an error.
+ */
+function extrachill_users_set_event_attendance_visibility( int $user_id, string $visibility ) {
+	return extrachill_users_set_visibility( $user_id, 'event_attendance_visibility', EXTRACHILL_USERS_EVENT_ATTENDANCE_VISIBILITY_META_KEY, $visibility );
+}
+
+/**
+ * Set privacy-preserving defaults for registrations created by Extra Chill.
+ *
+ * @param int $user_id User ID.
+ */
+function extrachill_users_set_new_user_visibility_defaults( int $user_id ): void {
+	if ( ! metadata_exists( 'user', $user_id, EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY ) ) {
+		update_user_meta( $user_id, EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY, 'private' );
+	}
+	if ( ! metadata_exists( 'user', $user_id, EXTRACHILL_USERS_EVENT_ATTENDANCE_VISIBILITY_META_KEY ) ) {
+		update_user_meta( $user_id, EXTRACHILL_USERS_EVENT_ATTENDANCE_VISIBILITY_META_KEY, 'private' );
+	}
+}
+
+/**
+ * Purge anonymous HTML caches that can project concert visibility.
+ *
+ * The domain owner selects affected sites and invokes the cache plugin's
+ * generic current-blog purge hook. The cache layer remains unaware of users,
+ * concerts, or visibility settings.
+ *
+ * @param int    $user_id       User ID.
+ * @param string $setting       Visibility setting name.
+ * @param string $old_visibility Previous visibility value.
+ * @param string $new_visibility New visibility value.
+ */
+function extrachill_users_purge_visibility_caches( int $user_id, string $setting, string $old_visibility, string $new_visibility ): void {
+	if ( $old_visibility === $new_visibility ) {
+		return;
+	}
+
+	$blog_ids = function_exists( 'ec_get_blog_id' )
+		? array( (int) ec_get_blog_id( 'community' ), (int) ec_get_blog_id( 'events' ) )
+		: array();
+
+	/**
+	 * Filters the site IDs whose anonymous HTML can project Users visibility.
+	 *
+	 * @param int[]  $blog_ids Affected site IDs.
+	 * @param int    $user_id User ID.
+	 * @param string $setting Changed visibility setting.
+	 */
+	$blog_ids = apply_filters( 'extrachill_users_visibility_cache_blog_ids', $blog_ids, $user_id, $setting );
+	$blog_ids = array_unique(
+		array_filter(
+			array_map( 'intval', (array) $blog_ids ),
+			static function ( int $blog_id ): bool {
+				return $blog_id > 0 && (bool) get_site( $blog_id );
+			}
+		)
+	);
+
+	foreach ( $blog_ids as $blog_id ) {
+		$switched = get_current_blog_id() !== $blog_id;
+		if ( $switched ) {
+			switch_to_blog( $blog_id );
+		}
+
+		try {
+			do_action( 'extrachill_cache_flush' );
+		} finally {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+		}
+	}
 }
 
 /**

--- a/tests/integration/UserCreationTest.php
+++ b/tests/integration/UserCreationTest.php
@@ -66,6 +66,50 @@ class Test_User_Creation extends WP_UnitTestCase {
 		$this->assertSame( '0', get_user_meta( $user_id, 'onboarding_from_join', true ) );
 	}
 
+	public function test_create_user_sets_explicit_private_concert_defaults(): void {
+		$user_id = $this->create_user(
+			array(
+				'username' => 'privateconcertuser',
+				'email'    => 'privateconcert@example.com',
+			)
+		);
+
+		$this->assertSame( 'private', get_user_meta( $user_id, EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY, true ) );
+		$this->assertSame( 'private', get_user_meta( $user_id, EXTRACHILL_USERS_EVENT_ATTENDANCE_VISIBILITY_META_KEY, true ) );
+	}
+
+	public function test_core_user_registration_sets_private_concert_defaults(): void {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'coreprivateconcertuser',
+				'user_pass'  => 'securepassword',
+				'user_email' => 'coreprivateconcert@example.com',
+			)
+		);
+
+		$this->assertIsInt( $user_id );
+		$this->assertSame( 'private', get_user_meta( $user_id, EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY, true ) );
+		$this->assertSame( 'private', get_user_meta( $user_id, EXTRACHILL_USERS_EVENT_ATTENDANCE_VISIBILITY_META_KEY, true ) );
+	}
+
+	public function test_core_user_registration_preserves_explicit_visibility_meta_input(): void {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'corepublicconcertuser',
+				'user_pass'  => 'securepassword',
+				'user_email' => 'corepublicconcert@example.com',
+				'meta_input' => array(
+					EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY  => 'public',
+					EXTRACHILL_USERS_EVENT_ATTENDANCE_VISIBILITY_META_KEY => 'public',
+				),
+			)
+		);
+
+		$this->assertIsInt( $user_id );
+		$this->assertSame( 'public', get_user_meta( $user_id, EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY, true ) );
+		$this->assertSame( 'public', get_user_meta( $user_id, EXTRACHILL_USERS_EVENT_ATTENDANCE_VISIBILITY_META_KEY, true ) );
+	}
+
 	public function test_create_user_from_join_flag(): void {
 		$user_id = $this->create_user(
 			array(

--- a/tests/unit/ConcertHistoryTimingTest.php
+++ b/tests/unit/ConcertHistoryTimingTest.php
@@ -25,6 +25,7 @@ class Test_Concert_History_Timing extends WP_UnitTestCase {
 
 		$this->events_blog_id = self::factory()->blog->create();
 		$this->user_id        = self::factory()->user->create();
+		update_user_meta( $this->user_id, EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY, 'public' );
 		$this->dates_table    = $wpdb->get_blog_prefix( $this->events_blog_id ) . 'datamachine_event_dates';
 
 		update_blog_option( $this->events_blog_id, 'timezone_string', 'America/New_York' );
@@ -170,6 +171,7 @@ class Test_Concert_History_Timing extends WP_UnitTestCase {
 
 	public function test_public_date_bounded_stats_remain_canonically_past_only(): void {
 		$owner_id = self::factory()->user->create();
+		update_user_meta( $owner_id, EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY, 'public' );
 		$this->track_event( 'Public Past Show', '2025-05-10 20:00:00', '2025-05-10 23:00:00', $owner_id );
 		$this->track_event( 'Public Ongoing Show', '2026-07-18 20:00:00', '2026-07-20 01:00:00', $owner_id );
 		$this->track_event( 'Public Future Show', '2027-05-10 20:00:00', null, $owner_id );
@@ -184,6 +186,50 @@ class Test_Concert_History_Timing extends WP_UnitTestCase {
 
 		$this->assertSame( 1, $stats['total_shows'] );
 		$this->assertSame( array( '2025' => 1 ), $stats['shows_by_year'] );
+	}
+
+	public function test_public_stats_are_past_only_without_trusting_date_to(): void {
+		$owner_id = self::factory()->user->create();
+		update_user_meta( $owner_id, EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY, 'public' );
+		$this->track_event( 'Public Past', '2025-05-10 20:00:00', '2025-05-10 23:00:00', $owner_id );
+		$this->track_event( 'Public Future', '2027-05-10 20:00:00', null, $owner_id );
+		wp_set_current_user( 0 );
+
+		$unbounded = wp_get_ability( 'extrachill/get-user-concert-stats' )->execute( array( 'user_id' => $owner_id ) );
+		$widened   = wp_get_ability( 'extrachill/get-user-concert-stats' )->execute(
+			array(
+				'user_id' => $owner_id,
+				'date_to' => '2099-12-31',
+			)
+		);
+
+		$this->assertSame( 1, $unbounded['total_shows'] );
+		$this->assertSame( 1, $widened['total_shows'] );
+		$this->assertSame( array( '2025' => 1 ), $widened['shows_by_year'] );
+	}
+
+	public function test_private_history_returns_forbidden_but_owner_and_admin_keep_full_access(): void {
+		$owner_id = self::factory()->user->create();
+		$this->track_event( 'Private Past', '2025-05-10 20:00:00', '2025-05-10 23:00:00', $owner_id );
+		$this->track_event( 'Private Future', '2027-05-10 20:00:00', null, $owner_id );
+		extrachill_users_set_concert_history_visibility( $owner_id, 'private' );
+
+		wp_set_current_user( 0 );
+		foreach ( array( 'extrachill/get-user-shows', 'extrachill/get-user-concert-stats' ) as $ability_name ) {
+			$result = wp_get_ability( $ability_name )->execute( array( 'user_id' => $owner_id ) );
+			$this->assertWPError( $result );
+			$this->assertSame( 'concert_history_private', $result->get_error_code() );
+			$this->assertSame( 403, $result->get_error_data()['status'] );
+		}
+
+		wp_set_current_user( $owner_id );
+		$this->assertSame( 2, wp_get_ability( 'extrachill/get-user-concert-stats' )->execute( array( 'user_id' => $owner_id ) )['total_shows'] );
+
+		$administrator_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $administrator_id );
+		wp_set_current_user( $administrator_id );
+		$this->assertSame( 2, wp_get_ability( 'extrachill/get-user-shows' )->execute( array( 'user_id' => $owner_id ) )['total'] );
+		revoke_super_admin( $administrator_id );
 	}
 
 	public function test_exact_boundaries_and_missing_end_match_canonical_states(): void {

--- a/tests/unit/ConcertHistoryVisibilityTest.php
+++ b/tests/unit/ConcertHistoryVisibilityTest.php
@@ -26,6 +26,7 @@ class Test_Concert_History_Visibility extends WP_UnitTestCase {
 
 		$this->events_blog_id = self::factory()->blog->create();
 		$this->user_id        = self::factory()->user->create();
+		update_user_meta( $this->user_id, EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY, 'public' );
 		$this->dates_table    = $wpdb->get_blog_prefix( $this->events_blog_id ) . 'datamachine_event_dates';
 
 		extrachill_users_install_concert_tracking_table();

--- a/tests/unit/ConcertTrackingAbilitiesTest.php
+++ b/tests/unit/ConcertTrackingAbilitiesTest.php
@@ -308,6 +308,43 @@ class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '%d', end( $this->attendee_queries ) );
 	}
 
+	public function test_private_attendees_are_filtered_before_limit_without_changing_count_or_owner_mark(): void {
+		global $wpdb;
+		$table           = extrachill_users_concert_tracking_table_name();
+		$seeded_user_ids = $this->seed_attendees( 4 );
+		extrachill_users_set_event_attendance_visibility( $seeded_user_ids[0], 'private' );
+		extrachill_users_set_event_attendance_visibility( $seeded_user_ids[2], 'private' );
+
+		$wpdb->insert(
+			$table,
+			array(
+				'user_id'    => $this->user_id,
+				'event_id'   => $this->event_id,
+				'blog_id'    => $this->events_blog_id,
+				'created_at' => gmdate( 'Y-m-d H:i:s', time() + 1 ),
+			),
+			array( '%d', '%d', '%d', '%s' )
+		);
+		extrachill_users_set_event_attendance_visibility( $this->user_id, 'private' );
+		$this->assertSame(
+			array( $seeded_user_ids[1], $seeded_user_ids[3] ),
+			wp_list_pluck( ec_users_get_event_attendees( $this->event_id, $this->events_blog_id, 2 ), 'user_id' )
+		);
+
+		$result = wp_get_ability( 'extrachill/get-event-attendance' )->execute(
+			array(
+				'event_id'          => $this->event_id,
+				'blog_id'           => $this->events_blog_id,
+				'include_attendees' => true,
+				'limit'             => 2,
+			)
+		);
+
+		$this->assertSame( 5, $result['count'] );
+		$this->assertTrue( $result['user_marked'] );
+		$this->assertSame( array( $seeded_user_ids[1], $seeded_user_ids[3] ), wp_list_pluck( $result['attendees'], 'user_id' ) );
+	}
+
 	public function test_registered_attendance_ability_and_rest_route_apply_defaults_and_bounds(): void {
 		$this->seed_attendees( 105 );
 		$ability = wp_get_ability( 'extrachill/get-event-attendance' );
@@ -441,6 +478,7 @@ class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
 		for ( $index = 0; $index < $count; ++$index ) {
 			$user_id    = self::factory()->user->create();
 			$user_ids[] = $user_id;
+			update_user_meta( $user_id, EXTRACHILL_USERS_EVENT_ATTENDANCE_VISIBILITY_META_KEY, 'public' );
 			$wpdb->insert(
 				$table,
 				array(

--- a/tests/unit/UserSettingsDefaultEventLocationTest.php
+++ b/tests/unit/UserSettingsDefaultEventLocationTest.php
@@ -365,6 +365,159 @@ class Test_User_Settings_Default_Event_Location extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Concert privacy settings are canonical ability fields with legacy-public defaults.
+	 */
+	public function test_concert_visibility_settings_round_trip_and_validate(): void {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		delete_user_meta( $user_id, EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY );
+		delete_user_meta( $user_id, EXTRACHILL_USERS_EVENT_ATTENDANCE_VISIBILITY_META_KEY );
+
+		$schema = wp_get_ability( 'extrachill/update-user-settings' )->get_input_schema()['properties'];
+		$this->assertSame( array( 'public', 'private' ), $schema['concert_history_visibility']['enum'] );
+		$this->assertSame( array( 'public', 'private' ), $schema['event_attendance_visibility']['enum'] );
+
+		$legacy = extrachill_users_ability_get_settings();
+		$this->assertSame( 'public', $legacy['concert_history_visibility'] );
+		$this->assertSame( 'public', $legacy['event_attendance_visibility'] );
+		$this->assertFalse( metadata_exists( 'user', $user_id, EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY ) );
+		$this->assertFalse( metadata_exists( 'user', $user_id, EXTRACHILL_USERS_EVENT_ATTENDANCE_VISIBILITY_META_KEY ) );
+
+		$updated = extrachill_users_ability_update_settings(
+			array(
+				'concert_history_visibility'  => 'private',
+				'event_attendance_visibility' => 'private',
+			)
+		);
+		$this->assertSame( 'private', $updated['concert_history_visibility'] );
+		$this->assertSame( 'private', $updated['event_attendance_visibility'] );
+
+		$invalid = extrachill_users_ability_update_settings( array( 'concert_history_visibility' => 'friends' ) );
+		$this->assertWPError( $invalid );
+		$this->assertSame( 'invalid_concert_history_visibility', $invalid->get_error_code() );
+	}
+
+	/**
+	 * Effective visibility changes publish one generic Users-owned transition.
+	 */
+	public function test_visibility_transition_action_contains_setting_and_values(): void {
+		$user_id     = self::factory()->user->create();
+		delete_user_meta( $user_id, EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY );
+		delete_user_meta( $user_id, EXTRACHILL_USERS_EVENT_ATTENDANCE_VISIBILITY_META_KEY );
+		$transitions = array();
+		$listener    = static function ( int $changed_user_id, string $setting, string $old, string $new ) use ( &$transitions ): void {
+			$transitions[] = array( $changed_user_id, $setting, $old, $new );
+		};
+		add_action( 'extrachill_users_visibility_changed', $listener, 10, 4 );
+
+		try {
+			extrachill_users_set_concert_history_visibility( $user_id, 'private' );
+			extrachill_users_set_concert_history_visibility( $user_id, 'private' );
+			extrachill_users_set_event_attendance_visibility( $user_id, 'private' );
+		} finally {
+			remove_action( 'extrachill_users_visibility_changed', $listener, 10 );
+		}
+
+		$this->assertSame(
+			array(
+				array( $user_id, 'concert_history_visibility', 'public', 'private' ),
+				array( $user_id, 'event_attendance_visibility', 'public', 'private' ),
+			),
+			$transitions
+		);
+	}
+
+	/**
+	 * Failed metadata writes remain private and publish no transition.
+	 */
+	public function test_visibility_write_failure_returns_error_without_transition(): void {
+		$user_id     = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		$transitions = 0;
+		$block_write = static function ( $check, int $object_id, string $meta_key ) use ( $user_id ) {
+			if ( $user_id === $object_id && EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY === $meta_key ) {
+				return false;
+			}
+
+			return $check;
+		};
+		$listener = static function () use ( &$transitions ): void {
+			++$transitions;
+		};
+		add_filter( 'update_user_metadata', $block_write, 10, 3 );
+		add_action( 'extrachill_users_visibility_changed', $listener, 20, 0 );
+
+		try {
+			$result = extrachill_users_ability_update_settings( array( 'concert_history_visibility' => 'public' ) );
+		} finally {
+			remove_filter( 'update_user_metadata', $block_write, 10 );
+			remove_action( 'extrachill_users_visibility_changed', $listener, 20 );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'visibility_update_failed', $result->get_error_code() );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+		$this->assertSame( 'concert_history_visibility', $result->get_error_data()['setting'] );
+		$this->assertSame( 'private', get_user_meta( $user_id, EXTRACHILL_USERS_CONCERT_HISTORY_VISIBILITY_META_KEY, true ) );
+		$this->assertSame( 0, $transitions );
+	}
+
+	/**
+	 * Users selects valid Community and Events sites and purges each once.
+	 */
+	public function test_visibility_cache_purge_targets_valid_domain_sites_and_restores_context(): void {
+		$original_blog_id = get_current_blog_id();
+		$purged_blog_ids  = array();
+		$target_sites     = function (): array {
+			return array( $this->community_blog_id, $this->events_blog_id, $this->community_blog_id, 999999 );
+		};
+		$capture_purge    = static function () use ( &$purged_blog_ids ): void {
+			$purged_blog_ids[] = get_current_blog_id();
+		};
+		add_filter( 'extrachill_users_visibility_cache_blog_ids', $target_sites );
+		add_action( 'extrachill_cache_flush', $capture_purge, 10, 0 );
+
+		try {
+			extrachill_users_purge_visibility_caches( 123, 'concert_history_visibility', 'public', 'private' );
+		} finally {
+			remove_filter( 'extrachill_users_visibility_cache_blog_ids', $target_sites );
+			remove_action( 'extrachill_cache_flush', $capture_purge, 10 );
+		}
+
+		$this->assertSame( array( $this->community_blog_id, $this->events_blog_id ), $purged_blog_ids );
+		$this->assertSame( $original_blog_id, get_current_blog_id() );
+	}
+
+	/**
+	 * A failing generic cache callback cannot strand the active blog context.
+	 */
+	public function test_visibility_cache_purge_restores_context_when_callback_fails(): void {
+		$original_blog_id = get_current_blog_id();
+		$target_sites     = function (): array {
+			return array( $this->community_blog_id );
+		};
+		$fail_purge       = static function (): void {
+			throw new RuntimeException( 'cache callback failed' );
+		};
+		add_filter( 'extrachill_users_visibility_cache_blog_ids', $target_sites );
+		add_action( 'extrachill_cache_flush', $fail_purge, 10, 0 );
+
+		try {
+			try {
+				extrachill_users_purge_visibility_caches( 123, 'event_attendance_visibility', 'public', 'private' );
+				$this->fail( 'Expected the cache callback exception.' );
+			} catch ( RuntimeException $error ) {
+				$this->assertSame( 'cache callback failed', $error->getMessage() );
+			}
+		} finally {
+			remove_filter( 'extrachill_users_visibility_cache_blog_ids', $target_sites );
+			remove_action( 'extrachill_cache_flush', $fail_purge, 10 );
+		}
+
+		$this->assertSame( $original_blog_id, get_current_blog_id() );
+	}
+
+	/**
 	 * Missing Events infrastructure fails reads open and writes explicitly.
 	 */
 	public function test_unavailable_site_and_taxonomy_restore_context_and_fail_safely(): void {


### PR DESCRIPTION
## Summary
- add separate concert-history and attendee-identity visibility settings
- enforce private history, centrally past-only public stats, and filtered attendee identities
- default legacy users public and new users private
- purge Community and Events anonymous caches through the generic cache hook

## Verification
- final independent security and architecture reviews: merge
- PHP syntax and diff checks passed
- focused test coverage added for settings, abilities, registration, attendance, and cache context

Closes #227