### PR TITLE
Remove obsolete build script link

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See [AGENTS.md](AGENTS.md) for technical implementation details.
 npm run build
 
 # Package for distribution
-./build.sh
+homeboy review build extrachill-users
 ```
 
 ## Documentation

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,0 @@
-../../../.github/build.sh


### PR DESCRIPTION
## Summary

- remove the dangling legacy `build.sh` symlink
- document the supported Homeboy package build command

## Why

The symlink targeted a shared script that no longer exists from managed workspaces. Source consumers that dereference links, including WP Codebox readonly mounts, failed before loading the plugin.

Closes #229.

## Verification

- WP Codebox now mounts the complete plugin source and reaches `wordpress.phpunit`
- the remaining test failure is the separately tracked multisite recipe issue Extra-Chill/homeboy-extensions#2310