### PR TITLE
fix: secure artist access administration

### DIFF
--- a/inc/core/abilities/artist-access.php
+++ b/inc/core/abilities/artist-access.php
@@ -14,6 +14,26 @@ defined( 'ABSPATH' ) || exit;
 add_action( 'wp_abilities_api_init', 'extrachill_users_register_artist_access_abilities' );
 
 /**
+ * Authorize Artist Platform access administration.
+ *
+ * @return bool
+ */
+function extrachill_users_artist_access_admin_permission() {
+	return current_user_can( 'manage_network_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+}
+
+/**
+ * Require Artist Platform access administration authorization.
+ *
+ * @return true|WP_Error
+ */
+function extrachill_users_require_artist_access_admin() {
+	return extrachill_users_artist_access_admin_permission()
+		? true
+		: new WP_Error( 'artist_access_forbidden', __( 'You cannot manage Artist Platform access.', 'extrachill-users' ), array( 'status' => 403 ) );
+}
+
+/**
  * Register artist access management abilities.
  */
 function extrachill_users_register_artist_access_abilities() {
@@ -29,7 +49,7 @@ function extrachill_users_register_artist_access_abilities() {
 			),
 			'output_schema'       => array( 'type' => 'object' ),
 			'execute_callback'    => 'extrachill_users_ability_list_artist_access_requests',
-			'permission_callback' => '__return_true',
+			'permission_callback' => 'extrachill_users_artist_access_admin_permission',
 			'meta'                => array(
 				'show_in_rest' => false,
 				'annotations'  => array(
@@ -59,7 +79,7 @@ function extrachill_users_register_artist_access_abilities() {
 			),
 			'output_schema'       => array( 'type' => 'object' ),
 			'execute_callback'    => 'extrachill_users_ability_approve_artist_access',
-			'permission_callback' => '__return_true',
+			'permission_callback' => 'extrachill_users_artist_access_admin_permission',
 			'meta'                => array(
 				'show_in_rest' => false,
 				'annotations'  => array(
@@ -114,7 +134,7 @@ function extrachill_users_register_artist_access_abilities() {
 			),
 			'output_schema'       => array( 'type' => 'object' ),
 			'execute_callback'    => 'extrachill_users_ability_reject_artist_access',
-			'permission_callback' => '__return_true',
+			'permission_callback' => 'extrachill_users_artist_access_admin_permission',
 			'meta'                => array(
 				'show_in_rest' => false,
 				'annotations'  => array(
@@ -133,6 +153,11 @@ function extrachill_users_register_artist_access_abilities() {
  * @return array Array with 'requests' key containing pending request data.
  */
 function extrachill_users_ability_list_artist_access_requests() {
+	$allowed = extrachill_users_require_artist_access_admin();
+	if ( is_wp_error( $allowed ) ) {
+		return $allowed;
+	}
+
 	$user_query = new WP_User_Query(
 		array(
 			'blog_id'  => 0,
@@ -174,6 +199,11 @@ function extrachill_users_ability_list_artist_access_requests() {
  * @return array|WP_Error Result or error.
  */
 function extrachill_users_ability_approve_artist_access( $input ) {
+	$allowed = extrachill_users_require_artist_access_admin();
+	if ( is_wp_error( $allowed ) ) {
+		return $allowed;
+	}
+
 	$user_id = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : 0;
 	$type    = isset( $input['type'] ) ? sanitize_text_field( $input['type'] ) : '';
 
@@ -246,6 +276,11 @@ function extrachill_users_ability_approve_artist_access( $input ) {
  * @return array|WP_Error Result or error.
  */
 function extrachill_users_ability_reject_artist_access( $input ) {
+	$allowed = extrachill_users_require_artist_access_admin();
+	if ( is_wp_error( $allowed ) ) {
+		return $allowed;
+	}
+
 	$user_id = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : 0;
 
 	if ( ! $user_id ) {

--- a/tests/unit/ArtistAccessAbilitiesTest.php
+++ b/tests/unit/ArtistAccessAbilitiesTest.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Artist Platform access ability authorization tests.
+ *
+ * @package ExtraChill\Users
+ */
+
+/**
+ * Verify administrative abilities fail closed while requests remain self-only.
+ */
+class Test_Artist_Access_Abilities extends WP_UnitTestCase {
+
+	/**
+	 * Register a clean copy of the abilities for each test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		require_once dirname( __DIR__, 2 ) . '/inc/core/abilities/artist-access.php';
+
+		foreach ( $this->ability_names() as $ability_name ) {
+			wp_unregister_ability( $ability_name );
+		}
+		extrachill_users_register_artist_access_abilities();
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Reset authentication state.
+	 */
+	protected function tearDown(): void {
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	/**
+	 * Return ability names owned by the artist access surface.
+	 *
+	 * @return string[]
+	 */
+	private function ability_names(): array {
+		return array(
+			'extrachill/list-artist-access-requests',
+			'extrachill/approve-artist-access',
+			'extrachill/request-artist-access',
+			'extrachill/reject-artist-access',
+		);
+	}
+
+	/**
+	 * Subscribers cannot execute any administrative ability.
+	 */
+	public function test_registered_administrative_abilities_deny_subscribers(): void {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		foreach ( array( 'list-artist-access-requests', 'approve-artist-access', 'reject-artist-access' ) as $name ) {
+			$result = wp_get_ability( 'extrachill/' . $name )->execute( array() );
+			$this->assertWPError( $result );
+			$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+		}
+	}
+
+	/**
+	 * Direct callback invocation cannot bypass administrative authorization.
+	 */
+	public function test_administrative_execute_callbacks_deny_direct_subscriber_invocation(): void {
+		$target_id = self::factory()->user->create();
+		update_user_meta( $target_id, 'artist_access_request', array( 'type' => 'artist' ) );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$results = array(
+			extrachill_users_ability_list_artist_access_requests(),
+			extrachill_users_ability_approve_artist_access(
+				array(
+					'user_id' => $target_id,
+					'type'    => 'artist',
+				)
+			),
+			extrachill_users_ability_reject_artist_access( array( 'user_id' => $target_id ) ),
+		);
+
+		foreach ( $results as $result ) {
+			$this->assertWPError( $result );
+			$this->assertSame( 'artist_access_forbidden', $result->get_error_code() );
+			$this->assertSame( 403, $result->get_error_data()['status'] );
+		}
+		$this->assertNotEmpty( get_user_meta( $target_id, 'artist_access_request', true ) );
+		$this->assertEmpty( get_user_meta( $target_id, 'user_is_artist', true ) );
+	}
+
+	/**
+	 * Network administrators can list and transition requests.
+	 */
+	public function test_network_admin_can_execute_administrative_abilities(): void {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $admin_id );
+		wp_set_current_user( $admin_id );
+
+		$approved_id = self::factory()->user->create();
+		$rejected_id = self::factory()->user->create();
+		update_user_meta( $approved_id, 'artist_access_request', array( 'type' => 'artist' ) );
+		update_user_meta( $rejected_id, 'artist_access_request', array( 'type' => 'professional' ) );
+
+		$list = wp_get_ability( 'extrachill/list-artist-access-requests' )->execute( array() );
+		$this->assertFalse( is_wp_error( $list ) );
+		$this->assertCount( 2, $list['requests'] );
+
+		$approved = wp_get_ability( 'extrachill/approve-artist-access' )->execute(
+			array(
+				'user_id' => $approved_id,
+				'type'    => 'artist',
+			)
+		);
+		$this->assertFalse( is_wp_error( $approved ) );
+		$this->assertSame( '1', get_user_meta( $approved_id, 'user_is_artist', true ) );
+
+		$rejected = wp_get_ability( 'extrachill/reject-artist-access' )->execute( array( 'user_id' => $rejected_id ) );
+		$this->assertFalse( is_wp_error( $rejected ) );
+		$this->assertEmpty( get_user_meta( $rejected_id, 'artist_access_request', true ) );
+	}
+
+	/**
+	 * The request ability continues to ignore supplied user IDs and use self.
+	 */
+	public function test_request_ability_remains_self_only(): void {
+		$self_id  = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$other_id = self::factory()->user->create();
+		wp_set_current_user( $self_id );
+
+		$result = extrachill_users_ability_request_artist_access(
+			array(
+				'user_id' => $other_id,
+				'type'    => 'artist',
+			)
+		);
+
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertSame( $self_id, $result['user_id'] );
+		$this->assertNotEmpty( get_user_meta( $self_id, 'artist_access_request', true ) );
+		$this->assertEmpty( get_user_meta( $other_id, 'artist_access_request', true ) );
+	}
+
+	/**
+	 * Explicit WP-CLI execution retains administrative access.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_explicit_wp_cli_context_is_authorized(): void {
+		define( 'WP_CLI', true );
+		wp_set_current_user( 0 );
+
+		$this->assertTrue( extrachill_users_artist_access_admin_permission() );
+		$this->assertNotWPError( extrachill_users_ability_list_artist_access_requests() );
+	}
+}


### PR DESCRIPTION
## Summary
- authorize Artist Platform list/approve/reject abilities only for network administrators or explicit WP-CLI execution
- repeat authorization inside every administrative execute callback so direct/internal calls fail closed with a 403
- preserve the existing authenticated self-only request behavior

## Authorization contract
Administrative access follows the repository's existing Artist Dispatch policy: `current_user_can( 'manage_network_options' ) || ( defined( 'WP_CLI' ) && WP_CLI )`. No compatibility bypass or new authentication layer is introduced.

## Tests
- added coverage for registered subscriber denial
- added direct execute callback denial and mutation protection
- added network-admin list/approve/reject access
- added explicit WP-CLI access and self-only request behavior
- `php -l inc/core/abilities/artist-access.php` passed
- `php -l tests/unit/ArtistAccessAbilitiesTest.php` passed
- `git diff --check` passed
- changed-file Homeboy lint completed with no findings; its PHPCS/PHPStan installations reported existing broken binaries
- focused PHPUnit execution was attempted, but Codebox failed before loading tests in WordPress bootstrap: `Call to a member function set_permalink_structure() on null`

Fixes #211