### PR TITLE
Fix reciprocal artist membership authorization

### DIFF
--- a/inc/artist-profiles.php
+++ b/inc/artist-profiles.php
@@ -90,6 +90,34 @@ function ec_get_artists_for_user( $user_id = null, $admin_override = false ) {
 }
 
 /**
+ * Validate a pending artist invitation before creating a user account.
+ *
+ * @param string $email     Registration email.
+ * @param string $token     Invitation token.
+ * @param int    $artist_id Artist profile ID.
+ * @return string|WP_Error Pending invitation ID or an error.
+ */
+function ec_users_validate_registration_artist_invitation( $email, $token, $artist_id ) {
+	if ( ! $token || ! $artist_id ) {
+		return new WP_Error( 'invalid_artist_invitation', __( 'A complete artist invitation is required.', 'extrachill-users' ), array( 'status' => 400 ) );
+	}
+	if ( ! function_exists( 'ec_get_pending_invitations' ) || ! function_exists( 'ec_accept_artist_membership_invitation' ) ) {
+		return new WP_Error( 'artist_invitation_dependency_missing', __( 'Artist invitations are temporarily unavailable.', 'extrachill-users' ), array( 'status' => 503 ) );
+	}
+
+	foreach ( ec_get_pending_invitations( $artist_id ) as $invite ) {
+		if ( isset( $invite['id'], $invite['token'], $invite['email'], $invite['status'] )
+			&& hash_equals( (string) $invite['token'], (string) $token )
+			&& strtolower( (string) $invite['email'] ) === strtolower( (string) $email )
+			&& 'invited_new_user' === $invite['status'] ) {
+			return (string) $invite['id'];
+		}
+	}
+
+	return new WP_Error( 'invalid_artist_invitation', __( 'The artist invitation is invalid or expired.', 'extrachill-users' ), array( 'status' => 400 ) );
+}
+
+/**
  * Check if user can create artist profiles
  *
  * @deprecated-soon Slated for migration to ec_user_can( 'create_artist_profile' )
@@ -179,7 +207,6 @@ function ec_get_latest_artist_for_user( $user_id = null ) {
  * published artist profile. Returns true if the user is:
  * - An administrator (manage_options capability)
  * - A validated reciprocal roster member
- * - The post author of the artist profile (legacy compatibility)
  *
  * @deprecated-soon Slated for migration to ec_user_can( 'manage_artist', [ 'artist_id' => $id ] )
  *                  and deletion per Extra-Chill/extrachill-users#60 (pending the
@@ -210,7 +237,6 @@ function ec_can_manage_artist( $user_id = null, $artist_id = null ) {
 		if ( ! $post instanceof WP_Post || 'artist_profile' !== $post->post_type || 'publish' !== $post->post_status ) {
 			return false;
 		}
-		$is_post_author = (int) $post->post_author === (int) $user_id;
 	} finally {
 		restore_current_blog();
 	}
@@ -219,11 +245,7 @@ function ec_can_manage_artist( $user_id = null, $artist_id = null ) {
 		return true;
 	}
 
-	if ( in_array( (int) $artist_id, ec_get_artists_for_user( $user_id ), true ) ) {
-		return true;
-	}
-
-	return $is_post_author;
+	return in_array( (int) $artist_id, ec_get_artists_for_user( $user_id ), true );
 }
 
 /**

--- a/inc/artist-profiles.php
+++ b/inc/artist-profiles.php
@@ -132,6 +132,55 @@ function ec_users_request_artist_invitation( $email, $token, $artist_id, $user_i
 }
 
 /**
+ * Classify an artist-owned invitation failure for a created account response.
+ *
+ * Unknown and permanent failures are never presented as client-retryable.
+ *
+ * @param WP_Error $error Artist invitation failure.
+ * @return array{status:string,retryable:bool,error:array{code:string,message:string,status:int}}
+ */
+function ec_users_classify_artist_invitation_error( WP_Error $error ) {
+	$code                = $error->get_error_code();
+	$data                = $error->get_error_data();
+	$http_status         = is_array( $data ) && isset( $data['status'] ) ? (int) $data['status'] : 500;
+	$retryable_codes     = array(
+		'artist_membership_busy',
+		'artist_site_unavailable',
+		'artist_roster_update_failed',
+		'user_membership_update_failed',
+		'artist_membership_retry_required',
+		'invitation_cleanup_failed',
+		'ec_cross_site_request_failed',
+	);
+	$manual_repair_codes = array(
+		'artist_membership_rollback_failed',
+		'artist_invitation_rollback_failed',
+		'artist_membership_partial_remove',
+	);
+
+	if ( in_array( $code, $retryable_codes, true ) ) {
+		$status    = 'pending_repair';
+		$retryable = true;
+	} elseif ( in_array( $code, $manual_repair_codes, true ) ) {
+		$status    = 'manual_repair';
+		$retryable = false;
+	} else {
+		$status    = 'failed';
+		$retryable = false;
+	}
+
+	return array(
+		'status'    => $status,
+		'retryable' => $retryable,
+		'error'     => array(
+			'code'    => $code,
+			'message' => $error->get_error_message(),
+			'status'  => $http_status,
+		),
+	);
+}
+
+/**
  * Check if user can create artist profiles
  *
  * @deprecated-soon Slated for migration to ec_user_can( 'create_artist_profile' )

--- a/inc/artist-profiles.php
+++ b/inc/artist-profiles.php
@@ -175,10 +175,11 @@ function ec_get_latest_artist_for_user( $user_id = null ) {
 /**
  * Check if user can manage a specific artist profile
  *
- * Network-wide permission check for artist management. Returns true if user is:
+ * Network-wide permission check for artist management. The target must be a
+ * published artist profile. Returns true if the user is:
  * - An administrator (manage_options capability)
- * - The post author of the artist profile
- * - Listed in the user's _artist_profile_ids meta (roster member)
+ * - A validated reciprocal roster member
+ * - The post author of the artist profile (legacy compatibility)
  *
  * @deprecated-soon Slated for migration to ec_user_can( 'manage_artist', [ 'artist_id' => $id ] )
  *                  and deletion per Extra-Chill/extrachill-users#60 (pending the
@@ -198,32 +199,31 @@ function ec_can_manage_artist( $user_id = null, $artist_id = null ) {
 		return false;
 	}
 
-	// Admins can manage any artist.
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+	if ( ! $artist_blog_id ) {
+		return false;
+	}
+
+	switch_to_blog( $artist_blog_id );
+	try {
+		$post = get_post( $artist_id );
+		if ( ! $post instanceof WP_Post || 'artist_profile' !== $post->post_type || 'publish' !== $post->post_status ) {
+			return false;
+		}
+		$is_post_author = (int) $post->post_author === (int) $user_id;
+	} finally {
+		restore_current_blog();
+	}
+
 	if ( user_can( $user_id, 'manage_options' ) ) {
 		return true;
 	}
 
-	// Check if user owns this artist via user meta.
-	$user_artist_ids = get_user_meta( $user_id, '_artist_profile_ids', true );
-	if ( is_array( $user_artist_ids ) && in_array( (int) $artist_id, array_map( 'intval', $user_artist_ids ), true ) ) {
+	if ( in_array( (int) $artist_id, ec_get_artists_for_user( $user_id ), true ) ) {
 		return true;
 	}
 
-	// Check if user is post author (requires a cross-site blog switch).
-	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
-	if ( $artist_blog_id ) {
-		switch_to_blog( $artist_blog_id );
-		try {
-			$post = get_post( $artist_id );
-			if ( $post instanceof WP_Post && (int) $post->post_author === (int) $user_id ) {
-				return true;
-			}
-		} finally {
-			restore_current_blog();
-		}
-	}
-
-	return false;
+	return $is_post_author;
 }
 
 /**

--- a/inc/artist-profiles.php
+++ b/inc/artist-profiles.php
@@ -90,31 +90,45 @@ function ec_get_artists_for_user( $user_id = null, $admin_override = false ) {
 }
 
 /**
- * Validate a pending artist invitation before creating a user account.
+ * Validate or accept an artist invitation on the artist site.
  *
  * @param string $email     Registration email.
  * @param string $token     Invitation token.
  * @param int    $artist_id Artist profile ID.
- * @return string|WP_Error Pending invitation ID or an error.
+ * @param int    $user_id   User ID when accepting after account creation.
+ * @return array|WP_Error Artist-owned invitation result or an error.
  */
-function ec_users_validate_registration_artist_invitation( $email, $token, $artist_id ) {
+function ec_users_request_artist_invitation( $email, $token, $artist_id, $user_id = 0 ) {
 	if ( ! $token || ! $artist_id ) {
 		return new WP_Error( 'invalid_artist_invitation', __( 'A complete artist invitation is required.', 'extrachill-users' ), array( 'status' => 400 ) );
 	}
-	if ( ! function_exists( 'ec_get_pending_invitations' ) || ! function_exists( 'ec_accept_artist_membership_invitation' ) ) {
+	if ( ! function_exists( 'ec_cross_site_rest_request' ) ) {
 		return new WP_Error( 'artist_invitation_dependency_missing', __( 'Artist invitations are temporarily unavailable.', 'extrachill-users' ), array( 'status' => 503 ) );
 	}
 
-	foreach ( ec_get_pending_invitations( $artist_id ) as $invite ) {
-		if ( isset( $invite['id'], $invite['token'], $invite['email'], $invite['status'] )
-			&& hash_equals( (string) $invite['token'], (string) $token )
-			&& strtolower( (string) $invite['email'] ) === strtolower( (string) $email )
-			&& 'invited_new_user' === $invite['status'] ) {
-			return (string) $invite['id'];
-		}
+	$input = array(
+		'artist_id' => absint( $artist_id ),
+		'email'     => sanitize_email( $email ),
+		'token'     => sanitize_text_field( $token ),
+	);
+	if ( $user_id ) {
+		$input['user_id'] = absint( $user_id );
 	}
 
-	return new WP_Error( 'invalid_artist_invitation', __( 'The artist invitation is invalid or expired.', 'extrachill-users' ), array( 'status' => 400 ) );
+	$force_loopback = static function () {
+		return true;
+	};
+	add_filter( 'ec_cross_site_use_http_loopback', $force_loopback, 10 );
+	try {
+		return ec_cross_site_rest_request(
+			'artist',
+			'POST',
+			'/wp-abilities/v1/abilities/extrachill/artist-invitation/run',
+			array( 'body' => array( 'input' => $input ) )
+		);
+	} finally {
+		remove_filter( 'ec_cross_site_use_http_loopback', $force_loopback, 10 );
+	}
 }
 
 /**

--- a/inc/auth-tokens/service.php
+++ b/inc/auth-tokens/service.php
@@ -456,12 +456,13 @@ function extrachill_users_register_with_tokens( array $payload ) {
 		}
 	}
 
-	$invite_id = '';
+	$has_artist_invitation = false;
 	if ( $invite_token || $invite_artist_id ) {
-		$invite_id = ec_users_validate_registration_artist_invitation( $email, $invite_token, $invite_artist_id );
-		if ( is_wp_error( $invite_id ) ) {
-			return $invite_id;
+		$validation = ec_users_request_artist_invitation( $email, $invite_token, $invite_artist_id );
+		if ( is_wp_error( $validation ) ) {
+			return $validation;
 		}
+		$has_artist_invitation = true;
 	}
 
 	$user_id = apply_filters( 'extrachill_create_community_user', false, $registration_data );
@@ -498,13 +499,14 @@ function extrachill_users_register_with_tokens( array $payload ) {
 	}
 
 	$processed_invite_artist_id = null;
-	if ( $invite_id ) {
-		$acceptance = ec_accept_artist_membership_invitation( (int) $user_id, $invite_artist_id, $invite_id );
+	$invitation_pending_repair  = false;
+	if ( $has_artist_invitation ) {
+		$acceptance = ec_users_request_artist_invitation( $email, $invite_token, $invite_artist_id, (int) $user_id );
 		if ( is_wp_error( $acceptance ) ) {
-			return $acceptance;
+			$invitation_pending_repair = true;
+		} else {
+			$processed_invite_artist_id = $invite_artist_id;
 		}
-		$processed_invite_artist_id = $invite_artist_id;
-		update_user_meta( (int) $user_id, 'onboarding_redirect_url', get_permalink( $invite_artist_id ) );
 	}
 
 	$user = get_user_by( 'id', (int) $user_id );
@@ -548,6 +550,9 @@ function extrachill_users_register_with_tokens( array $payload ) {
 
 	if ( $processed_invite_artist_id ) {
 		$response['invite_artist_id'] = (int) $processed_invite_artist_id;
+	}
+	if ( $has_artist_invitation ) {
+		$response['artist_invitation_status'] = $invitation_pending_repair ? 'pending_repair' : 'applied';
 	}
 
 	return $response;

--- a/inc/auth-tokens/service.php
+++ b/inc/auth-tokens/service.php
@@ -456,6 +456,14 @@ function extrachill_users_register_with_tokens( array $payload ) {
 		}
 	}
 
+	$invite_id = '';
+	if ( $invite_token || $invite_artist_id ) {
+		$invite_id = ec_users_validate_registration_artist_invitation( $email, $invite_token, $invite_artist_id );
+		if ( is_wp_error( $invite_id ) ) {
+			return $invite_id;
+		}
+	}
+
 	$user_id = apply_filters( 'extrachill_create_community_user', false, $registration_data );
 	if ( is_wp_error( $user_id ) ) {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Expected operational logging for failed auth/registration flows.
@@ -490,26 +498,13 @@ function extrachill_users_register_with_tokens( array $payload ) {
 	}
 
 	$processed_invite_artist_id = null;
-	if ( $invite_token && $invite_artist_id && function_exists( 'ec_get_pending_invitations' ) && function_exists( 'ec_add_artist_membership' ) && function_exists( 'ec_remove_pending_invitation' ) ) {
-		$pending_invitations         = ec_get_pending_invitations( $invite_artist_id );
-		$valid_invite_id_for_removal = null;
-
-		foreach ( $pending_invitations as $invite ) {
-			if ( isset( $invite['token'] ) && $invite['token'] === $invite_token &&
-				isset( $invite['email'] ) && strtolower( $invite['email'] ) === strtolower( $email ) &&
-				isset( $invite['status'] ) && 'invited_new_user' === $invite['status'] ) {
-				$valid_invite_id_for_removal = isset( $invite['id'] ) ? $invite['id'] : null;
-				break;
-			}
+	if ( $invite_id ) {
+		$acceptance = ec_accept_artist_membership_invitation( (int) $user_id, $invite_artist_id, $invite_id );
+		if ( is_wp_error( $acceptance ) ) {
+			return $acceptance;
 		}
-
-		if ( $valid_invite_id_for_removal ) {
-			if ( ec_add_artist_membership( (int) $user_id, $invite_artist_id ) ) {
-				ec_remove_pending_invitation( $invite_artist_id, $valid_invite_id_for_removal );
-				$processed_invite_artist_id = $invite_artist_id;
-				update_user_meta( (int) $user_id, 'onboarding_redirect_url', get_permalink( $invite_artist_id ) );
-			}
-		}
+		$processed_invite_artist_id = $invite_artist_id;
+		update_user_meta( (int) $user_id, 'onboarding_redirect_url', get_permalink( $invite_artist_id ) );
 	}
 
 	$user = get_user_by( 'id', (int) $user_id );

--- a/inc/auth-tokens/service.php
+++ b/inc/auth-tokens/service.php
@@ -499,11 +499,11 @@ function extrachill_users_register_with_tokens( array $payload ) {
 	}
 
 	$processed_invite_artist_id = null;
-	$invitation_pending_repair  = false;
+	$invitation_outcome         = array();
 	if ( $has_artist_invitation ) {
 		$acceptance = ec_users_request_artist_invitation( $email, $invite_token, $invite_artist_id, (int) $user_id );
 		if ( is_wp_error( $acceptance ) ) {
-			$invitation_pending_repair = true;
+			$invitation_outcome = ec_users_classify_artist_invitation_error( $acceptance );
 		} else {
 			$processed_invite_artist_id = $invite_artist_id;
 		}
@@ -552,7 +552,11 @@ function extrachill_users_register_with_tokens( array $payload ) {
 		$response['invite_artist_id'] = (int) $processed_invite_artist_id;
 	}
 	if ( $has_artist_invitation ) {
-		$response['artist_invitation_status'] = $invitation_pending_repair ? 'pending_repair' : 'applied';
+		$response['artist_invitation_status'] = $invitation_outcome ? $invitation_outcome['status'] : 'applied';
+		if ( $invitation_outcome ) {
+			$response['artist_invitation_retryable'] = $invitation_outcome['retryable'];
+			$response['artist_invitation_error']     = $invitation_outcome['error'];
+		}
 	}
 
 	return $response;

--- a/inc/auth/register.php
+++ b/inc/auth/register.php
@@ -102,11 +102,11 @@ function extrachill_handle_registration() {
 	}
 
 	$processed_invite_artist_id = null;
-	$invitation_pending_repair  = false;
+	$invitation_outcome         = array();
 	if ( $has_artist_invitation ) {
 		$acceptance = ec_users_request_artist_invitation( $email, $invite_token_posted, $invite_artist_id_posted, $user_id );
 		if ( is_wp_error( $acceptance ) ) {
-			$invitation_pending_repair = true;
+			$invitation_outcome = ec_users_classify_artist_invitation_error( $acceptance );
 		} else {
 			$processed_invite_artist_id = $invite_artist_id_posted;
 		}
@@ -121,7 +121,7 @@ function extrachill_handle_registration() {
 	}
 	// phpcs:enable WordPress.Security.NonceVerification.Missing
 
-	extrachill_auto_login_new_user( $user_id, $redirect, $processed_invite_artist_id, $success_redirect_url, $invitation_pending_repair );
+	extrachill_auto_login_new_user( $user_id, $redirect, $processed_invite_artist_id, $success_redirect_url, $invitation_outcome );
 }
 add_action( 'admin_post_nopriv_extrachill_register_user', 'extrachill_handle_registration' );
 add_action( 'admin_post_extrachill_register_user', 'extrachill_handle_registration' );
@@ -133,9 +133,9 @@ add_action( 'admin_post_extrachill_register_user', 'extrachill_handle_registrati
  * @param EC_Redirect_Handler $redirect                   Redirect handler instance.
  * @param int|null            $processed_invite_artist_id Artist ID if roster invitation was processed.
  * @param string              $success_redirect_url       Custom success redirect URL from block attribute.
- * @param bool                $invitation_pending_repair  Whether the invitation remains pending for retry.
+ * @param array               $invitation_outcome         Classified invitation failure after account creation.
  */
-function extrachill_auto_login_new_user( int $user_id, EC_Redirect_Handler $redirect, ?int $processed_invite_artist_id = null, string $success_redirect_url = '', bool $invitation_pending_repair = false ) {
+function extrachill_auto_login_new_user( int $user_id, EC_Redirect_Handler $redirect, ?int $processed_invite_artist_id = null, string $success_redirect_url = '', array $invitation_outcome = array() ) {
 	$user = get_user_by( 'id', $user_id );
 
 	if ( ! $user ) {
@@ -166,8 +166,13 @@ function extrachill_auto_login_new_user( int $user_id, EC_Redirect_Handler $redi
 	$onboarding_url = function_exists( 'ec_get_site_url' )
 		? ec_get_site_url( 'community' ) . '/onboarding/'
 		: home_url( '/onboarding/' );
-	if ( $invitation_pending_repair ) {
-		$onboarding_url = add_query_arg( 'artist_invitation', 'pending_repair', $onboarding_url );
+	if ( $invitation_outcome ) {
+		$query_args = array( 'artist_invitation' => $invitation_outcome['status'] );
+		if ( ! empty( $invitation_outcome['error'] ) ) {
+			$query_args['artist_invitation_error']        = $invitation_outcome['error']['code'];
+			$query_args['artist_invitation_error_status'] = $invitation_outcome['error']['status'];
+		}
+		$onboarding_url = add_query_arg( $query_args, $onboarding_url );
 	}
 
 	$redirect->redirect_to( $onboarding_url );

--- a/inc/auth/register.php
+++ b/inc/auth/register.php
@@ -58,12 +58,13 @@ function extrachill_handle_registration() {
 	$from_join               = isset( $_POST['from_join'] ) && 'true' === $_POST['from_join'];
 	$invite_token_posted     = isset( $_POST['invite_token'] ) ? sanitize_text_field( wp_unslash( $_POST['invite_token'] ) ) : '';
 	$invite_artist_id_posted = isset( $_POST['invite_artist_id'] ) ? absint( $_POST['invite_artist_id'] ) : 0;
-	$invite_id               = '';
+	$has_artist_invitation   = false;
 	if ( $invite_token_posted || $invite_artist_id_posted ) {
-		$invite_id = ec_users_validate_registration_artist_invitation( $email, $invite_token_posted, $invite_artist_id_posted );
-		if ( is_wp_error( $invite_id ) ) {
-			$redirect->error( $invite_id->get_error_message() );
+		$validation = ec_users_request_artist_invitation( $email, $invite_token_posted, $invite_artist_id_posted );
+		if ( is_wp_error( $validation ) ) {
+			$redirect->error( $validation->get_error_message() );
 		}
+		$has_artist_invitation = true;
 	}
 
 	$username = function_exists( 'ec_generate_username_from_email' )
@@ -101,12 +102,14 @@ function extrachill_handle_registration() {
 	}
 
 	$processed_invite_artist_id = null;
-	if ( $invite_id ) {
-		$acceptance = ec_accept_artist_membership_invitation( $user_id, $invite_artist_id_posted, $invite_id );
+	$invitation_pending_repair  = false;
+	if ( $has_artist_invitation ) {
+		$acceptance = ec_users_request_artist_invitation( $email, $invite_token_posted, $invite_artist_id_posted, $user_id );
 		if ( is_wp_error( $acceptance ) ) {
-			$redirect->error( $acceptance->get_error_message() );
+			$invitation_pending_repair = true;
+		} else {
+			$processed_invite_artist_id = $invite_artist_id_posted;
 		}
-		$processed_invite_artist_id = $invite_artist_id_posted;
 	}
 
 	$success_redirect_url = isset( $_POST['success_redirect_url'] ) ? wp_unslash( $_POST['success_redirect_url'] ) : '';
@@ -118,7 +121,7 @@ function extrachill_handle_registration() {
 	}
 	// phpcs:enable WordPress.Security.NonceVerification.Missing
 
-	extrachill_auto_login_new_user( $user_id, $redirect, $processed_invite_artist_id, $success_redirect_url );
+	extrachill_auto_login_new_user( $user_id, $redirect, $processed_invite_artist_id, $success_redirect_url, $invitation_pending_repair );
 }
 add_action( 'admin_post_nopriv_extrachill_register_user', 'extrachill_handle_registration' );
 add_action( 'admin_post_extrachill_register_user', 'extrachill_handle_registration' );
@@ -130,8 +133,9 @@ add_action( 'admin_post_extrachill_register_user', 'extrachill_handle_registrati
  * @param EC_Redirect_Handler $redirect                   Redirect handler instance.
  * @param int|null            $processed_invite_artist_id Artist ID if roster invitation was processed.
  * @param string              $success_redirect_url       Custom success redirect URL from block attribute.
+ * @param bool                $invitation_pending_repair  Whether the invitation remains pending for retry.
  */
-function extrachill_auto_login_new_user( int $user_id, EC_Redirect_Handler $redirect, ?int $processed_invite_artist_id = null, string $success_redirect_url = '' ) {
+function extrachill_auto_login_new_user( int $user_id, EC_Redirect_Handler $redirect, ?int $processed_invite_artist_id = null, string $success_redirect_url = '', bool $invitation_pending_repair = false ) {
 	$user = get_user_by( 'id', $user_id );
 
 	if ( ! $user ) {
@@ -162,6 +166,9 @@ function extrachill_auto_login_new_user( int $user_id, EC_Redirect_Handler $redi
 	$onboarding_url = function_exists( 'ec_get_site_url' )
 		? ec_get_site_url( 'community' ) . '/onboarding/'
 		: home_url( '/onboarding/' );
+	if ( $invitation_pending_repair ) {
+		$onboarding_url = add_query_arg( 'artist_invitation', 'pending_repair', $onboarding_url );
+	}
 
 	$redirect->redirect_to( $onboarding_url );
 }

--- a/inc/auth/register.php
+++ b/inc/auth/register.php
@@ -55,7 +55,16 @@ function extrachill_handle_registration() {
 		$redirect->error( __( 'Registration source is missing. Please reload and try again.', 'extrachill-users' ) );
 	}
 
-	$from_join = isset( $_POST['from_join'] ) && 'true' === $_POST['from_join'];
+	$from_join               = isset( $_POST['from_join'] ) && 'true' === $_POST['from_join'];
+	$invite_token_posted     = isset( $_POST['invite_token'] ) ? sanitize_text_field( wp_unslash( $_POST['invite_token'] ) ) : '';
+	$invite_artist_id_posted = isset( $_POST['invite_artist_id'] ) ? absint( $_POST['invite_artist_id'] ) : 0;
+	$invite_id               = '';
+	if ( $invite_token_posted || $invite_artist_id_posted ) {
+		$invite_id = ec_users_validate_registration_artist_invitation( $email, $invite_token_posted, $invite_artist_id_posted );
+		if ( is_wp_error( $invite_id ) ) {
+			$redirect->error( $invite_id->get_error_message() );
+		}
+	}
 
 	$username = function_exists( 'ec_generate_username_from_email' )
 		? ec_generate_username_from_email( $email )
@@ -92,30 +101,12 @@ function extrachill_handle_registration() {
 	}
 
 	$processed_invite_artist_id = null;
-	$invite_token_posted        = isset( $_POST['invite_token'] ) ? sanitize_text_field( wp_unslash( $_POST['invite_token'] ) ) : null;
-	$invite_artist_id_posted    = isset( $_POST['invite_artist_id'] ) ? absint( $_POST['invite_artist_id'] ) : null;
-
-	if ( $invite_token_posted && $invite_artist_id_posted && function_exists( 'ec_get_pending_invitations' ) && function_exists( 'ec_add_artist_membership' ) && function_exists( 'ec_remove_pending_invitation' ) ) {
-		$pending_invitations         = ec_get_pending_invitations( $invite_artist_id_posted );
-		$valid_invite_data           = null;
-		$valid_invite_id_for_removal = null;
-
-		foreach ( $pending_invitations as $invite ) {
-			if ( isset( $invite['token'] ) && $invite['token'] === $invite_token_posted &&
-				isset( $invite['email'] ) && strtolower( $invite['email'] ) === strtolower( $email ) &&
-				isset( $invite['status'] ) && 'invited_new_user' === $invite['status'] ) {
-				$valid_invite_data           = $invite;
-				$valid_invite_id_for_removal = $invite['id'];
-				break;
-			}
+	if ( $invite_id ) {
+		$acceptance = ec_accept_artist_membership_invitation( $user_id, $invite_artist_id_posted, $invite_id );
+		if ( is_wp_error( $acceptance ) ) {
+			$redirect->error( $acceptance->get_error_message() );
 		}
-
-		if ( $valid_invite_data ) {
-			if ( ec_add_artist_membership( $user_id, $invite_artist_id_posted ) ) {
-				ec_remove_pending_invitation( $invite_artist_id_posted, $valid_invite_id_for_removal );
-				$processed_invite_artist_id = $invite_artist_id_posted;
-			}
-		}
+		$processed_invite_artist_id = $invite_artist_id_posted;
 	}
 
 	$success_redirect_url = isset( $_POST['success_redirect_url'] ) ? wp_unslash( $_POST['success_redirect_url'] ) : '';

--- a/tests/unit/ArtistInvitationRegistrationTest.php
+++ b/tests/unit/ArtistInvitationRegistrationTest.php
@@ -13,6 +13,7 @@ class Test_Artist_Invitation_Registration extends WP_UnitTestCase {
 
 	protected function tearDown(): void {
 		unset( $_SERVER['HTTP_EXTRACHILL_CLIENT'] );
+		remove_all_filters( 'pre_http_request' );
 		parent::tearDown();
 	}
 
@@ -36,9 +37,126 @@ class Test_Artist_Invitation_Registration extends WP_UnitTestCase {
 	}
 
 	public function test_incomplete_browser_invitation_contract_is_rejected(): void {
-		$result = ec_users_validate_registration_artist_invitation( 'new@example.com', 'token', 0 );
+		$result = ec_users_request_artist_invitation( 'new@example.com', 'token', 0 );
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'invalid_artist_invitation', $result->get_error_code() );
+	}
+
+	public function test_invitation_request_uses_artist_site_http_ability(): void {
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) {
+				$this->assertStringContainsString( '/wp-json/wp-abilities/v1/abilities/extrachill/artist-invitation/run', $url );
+				$this->assertStringContainsString( '"artist_id":20', $args['body'] );
+				return array(
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'headers'  => array(),
+					'body'     => wp_json_encode(
+						array(
+							'status'    => 'valid',
+							'artist_id' => 20,
+						)
+					),
+					'cookies'  => array(),
+				);
+			},
+			10,
+			3
+		);
+
+		$result = ec_users_request_artist_invitation( 'new@example.com', 'secret', 20 );
+		$this->assertSame(
+			array(
+				'status'    => 'valid',
+				'artist_id' => 20,
+			),
+			$result
+		);
+		$this->assertFalse( has_filter( 'ec_cross_site_use_http_loopback' ) );
+	}
+
+	public function test_token_registration_returns_account_with_pending_repair_status(): void {
+		$_SERVER['HTTP_EXTRACHILL_CLIENT'] = 'app';
+		$request_count                     = 0;
+		add_filter(
+			'pre_http_request',
+			static function () use ( &$request_count ) {
+				++$request_count;
+				if ( 1 === $request_count ) {
+					return array(
+						'response' => array(
+							'code'    => 200,
+							'message' => 'OK',
+						),
+						'headers'  => array(),
+						'body'     => wp_json_encode(
+							array(
+								'status'    => 'valid',
+								'artist_id' => 20,
+							)
+						),
+						'cookies'  => array(),
+					);
+				}
+				return array(
+					'response' => array(
+						'code'    => 503,
+						'message' => 'Busy',
+					),
+					'headers'  => array(),
+					'body'     => wp_json_encode(
+						array(
+							'code'    => 'artist_membership_busy',
+							'message' => 'Retry membership.',
+						)
+					),
+					'cookies'  => array(),
+				);
+			},
+			10,
+			3
+		);
+
+		$email  = 'pending-repair@example.com';
+		$result = extrachill_users_register_with_tokens(
+			array(
+				'email'            => $email,
+				'password'         => 'secure-password',
+				'password_confirm' => 'secure-password',
+				'device_id'        => '123e4567-e89b-42d3-a456-426614174000',
+				'invite_token'     => 'secret-token',
+				'invite_artist_id' => 20,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'pending_repair', $result['artist_invitation_status'] );
+		$this->assertNotFalse( email_exists( $email ) );
+		$this->assertSame( 2, $request_count );
+	}
+
+	public function test_browser_registration_logs_in_created_account_with_pending_repair_redirect(): void {
+		$user_id  = self::factory()->user->create( array( 'user_email' => 'browser-repair@example.com' ) );
+		$redirect = new class( 'https://example.org/register' ) extends EC_Redirect_Handler {
+			/**
+			 * Captured redirect URL.
+			 *
+			 * @var string
+			 */
+			public string $captured_url = '';
+
+			public function redirect_to( string $url ): void {
+				$this->captured_url = $url;
+			}
+		};
+
+		extrachill_auto_login_new_user( $user_id, $redirect, null, '', true );
+
+		$this->assertSame( $user_id, get_current_user_id() );
+		$this->assertStringContainsString( 'artist_invitation=pending_repair', $redirect->captured_url );
 	}
 }

--- a/tests/unit/ArtistInvitationRegistrationTest.php
+++ b/tests/unit/ArtistInvitationRegistrationTest.php
@@ -80,11 +80,35 @@ class Test_Artist_Invitation_Registration extends WP_UnitTestCase {
 	}
 
 	public function test_token_registration_returns_account_with_pending_repair_status(): void {
+		$this->assert_token_registration_invitation_outcome( 'artist_membership_busy', 409, 'pending_repair', true );
+	}
+
+	public function test_token_registration_preserves_permanent_invitation_failure(): void {
+		$this->assert_token_registration_invitation_outcome( 'invalid_artist_invitation', 400, 'failed', false );
+	}
+
+	public function test_token_registration_preserves_manual_repair_invitation_failure(): void {
+		$this->assert_token_registration_invitation_outcome( 'artist_invitation_rollback_failed', 500, 'manual_repair', false );
+	}
+
+	public function test_browser_registration_reports_retryable_invitation_outcome(): void {
+		$this->assert_browser_invitation_outcome( 'artist_membership_busy', 409, 'pending_repair', true );
+	}
+
+	public function test_browser_registration_reports_permanent_invitation_outcome(): void {
+		$this->assert_browser_invitation_outcome( 'invalid_artist_invitation', 400, 'failed', false );
+	}
+
+	public function test_browser_registration_reports_manual_repair_invitation_outcome(): void {
+		$this->assert_browser_invitation_outcome( 'artist_invitation_rollback_failed', 500, 'manual_repair', false );
+	}
+
+	private function assert_token_registration_invitation_outcome( string $error_code, int $error_status, string $expected_status, bool $expected_retryable ): void {
 		$_SERVER['HTTP_EXTRACHILL_CLIENT'] = 'app';
 		$request_count                     = 0;
 		add_filter(
 			'pre_http_request',
-			static function () use ( &$request_count ) {
+			static function () use ( &$request_count, $error_code, $error_status ) {
 				++$request_count;
 				if ( 1 === $request_count ) {
 					return array(
@@ -104,14 +128,14 @@ class Test_Artist_Invitation_Registration extends WP_UnitTestCase {
 				}
 				return array(
 					'response' => array(
-						'code'    => 503,
-						'message' => 'Busy',
+						'code'    => $error_status,
+						'message' => 'Invitation failure',
 					),
 					'headers'  => array(),
 					'body'     => wp_json_encode(
 						array(
-							'code'    => 'artist_membership_busy',
-							'message' => 'Retry membership.',
+							'code'    => $error_code,
+							'message' => 'Precise invitation failure.',
 						)
 					),
 					'cookies'  => array(),
@@ -121,7 +145,7 @@ class Test_Artist_Invitation_Registration extends WP_UnitTestCase {
 			3
 		);
 
-		$email  = 'pending-repair@example.com';
+		$email  = sanitize_key( $error_code ) . '@example.com';
 		$result = extrachill_users_register_with_tokens(
 			array(
 				'email'            => $email,
@@ -134,13 +158,17 @@ class Test_Artist_Invitation_Registration extends WP_UnitTestCase {
 		);
 
 		$this->assertIsArray( $result );
-		$this->assertSame( 'pending_repair', $result['artist_invitation_status'] );
+		$this->assertSame( $expected_status, $result['artist_invitation_status'] );
+		$this->assertSame( $expected_retryable, $result['artist_invitation_retryable'] );
+		$this->assertSame( $error_code, $result['artist_invitation_error']['code'] );
+		$this->assertSame( 'Precise invitation failure.', $result['artist_invitation_error']['message'] );
+		$this->assertSame( $error_status, $result['artist_invitation_error']['status'] );
 		$this->assertNotFalse( email_exists( $email ) );
 		$this->assertSame( 2, $request_count );
 	}
 
-	public function test_browser_registration_logs_in_created_account_with_pending_repair_redirect(): void {
-		$user_id  = self::factory()->user->create( array( 'user_email' => 'browser-repair@example.com' ) );
+	private function assert_browser_invitation_outcome( string $error_code, int $error_status, string $expected_status, bool $expected_retryable ): void {
+		$user_id  = self::factory()->user->create( array( 'user_email' => sanitize_key( $error_code ) . '-browser@example.com' ) );
 		$redirect = new class( 'https://example.org/register' ) extends EC_Redirect_Handler {
 			/**
 			 * Captured redirect URL.
@@ -153,10 +181,17 @@ class Test_Artist_Invitation_Registration extends WP_UnitTestCase {
 				$this->captured_url = $url;
 			}
 		};
+		$outcome  = ec_users_classify_artist_invitation_error(
+			new WP_Error( $error_code, 'Precise invitation failure.', array( 'status' => $error_status ) )
+		);
 
-		extrachill_auto_login_new_user( $user_id, $redirect, null, '', true );
+		extrachill_auto_login_new_user( $user_id, $redirect, null, '', $outcome );
 
 		$this->assertSame( $user_id, get_current_user_id() );
-		$this->assertStringContainsString( 'artist_invitation=pending_repair', $redirect->captured_url );
+		$this->assertSame( $expected_status, $outcome['status'] );
+		$this->assertSame( $expected_retryable, $outcome['retryable'] );
+		$this->assertStringContainsString( 'artist_invitation=' . $expected_status, $redirect->captured_url );
+		$this->assertStringContainsString( 'artist_invitation_error=' . $error_code, $redirect->captured_url );
+		$this->assertStringContainsString( 'artist_invitation_error_status=' . $error_status, $redirect->captured_url );
 	}
 }

--- a/tests/unit/ArtistInvitationRegistrationTest.php
+++ b/tests/unit/ArtistInvitationRegistrationTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Artist invitation registration tests.
+ *
+ * @package ExtraChill\Users
+ */
+
+/**
+ * Verify invitation failures stop before user creation when possible.
+ */
+class Test_Artist_Invitation_Registration extends WP_UnitTestCase {
+	// phpcs:disable Squiz.Commenting.FunctionComment.Missing
+
+	protected function tearDown(): void {
+		unset( $_SERVER['HTTP_EXTRACHILL_CLIENT'] );
+		parent::tearDown();
+	}
+
+	public function test_incomplete_invitation_is_rejected_before_token_registration_creates_user(): void {
+		$_SERVER['HTTP_EXTRACHILL_CLIENT'] = 'app';
+		$email                             = 'failed-invite@example.com';
+
+		$result = extrachill_users_register_with_tokens(
+			array(
+				'email'            => $email,
+				'password'         => 'secure-password',
+				'password_confirm' => 'secure-password',
+				'device_id'        => '123e4567-e89b-42d3-a456-426614174000',
+				'invite_token'     => 'token-without-artist',
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_artist_invitation', $result->get_error_code() );
+		$this->assertFalse( email_exists( $email ) );
+	}
+
+	public function test_incomplete_browser_invitation_contract_is_rejected(): void {
+		$result = ec_users_validate_registration_artist_invitation( 'new@example.com', 'token', 0 );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_artist_invitation', $result->get_error_code() );
+	}
+}

--- a/tests/unit/ArtistMembershipAuthorizationTest.php
+++ b/tests/unit/ArtistMembershipAuthorizationTest.php
@@ -84,12 +84,17 @@ class Test_Artist_Membership_Authorization extends WP_UnitTestCase {
 		}
 	}
 
-	public function test_published_artist_post_author_fallback_is_preserved(): void {
-		$user_id    = self::factory()->user->create();
-		$artist_id  = $this->create_artist( $user_id );
-		$private_id = $this->create_artist( $user_id, 'private' );
+	public function test_former_post_author_cannot_manage_without_reciprocal_membership(): void {
+		$user_id   = self::factory()->user->create();
+		$artist_id = $this->create_artist( $user_id );
 
+		$this->assertFalse( ec_can_manage_artist( $user_id, $artist_id ) );
+
+		update_user_meta( $user_id, '_artist_profile_ids', array( $artist_id ) );
+		$this->set_artist_members( $artist_id, array( $user_id ) );
 		$this->assertTrue( ec_can_manage_artist( $user_id, $artist_id ) );
-		$this->assertFalse( ec_can_manage_artist( $user_id, $private_id ) );
+
+		$this->set_artist_members( $artist_id, array() );
+		$this->assertFalse( ec_can_manage_artist( $user_id, $artist_id ) );
 	}
 }

--- a/tests/unit/ArtistMembershipAuthorizationTest.php
+++ b/tests/unit/ArtistMembershipAuthorizationTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Artist membership authorization tests.
+ *
+ * @package ExtraChill\Users
+ */
+
+/**
+ * Verify artist authorization uses the reciprocal membership contract.
+ */
+class Test_Artist_Membership_Authorization extends WP_UnitTestCase {
+	// phpcs:disable Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.VariableComment.Missing
+
+	private int $artist_blog_id;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->artist_blog_id = (int) ec_get_blog_id( 'artist' );
+		while ( ! get_blog_details( $this->artist_blog_id ) ) {
+			self::factory()->blog->create();
+		}
+
+		switch_to_blog( $this->artist_blog_id );
+		register_post_type( 'artist_profile', array( 'public' => true ) );
+		restore_current_blog();
+	}
+
+	private function create_artist( int $author, string $status = 'publish', string $type = 'artist_profile' ): int {
+		switch_to_blog( $this->artist_blog_id );
+		$artist_id = self::factory()->post->create(
+			array(
+				'post_author' => $author,
+				'post_status' => $status,
+				'post_type'   => $type,
+			)
+		);
+		restore_current_blog();
+
+		return $artist_id;
+	}
+
+	private function set_artist_members( int $artist_id, array $user_ids ): void {
+		switch_to_blog( $this->artist_blog_id );
+		update_post_meta( $artist_id, '_artist_member_ids', $user_ids );
+		restore_current_blog();
+	}
+
+	public function test_valid_reciprocal_membership_can_manage_artist(): void {
+		$user_id   = self::factory()->user->create();
+		$artist_id = $this->create_artist( self::factory()->user->create() );
+		update_user_meta( $user_id, '_artist_profile_ids', array( $artist_id ) );
+		$this->set_artist_members( $artist_id, array( $user_id ) );
+
+		$this->assertTrue( ec_can_manage_artist( $user_id, $artist_id ) );
+	}
+
+	public function test_one_sided_memberships_cannot_manage_artist(): void {
+		$user_side_id   = self::factory()->user->create();
+		$artist_side_id = self::factory()->user->create();
+		$artist_id      = $this->create_artist( self::factory()->user->create() );
+		update_user_meta( $user_side_id, '_artist_profile_ids', array( $artist_id ) );
+		$this->set_artist_members( $artist_id, array( $artist_side_id ) );
+
+		$this->assertFalse( ec_can_manage_artist( $user_side_id, $artist_id ) );
+		$this->assertFalse( ec_can_manage_artist( $artist_side_id, $artist_id ) );
+	}
+
+	public function test_invalid_targets_cannot_be_managed(): void {
+		$user_id    = self::factory()->user->create();
+		$private_id = $this->create_artist( $user_id, 'private' );
+		$wrong_id   = $this->create_artist( $user_id, 'publish', 'post' );
+		$deleted_id = $this->create_artist( $user_id );
+		$target_ids = array( $private_id, $wrong_id, $deleted_id );
+		update_user_meta( $user_id, '_artist_profile_ids', $target_ids );
+		foreach ( $target_ids as $target_id ) {
+			$this->set_artist_members( $target_id, array( $user_id ) );
+		}
+		switch_to_blog( $this->artist_blog_id );
+		wp_delete_post( $deleted_id, true );
+		restore_current_blog();
+
+		foreach ( $target_ids as $target_id ) {
+			$this->assertFalse( ec_can_manage_artist( $user_id, $target_id ) );
+		}
+	}
+
+	public function test_published_artist_post_author_fallback_is_preserved(): void {
+		$user_id    = self::factory()->user->create();
+		$artist_id  = $this->create_artist( $user_id );
+		$private_id = $this->create_artist( $user_id, 'private' );
+
+		$this->assertTrue( ec_can_manage_artist( $user_id, $artist_id ) );
+		$this->assertFalse( ec_can_manage_artist( $user_id, $private_id ) );
+	}
+}


### PR DESCRIPTION
## Summary
- retain reciprocal validated membership as the only non-admin artist management grant; `post_author` does not grant access
- route registration invitation validation/acceptance to the artist-owned ability through the existing cross-site HTTP-loopback seam
- classify post-account acceptance failures as retryable pending repair, permanent failure, or non-retryable manual repair without discarding precise code/message/status

## Ownership
Users owns canonical user-to-artist reads, authorization, account creation, login/token issuance, and client-facing registration outcomes. Artist invitation matching, mutation, locking, compensation, and consumption remain in Extra-Chill/extrachill-artist-platform#143.

Tracks Extra-Chill/extrachill-artist-platform#46.

## Outcome classification
Only explicitly transient errors such as lock contention, owner-site unavailability, retry-required writes, and invitation cleanup failure become `pending_repair` with `retryable: true`.

Consumed/invalid invitations, invalid targets, user mismatches, and unknown errors become `failed` with `retryable: false`. Rollback/partial-state errors become `manual_repair` with `retryable: false`. Token responses preserve the exact artist error code, message, and HTTP status; browser onboarding redirects preserve outcome, error code, and status as query parameters.

All post-account outcomes remain truthful successful-account responses, so clients do not retry account creation and dead-end at `email_exists`:
- browser flow logs in the created account and redirects with the classified outcome
- token flow issues the created account's token pair and includes classified invitation fields
- the durable invitation remains available only when the owner reports a retryable condition

## Rebase
Current Users branch was already based on current `origin/main`; no history rewrite was needed.

## Verification
- targeted WPCS passes for authorization, cross-site invitation orchestration, token registration, and membership/invitation tests
- all changed PHP syntax and `git diff --check` pass
- added browser and token coverage for retryable, permanent/consumed, and manual-repair outcomes plus exact code/message/status and created-account side effects
- targeted Homeboy integration attempt `e5da8948-98f0-4d85-a359-c57e6baab1b0` failed before WordPress/plugin execution because the bundled extension autoloader cannot load `Composer\\Autoload\\ClassLoader`; tracked upstream as Extra-Chill/homeboy-extensions#2322

## Companion
- Extra-Chill/extrachill-artist-platform#143
- Extra-Chill/extrachill-artist-platform#46