### PR TITLE
feat: track onboarding artist access grants

### DIFF
--- a/inc/core/abilities/onboarding.php
+++ b/inc/core/abilities/onboarding.php
@@ -13,6 +13,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+const EC_USERS_ONBOARDING_ARTIST_GRANT_META = '_extrachill_onboarding_artist_grant';
+
 add_action( 'wp_abilities_api_init', 'extrachill_users_register_onboarding_abilities' );
 
 /**
@@ -157,6 +159,211 @@ function extrachill_users_register_onboarding_abilities() {
 // ─── Execute Callbacks ──────────────────────────────────────────────────────
 
 /**
+ * Return the request-local onboarding lock registry.
+ *
+ * @return array<int,bool> Locked user IDs.
+ */
+function &ec_users_onboarding_lock_registry() {
+	static $locks = array();
+	return $locks;
+}
+
+/**
+ * Acquire the per-user onboarding transition lock.
+ *
+ * The request-local guard rejects same-connection reentrancy, while MySQL's
+ * advisory lock serializes separate PHP workers.
+ *
+ * @param int $user_id User ID.
+ * @return string|WP_Error Lock name or error.
+ */
+function ec_users_acquire_onboarding_lock( $user_id ) {
+	global $wpdb;
+
+	$locks = &ec_users_onboarding_lock_registry();
+	if ( isset( $locks[ $user_id ] ) ) {
+		return new WP_Error(
+			'onboarding_transition_locked',
+			__( 'Another onboarding update is in progress. Please retry.', 'extrachill-users' ),
+			array(
+				'status'         => 409,
+				'classification' => 'retry',
+				'retryable'      => true,
+			)
+		);
+	}
+
+	$locks[ $user_id ] = true;
+	$lock_name         = 'ec_onboarding_' . md5( (string) $user_id );
+	// phpcs:disable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL -- Existing per-transition advisory lock pattern.
+	$acquired = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, 5)', $lock_name ) );
+	// phpcs:enable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL
+	if ( null === $acquired && '' !== $wpdb->last_error ) {
+		unset( $locks[ $user_id ] );
+		return new WP_Error(
+			'onboarding_lock_database_error',
+			__( 'Onboarding could not be updated. Please retry.', 'extrachill-users' ),
+			array(
+				'status'         => 500,
+				'classification' => 'retry',
+				'retryable'      => true,
+			)
+		);
+	}
+	if ( 1 !== (int) $acquired ) {
+		unset( $locks[ $user_id ] );
+		return new WP_Error(
+			'onboarding_transition_locked',
+			__( 'Another onboarding update is in progress. Please retry.', 'extrachill-users' ),
+			array(
+				'status'         => 409,
+				'classification' => 'retry',
+				'retryable'      => true,
+			)
+		);
+	}
+
+	return $lock_name;
+}
+
+/**
+ * Release an owned onboarding transition lock.
+ *
+ * @param int    $user_id   User ID.
+ * @param string $lock_name Advisory lock name.
+ */
+function ec_users_release_onboarding_lock( $user_id, $lock_name ) {
+	global $wpdb;
+
+	$locks = &ec_users_onboarding_lock_registry();
+	// phpcs:disable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL -- Existing per-transition advisory lock pattern.
+	$wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) );
+	// phpcs:enable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL
+	unset( $locks[ $user_id ] );
+}
+
+/**
+ * Compare-and-swap the onboarding grant delivery state.
+ *
+ * @param int   $user_id User ID.
+ * @param array $next    Replacement state.
+ * @param array $current State read while holding the transition lock.
+ * @return bool Whether the exact transition persisted.
+ */
+function ec_users_write_onboarding_grant_state( $user_id, array $next, array $current ) {
+	if ( empty( $current ) ) {
+		return false !== add_user_meta( $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META, $next, true );
+	}
+
+	return false !== update_user_meta( $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META, $next, $current );
+}
+
+/**
+ * Restore transition metadata and verify every resulting value.
+ *
+ * @param int   $user_id      User ID.
+ * @param array $previous_meta Previous value/existence records by key.
+ * @return bool Whether every key was restored exactly.
+ */
+function ec_users_restore_onboarding_transition_meta( $user_id, array $previous_meta ) {
+	$restored = true;
+	foreach ( $previous_meta as $meta_key => $previous ) {
+		if ( $previous['exists'] ) {
+			$write_failed   = false === update_user_meta( $user_id, $meta_key, $previous['value'] );
+			$restored_value = get_user_meta( $user_id, $meta_key, true );
+			$key_restored   = $restored_value === $previous['value'];
+		} else {
+			$write_failed = false === delete_user_meta( $user_id, $meta_key );
+			$key_restored = ! metadata_exists( 'user', $user_id, $meta_key );
+		}
+		$restored = $restored && $key_restored && ( ! $write_failed || $key_restored );
+	}
+
+	return $restored;
+}
+
+/**
+ * Deliver one reserved onboarding grant event with durable outcome markers.
+ *
+ * @param int   $user_id User ID.
+ * @param array $state   Pending delivery state held under the onboarding lock.
+ * @return true|WP_Error True when delivered, or a classified recovery error.
+ */
+function ec_users_deliver_onboarding_artist_grant( $user_id, array $state ) {
+	if ( 'delivered' === ( $state['status'] ?? '' ) ) {
+		return true;
+	}
+	if ( 'pending' !== ( $state['status'] ?? '' ) ) {
+		return new WP_Error(
+			'onboarding_grant_repair_required',
+			__( 'The onboarding access grant requires manual reconciliation.', 'extrachill-users' ),
+			array(
+				'status'         => 500,
+				'classification' => 'manual_repair',
+				'retryable'      => false,
+			)
+		);
+	}
+
+	$reserved           = $state;
+	$reserved['status'] = 'reserved';
+	if ( ! ec_users_write_onboarding_grant_state( $user_id, $reserved, $state ) ) {
+		return new WP_Error(
+			'onboarding_grant_reservation_failed',
+			__( 'The onboarding access event could not be reserved. Please retry.', 'extrachill-users' ),
+			array(
+				'status'         => 500,
+				'classification' => 'retry',
+				'retryable'      => true,
+			)
+		);
+	}
+
+	$method       = (string) $state['method'];
+	$is_artist    = in_array( $method, array( 'artist', 'artist_and_professional' ), true );
+	$professional = in_array( $method, array( 'professional', 'artist_and_professional' ), true );
+	if ( 0 >= ec_users_emit_onboarding_artist_access_granted( $user_id, $is_artist, $professional ) ) {
+		if ( ! ec_users_write_onboarding_grant_state( $user_id, $state, $reserved ) ) {
+			return new WP_Error(
+				'onboarding_grant_repair_required',
+				__( 'Analytics delivery failed and its reservation requires manual reconciliation.', 'extrachill-users' ),
+				array(
+					'status'         => 500,
+					'classification' => 'manual_repair',
+					'retryable'      => false,
+				)
+			);
+		}
+		return new WP_Error(
+			'onboarding_grant_delivery_failed',
+			__( 'The onboarding access event could not be recorded. Please retry.', 'extrachill-users' ),
+			array(
+				'status'         => 500,
+				'classification' => 'retry',
+				'retryable'      => true,
+			)
+		);
+	}
+
+	$delivered                 = $reserved;
+	$delivered['status']       = 'delivered';
+	$delivered['delivered_at'] = time();
+	if ( ! ec_users_write_onboarding_grant_state( $user_id, $delivered, $reserved ) ) {
+		return new WP_Error(
+			'onboarding_grant_repair_required',
+			__( 'The onboarding access event was recorded but its receipt requires manual reconciliation.', 'extrachill-users' ),
+			array(
+				'status'         => 500,
+				'classification' => 'manual_repair',
+				'retryable'      => false,
+			)
+		);
+	}
+
+	return true;
+}
+
+/**
  * Complete onboarding for a user.
  *
  * Validates username, updates the user record, sets artist/professional flags,
@@ -176,13 +383,6 @@ function extrachill_users_ability_complete_onboarding( $input ) {
 	$user = get_userdata( $user_id );
 	if ( ! $user ) {
 		return ec_users_onboarding_error( 'invalid_user', __( 'Invalid user.', 'extrachill-users' ), $user_id );
-	}
-
-	$had_artist_access = '1' === get_user_meta( $user_id, 'user_is_artist', true )
-		|| '1' === get_user_meta( $user_id, 'user_is_professional', true );
-
-	if ( function_exists( 'ec_is_onboarding_complete' ) && ec_is_onboarding_complete( $user_id ) ) {
-		return ec_users_onboarding_error( 'already_completed', __( 'Onboarding already completed.', 'extrachill-users' ), $user_id );
 	}
 
 	// Validate username via ability.
@@ -222,70 +422,179 @@ function extrachill_users_ability_complete_onboarding( $input ) {
 		return ec_users_onboarding_error( 'invalid_local_scene_visibility', __( 'Local Scene visibility must be public or private.', 'extrachill-users' ), $user_id );
 	}
 
-	// Update username in database.
-	global $wpdb;
-
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Updating the core user row is the onboarding operation.
-	$result = $wpdb->update(
-		$wpdb->users,
-		array(
-			'user_login'    => $username,
-			'user_nicename' => sanitize_title( $username ),
-			'display_name'  => $username,
-		),
-		array( 'ID' => $user_id ),
-		array( '%s', '%s', '%s' ),
-		array( '%d' )
-	);
-
-	if ( false === $result ) {
-		return ec_users_onboarding_error( 'update_failed', __( 'Failed to update username.', 'extrachill-users' ), $user_id );
+	$lock = ec_users_acquire_onboarding_lock( $user_id );
+	if ( is_wp_error( $lock ) ) {
+		return $lock;
 	}
 
-	if ( '' !== $local_scene ) {
-		extrachill_users_set_local_scene( $user_id, $local_scene );
-	}
-	extrachill_users_set_local_scene_visibility( $user_id, $visibility );
-
-	// Persist access and completion as one verified transition. Restoring these
-	// values on failure prevents a partial grant from becoming an unmeasurable
-	// retry that appears already granted.
-	$transition_keys = array(
-		'user_is_artist',
-		'user_is_professional',
-		'onboarding_completed',
-		'onboarding_completed_at',
-	);
-	$previous_meta   = array();
-	foreach ( $transition_keys as $meta_key ) {
-		$previous_meta[ $meta_key ] = array(
-			'exists' => metadata_exists( 'user', $user_id, $meta_key ),
-			'value'  => get_user_meta( $user_id, $meta_key, true ),
-		);
-	}
-	$completed_at = time();
-
-	update_user_meta( $user_id, 'user_is_artist', $user_is_artist ? '1' : '0' );
-	update_user_meta( $user_id, 'user_is_professional', $user_is_professional ? '1' : '0' );
-	update_user_meta( $user_id, 'onboarding_completed', '1' );
-	update_user_meta( $user_id, 'onboarding_completed_at', $completed_at );
-
-	$stored_completed_at  = (int) get_user_meta( $user_id, 'onboarding_completed_at', true );
-	$transition_persisted = ( $user_is_artist ? '1' : '0' ) === get_user_meta( $user_id, 'user_is_artist', true )
-		&& ( $user_is_professional ? '1' : '0' ) === get_user_meta( $user_id, 'user_is_professional', true )
-		&& '1' === get_user_meta( $user_id, 'onboarding_completed', true )
-		&& $stored_completed_at === $completed_at;
-
-	if ( ! $transition_persisted ) {
-		foreach ( $previous_meta as $meta_key => $previous ) {
-			if ( $previous['exists'] ) {
-				update_user_meta( $user_id, $meta_key, $previous['value'] );
-			} else {
-				delete_user_meta( $user_id, $meta_key );
+	try {
+		$grant_state = get_user_meta( $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META, true );
+		$grant_state = is_array( $grant_state ) ? $grant_state : array();
+		if ( function_exists( 'ec_is_onboarding_complete' ) && ec_is_onboarding_complete( $user_id ) ) {
+			if ( ! empty( $grant_state ) && 'delivered' !== ( $grant_state['status'] ?? '' ) ) {
+				$delivery = ec_users_deliver_onboarding_artist_grant( $user_id, $grant_state );
+				if ( is_wp_error( $delivery ) ) {
+					return $delivery;
+				}
 			}
+			return ec_users_onboarding_error( 'already_completed', __( 'Onboarding already completed.', 'extrachill-users' ), $user_id );
 		}
 
-		return ec_users_onboarding_error( 'onboarding_state_update_failed', __( 'Failed to save onboarding state.', 'extrachill-users' ), $user_id );
+		// Update username in database.
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Updating the core user row is the onboarding operation.
+		$result = $wpdb->update(
+			$wpdb->users,
+			array(
+				'user_login'    => $username,
+				'user_nicename' => sanitize_title( $username ),
+				'display_name'  => $username,
+			),
+			array( 'ID' => $user_id ),
+			array( '%s', '%s', '%s' ),
+			array( '%d' )
+		);
+
+		if ( false === $result ) {
+			return ec_users_onboarding_error( 'update_failed', __( 'Failed to update username.', 'extrachill-users' ), $user_id );
+		}
+
+		if ( '' !== $local_scene ) {
+			extrachill_users_set_local_scene( $user_id, $local_scene );
+		}
+		extrachill_users_set_local_scene_visibility( $user_id, $visibility );
+
+		$had_artist_access = '1' === get_user_meta( $user_id, 'user_is_artist', true )
+			|| '1' === get_user_meta( $user_id, 'user_is_professional', true );
+		$new_grant_state   = false;
+		if ( empty( $grant_state ) && ! $had_artist_access && ( $user_is_artist || $user_is_professional ) ) {
+			$grant_state = array(
+				'status'     => 'pending',
+				'method'     => ec_users_get_onboarding_artist_grant_method( $user_is_artist, $user_is_professional ),
+				'created_at' => time(),
+			);
+			if ( ! ec_users_write_onboarding_grant_state( $user_id, $grant_state, array() ) ) {
+				return new WP_Error(
+					'onboarding_grant_state_failed',
+					__( 'The onboarding access transition could not be reserved. Please retry.', 'extrachill-users' ),
+					array(
+						'status'         => 500,
+						'classification' => 'retry',
+						'retryable'      => true,
+					)
+				);
+			}
+			$new_grant_state = true;
+		} elseif ( ! empty( $grant_state ) && 'pending' !== ( $grant_state['status'] ?? '' ) && 'delivered' !== ( $grant_state['status'] ?? '' ) ) {
+			return new WP_Error(
+				'onboarding_grant_repair_required',
+				__( 'The onboarding access grant requires manual reconciliation.', 'extrachill-users' ),
+				array(
+					'status'         => 500,
+					'classification' => 'manual_repair',
+					'retryable'      => false,
+				)
+			);
+		}
+
+		// Persist access and completion as one verified transition. Restoring these
+		// values on failure prevents a partial grant from becoming an unmeasurable
+		// retry that appears already granted.
+		$transition_keys = array(
+			'user_is_artist',
+			'user_is_professional',
+			'onboarding_completed',
+			'onboarding_completed_at',
+		);
+		$previous_meta   = array();
+		foreach ( $transition_keys as $meta_key ) {
+			$previous_meta[ $meta_key ] = array(
+				'exists' => metadata_exists( 'user', $user_id, $meta_key ),
+				'value'  => get_user_meta( $user_id, $meta_key, true ),
+			);
+		}
+		$completed_at = time();
+
+		update_user_meta( $user_id, 'user_is_artist', $user_is_artist ? '1' : '0' );
+		update_user_meta( $user_id, 'user_is_professional', $user_is_professional ? '1' : '0' );
+		update_user_meta( $user_id, 'onboarding_completed', '1' );
+		update_user_meta( $user_id, 'onboarding_completed_at', $completed_at );
+
+		$stored_completed_at  = (int) get_user_meta( $user_id, 'onboarding_completed_at', true );
+		$transition_persisted = ( $user_is_artist ? '1' : '0' ) === get_user_meta( $user_id, 'user_is_artist', true )
+			&& ( $user_is_professional ? '1' : '0' ) === get_user_meta( $user_id, 'user_is_professional', true )
+			&& '1' === get_user_meta( $user_id, 'onboarding_completed', true )
+			&& $stored_completed_at === $completed_at;
+
+		if ( ! $transition_persisted ) {
+			$rollback_succeeded = ec_users_restore_onboarding_transition_meta( $user_id, $previous_meta );
+			if ( ! $rollback_succeeded ) {
+				$repair_recorded = false;
+				if ( ! empty( $grant_state ) && 'pending' === ( $grant_state['status'] ?? '' ) ) {
+					$repair_state           = $grant_state;
+					$repair_state['status'] = 'repair_required';
+					$repair_recorded        = ec_users_write_onboarding_grant_state( $user_id, $repair_state, $grant_state );
+				}
+				if ( ! empty( $grant_state ) && ! $repair_recorded ) {
+					$current_grant_state = get_user_meta( $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META, true );
+					if ( $grant_state === $current_grant_state ) {
+						return new WP_Error(
+							'onboarding_state_rollback_retry_required',
+							__( 'Onboarding state was only partially restored. Please retry.', 'extrachill-users' ),
+							array(
+								'status'         => 500,
+								'classification' => 'retry',
+								'retryable'      => true,
+							)
+						);
+					}
+				}
+				return new WP_Error(
+					'onboarding_state_rollback_failed',
+					__( 'Onboarding state could not be restored and requires manual repair.', 'extrachill-users' ),
+					array(
+						'status'         => 500,
+						'classification' => 'manual_repair',
+						'retryable'      => false,
+					)
+				);
+			}
+
+			if ( $new_grant_state ) {
+				$deleted = delete_user_meta( $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META, $grant_state );
+				if ( ! $deleted || metadata_exists( 'user', $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META ) ) {
+					return new WP_Error(
+						'onboarding_grant_repair_required',
+						__( 'Onboarding was restored but its grant reservation requires manual repair.', 'extrachill-users' ),
+						array(
+							'status'         => 500,
+							'classification' => 'manual_repair',
+							'retryable'      => false,
+						)
+					);
+				}
+			}
+
+			return new WP_Error(
+				'onboarding_state_update_failed',
+				__( 'Failed to save onboarding state. Please retry.', 'extrachill-users' ),
+				array(
+					'status'         => 500,
+					'classification' => 'retry',
+					'retryable'      => true,
+				)
+			);
+		}
+
+		if ( ! empty( $grant_state ) && 'pending' === ( $grant_state['status'] ?? '' ) ) {
+			$delivery = ec_users_deliver_onboarding_artist_grant( $user_id, $grant_state );
+			if ( is_wp_error( $delivery ) ) {
+				return $delivery;
+			}
+		}
+	} finally {
+		ec_users_release_onboarding_lock( $user_id, $lock );
 	}
 
 	clean_user_cache( $user_id );
@@ -301,10 +610,6 @@ function extrachill_users_ability_complete_onboarding( $input ) {
 	 * @param array $input   Onboarding data.
 	 */
 	do_action( 'ec_onboarding_completed', $user_id, $input );
-
-	if ( ! $had_artist_access && ( $user_is_artist || $user_is_professional ) ) {
-		ec_users_emit_onboarding_artist_access_granted( $user_id, $user_is_artist, $user_is_professional );
-	}
 
 	$event_data = array(
 		'has_local_scene' => '' !== $local_scene,

--- a/inc/core/abilities/onboarding.php
+++ b/inc/core/abilities/onboarding.php
@@ -178,6 +178,9 @@ function extrachill_users_ability_complete_onboarding( $input ) {
 		return ec_users_onboarding_error( 'invalid_user', __( 'Invalid user.', 'extrachill-users' ), $user_id );
 	}
 
+	$had_artist_access = '1' === get_user_meta( $user_id, 'user_is_artist', true )
+		|| '1' === get_user_meta( $user_id, 'user_is_professional', true );
+
 	if ( function_exists( 'ec_is_onboarding_complete' ) && ec_is_onboarding_complete( $user_id ) ) {
 		return ec_users_onboarding_error( 'already_completed', __( 'Onboarding already completed.', 'extrachill-users' ), $user_id );
 	}
@@ -222,6 +225,7 @@ function extrachill_users_ability_complete_onboarding( $input ) {
 	// Update username in database.
 	global $wpdb;
 
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Updating the core user row is the onboarding operation.
 	$result = $wpdb->update(
 		$wpdb->users,
 		array(
@@ -243,11 +247,46 @@ function extrachill_users_ability_complete_onboarding( $input ) {
 	}
 	extrachill_users_set_local_scene_visibility( $user_id, $visibility );
 
-	// Set flags and mark complete.
+	// Persist access and completion as one verified transition. Restoring these
+	// values on failure prevents a partial grant from becoming an unmeasurable
+	// retry that appears already granted.
+	$transition_keys = array(
+		'user_is_artist',
+		'user_is_professional',
+		'onboarding_completed',
+		'onboarding_completed_at',
+	);
+	$previous_meta   = array();
+	foreach ( $transition_keys as $meta_key ) {
+		$previous_meta[ $meta_key ] = array(
+			'exists' => metadata_exists( 'user', $user_id, $meta_key ),
+			'value'  => get_user_meta( $user_id, $meta_key, true ),
+		);
+	}
+	$completed_at = time();
+
 	update_user_meta( $user_id, 'user_is_artist', $user_is_artist ? '1' : '0' );
 	update_user_meta( $user_id, 'user_is_professional', $user_is_professional ? '1' : '0' );
 	update_user_meta( $user_id, 'onboarding_completed', '1' );
-	update_user_meta( $user_id, 'onboarding_completed_at', time() );
+	update_user_meta( $user_id, 'onboarding_completed_at', $completed_at );
+
+	$stored_completed_at  = (int) get_user_meta( $user_id, 'onboarding_completed_at', true );
+	$transition_persisted = ( $user_is_artist ? '1' : '0' ) === get_user_meta( $user_id, 'user_is_artist', true )
+		&& ( $user_is_professional ? '1' : '0' ) === get_user_meta( $user_id, 'user_is_professional', true )
+		&& '1' === get_user_meta( $user_id, 'onboarding_completed', true )
+		&& $stored_completed_at === $completed_at;
+
+	if ( ! $transition_persisted ) {
+		foreach ( $previous_meta as $meta_key => $previous ) {
+			if ( $previous['exists'] ) {
+				update_user_meta( $user_id, $meta_key, $previous['value'] );
+			} else {
+				delete_user_meta( $user_id, $meta_key );
+			}
+		}
+
+		return ec_users_onboarding_error( 'onboarding_state_update_failed', __( 'Failed to save onboarding state.', 'extrachill-users' ), $user_id );
+	}
 
 	clean_user_cache( $user_id );
 
@@ -262,6 +301,10 @@ function extrachill_users_ability_complete_onboarding( $input ) {
 	 * @param array $input   Onboarding data.
 	 */
 	do_action( 'ec_onboarding_completed', $user_id, $input );
+
+	if ( ! $had_artist_access && ( $user_is_artist || $user_is_professional ) ) {
+		ec_users_emit_onboarding_artist_access_granted( $user_id, $user_is_artist, $user_is_professional );
+	}
 
 	$event_data = array(
 		'has_local_scene' => '' !== $local_scene,

--- a/inc/core/abilities/onboarding.php
+++ b/inc/core/abilities/onboarding.php
@@ -259,6 +259,82 @@ function ec_users_write_onboarding_grant_state( $user_id, array $next, array $cu
 }
 
 /**
+ * Reconcile an incomplete pending grant against the current bounded intent.
+ *
+ * When no access persisted, the retry may safely replace or remove stale
+ * intent. Existing access makes a changed intent ambiguous and must fail
+ * closed rather than relabel the transition.
+ *
+ * @param int   $user_id             User ID.
+ * @param array $state               Current grant receipt.
+ * @param bool  $is_artist           Current artist intent.
+ * @param bool  $is_professional     Current professional intent.
+ * @return array|WP_Error Reconciled receipt or error.
+ */
+function ec_users_reconcile_pending_onboarding_grant( $user_id, array $state, $is_artist, $is_professional ) {
+	if ( 'pending' !== ( $state['status'] ?? '' ) ) {
+		return $state;
+	}
+
+	$has_artist       = '1' === get_user_meta( $user_id, 'user_is_artist', true );
+	$has_professional = '1' === get_user_meta( $user_id, 'user_is_professional', true );
+	$wants_access     = $is_artist || $is_professional;
+	$current_method   = $wants_access ? ec_users_get_onboarding_artist_grant_method( $is_artist, $is_professional ) : '';
+	$receipt_method   = (string) ( $state['method'] ?? '' );
+
+	if ( $has_artist || $has_professional ) {
+		$stored_method = ec_users_get_onboarding_artist_grant_method( $has_artist, $has_professional );
+		if ( $stored_method !== $receipt_method || $current_method !== $stored_method ) {
+			return new WP_Error(
+				'onboarding_grant_intent_repair_required',
+				__( 'Stored onboarding access no longer matches the pending grant and requires manual reconciliation.', 'extrachill-users' ),
+				array(
+					'status'         => 500,
+					'classification' => 'manual_repair',
+					'retryable'      => false,
+				)
+			);
+		}
+		return $state;
+	}
+
+	if ( ! $wants_access ) {
+		$deleted = delete_user_meta( $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META, $state );
+		if ( $deleted && ! metadata_exists( 'user', $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META ) ) {
+			return array();
+		}
+		return new WP_Error(
+			'onboarding_grant_intent_update_failed',
+			__( 'The stale onboarding grant could not be cleared. Please retry.', 'extrachill-users' ),
+			array(
+				'status'         => 500,
+				'classification' => 'retry',
+				'retryable'      => true,
+			)
+		);
+	}
+
+	if ( $current_method === $receipt_method ) {
+		return $state;
+	}
+	$next           = $state;
+	$next['method'] = $current_method;
+	if ( ec_users_write_onboarding_grant_state( $user_id, $next, $state ) ) {
+		return $next;
+	}
+
+	return new WP_Error(
+		'onboarding_grant_intent_update_failed',
+		__( 'The onboarding grant intent could not be updated. Please retry.', 'extrachill-users' ),
+		array(
+			'status'         => 500,
+			'classification' => 'retry',
+			'retryable'      => true,
+		)
+	);
+}
+
+/**
  * Restore transition metadata and verify every resulting value.
  *
  * @param int   $user_id      User ID.
@@ -439,6 +515,23 @@ function extrachill_users_ability_complete_onboarding( $input ) {
 			}
 			return ec_users_onboarding_error( 'already_completed', __( 'Onboarding already completed.', 'extrachill-users' ), $user_id );
 		}
+		if ( ! empty( $grant_state ) ) {
+			$grant_state = ec_users_reconcile_pending_onboarding_grant( $user_id, $grant_state, $user_is_artist, $user_is_professional );
+			if ( is_wp_error( $grant_state ) ) {
+				return $grant_state;
+			}
+			if ( ! empty( $grant_state ) && 'pending' !== ( $grant_state['status'] ?? '' ) ) {
+				return new WP_Error(
+					'onboarding_grant_repair_required',
+					__( 'The onboarding access grant requires manual reconciliation.', 'extrachill-users' ),
+					array(
+						'status'         => 500,
+						'classification' => 'manual_repair',
+						'retryable'      => false,
+					)
+				);
+			}
+		}
 
 		// Update username in database.
 		global $wpdb;
@@ -486,16 +579,6 @@ function extrachill_users_ability_complete_onboarding( $input ) {
 				);
 			}
 			$new_grant_state = true;
-		} elseif ( ! empty( $grant_state ) && 'pending' !== ( $grant_state['status'] ?? '' ) && 'delivered' !== ( $grant_state['status'] ?? '' ) ) {
-			return new WP_Error(
-				'onboarding_grant_repair_required',
-				__( 'The onboarding access grant requires manual reconciliation.', 'extrachill-users' ),
-				array(
-					'status'         => 500,
-					'classification' => 'manual_repair',
-					'retryable'      => false,
-				)
-			);
 		}
 
 		// Persist access and completion as one verified transition. Restoring these

--- a/inc/onboarding/analytics.php
+++ b/inc/onboarding/analytics.php
@@ -32,6 +32,49 @@ function ec_users_emit_onboarding_event( string $event_type, int $user_id, array
 }
 
 /**
+ * Emit the canonical onboarding-origin artist access transition.
+ *
+ * The payload is entirely server-owned and restricted to the Analytics-owned
+ * contract. User input and registration attribution are deliberately excluded.
+ *
+ * @param int  $user_id             User receiving access.
+ * @param bool $is_artist           Whether artist access was granted.
+ * @param bool $is_professional     Whether professional access was granted.
+ * @return int Event ID, or zero when analytics is unavailable.
+ */
+function ec_users_emit_onboarding_artist_access_granted( int $user_id, bool $is_artist, bool $is_professional ): int {
+	if ( $is_artist && $is_professional ) {
+		$method = 'artist_and_professional';
+	} elseif ( $is_artist ) {
+		$method = 'artist';
+	} else {
+		$method = 'professional';
+	}
+
+	if ( ! in_array( $method, EC_ANALYTICS_ARTIST_ACCESS_GRANTED_METHODS, true ) ) {
+		return 0;
+	}
+
+	$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/track-analytics-event' ) : null;
+	if ( ! $ability ) {
+		return 0;
+	}
+
+	$result = $ability->execute(
+		array(
+			'event_type' => EC_ANALYTICS_EVENT_ARTIST_ACCESS_GRANTED,
+			'event_data' => array(
+				'user_id' => $user_id,
+				'source'  => EC_ANALYTICS_ARTIST_ACCESS_GRANTED_SOURCE_ONBOARDING,
+				'method'  => $method,
+			),
+		)
+	);
+
+	return is_int( $result ) ? $result : 0;
+}
+
+/**
  * Emit one viewed event when a dynamic block renders more than once per request.
  *
  * @param int $user_id User ID.

--- a/inc/onboarding/analytics.php
+++ b/inc/onboarding/analytics.php
@@ -32,6 +32,20 @@ function ec_users_emit_onboarding_event( string $event_type, int $user_id, array
 }
 
 /**
+ * Resolve the bounded access method for an onboarding grant.
+ *
+ * @param bool $is_artist       Whether artist access was granted.
+ * @param bool $is_professional Whether professional access was granted.
+ * @return string Canonical grant method.
+ */
+function ec_users_get_onboarding_artist_grant_method( bool $is_artist, bool $is_professional ): string {
+	if ( $is_artist && $is_professional ) {
+		return 'artist_and_professional';
+	}
+	return $is_artist ? 'artist' : 'professional';
+}
+
+/**
  * Emit the canonical onboarding-origin artist access transition.
  *
  * The payload is entirely server-owned and restricted to the Analytics-owned
@@ -43,13 +57,7 @@ function ec_users_emit_onboarding_event( string $event_type, int $user_id, array
  * @return int Event ID, or zero when analytics is unavailable.
  */
 function ec_users_emit_onboarding_artist_access_granted( int $user_id, bool $is_artist, bool $is_professional ): int {
-	if ( $is_artist && $is_professional ) {
-		$method = 'artist_and_professional';
-	} elseif ( $is_artist ) {
-		$method = 'artist';
-	} else {
-		$method = 'professional';
-	}
+	$method = ec_users_get_onboarding_artist_grant_method( $is_artist, $is_professional );
 
 	if ( ! in_array( $method, EC_ANALYTICS_ARTIST_ACCESS_GRANTED_METHODS, true ) ) {
 		return 0;

--- a/tests/unit/OnboardingArtistAccessGrantTest.php
+++ b/tests/unit/OnboardingArtistAccessGrantTest.php
@@ -22,7 +22,24 @@ class Test_Onboarding_Artist_Access_Grant extends WP_UnitTestCase {
 	 */
 	protected function setUp(): void {
 		parent::setUp();
+		$constants = array(
+			'EC_ANALYTICS_EVENT_ARTIST_ACCESS_GRANTED' => 'artist_access_granted',
+			'EC_ANALYTICS_ARTIST_ACCESS_GRANTED_SOURCE_ONBOARDING' => 'onboarding',
+			'EC_ANALYTICS_EVENT_ONBOARDING_COMPLETED'  => 'onboarding_completed',
+			'EC_ANALYTICS_EVENT_ONBOARDING_REMINDER_RECOVERED' => 'onboarding_reminder_recovered',
+			'EC_ANALYTICS_EVENT_ONBOARDING_SUBMISSION_FAILED' => 'onboarding_submission_failed',
+		);
+		foreach ( $constants as $constant => $value ) {
+			if ( ! defined( $constant ) ) {
+				define( $constant, $value );
+			}
+		}
+		if ( ! defined( 'EC_ANALYTICS_ARTIST_ACCESS_GRANTED_METHODS' ) ) {
+			define( 'EC_ANALYTICS_ARTIST_ACCESS_GRANTED_METHODS', array( 'artist', 'professional', 'artist_and_professional' ) );
+		}
 		$GLOBALS['ec_onboarding_grant_events'] = array();
+		$locks                                 = &ec_users_onboarding_lock_registry();
+		$locks                                 = array();
 
 		if ( ! wp_has_ability( 'extrachill/track-analytics-event' ) ) {
 			wp_register_ability(
@@ -48,6 +65,8 @@ class Test_Onboarding_Artist_Access_Grant extends WP_UnitTestCase {
 	 * Remove analytics fixtures.
 	 */
 	protected function tearDown(): void {
+		$locks = &ec_users_onboarding_lock_registry();
+		$locks = array();
 		if ( $this->registered_fake_analytics ) {
 			wp_unregister_ability( 'extrachill/track-analytics-event' );
 		}
@@ -92,6 +111,55 @@ class Test_Onboarding_Artist_Access_Grant extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A same-request contender cannot reenter an owned transition lock.
+	 */
+	public function test_transition_lock_rejects_reentrant_owner(): void {
+		$user_id = $this->create_onboarding_user( 'grantlock' );
+		$lock    = ec_users_acquire_onboarding_lock( $user_id );
+		$this->assertNotWPError( $lock );
+
+		try {
+			$contender = ec_users_acquire_onboarding_lock( $user_id );
+		} finally {
+			ec_users_release_onboarding_lock( $user_id, $lock );
+		}
+
+		$this->assertWPError( $contender );
+		$this->assertSame( 'onboarding_transition_locked', $contender->get_error_code() );
+		$this->assertSame( 'retry', $contender->get_error_data()['classification'] );
+		$this->assertTrue( $contender->get_error_data()['retryable'] );
+	}
+
+	/**
+	 * A reentrant completion loses the lock race and only the owner emits.
+	 */
+	public function test_reentrant_completion_has_one_transition_winner(): void {
+		$user_id           = $this->create_onboarding_user( 'grantreentrant' );
+		$inside_transition = false;
+		$reentrant_result  = null;
+		$reenter           = function ( $check, $object_id, $meta_key ) use ( $user_id, &$inside_transition, &$reentrant_result ) {
+			if ( $user_id === (int) $object_id && 'user_is_artist' === $meta_key && ! $inside_transition ) {
+				$inside_transition = true;
+				$reentrant_result  = $this->complete( $user_id, true, false );
+			}
+			return $check;
+		};
+		add_filter( 'add_user_metadata', $reenter, 10, 3 );
+
+		try {
+			$result = $this->complete( $user_id, true, false );
+		} finally {
+			remove_filter( 'add_user_metadata', $reenter, 10 );
+		}
+
+		$this->assertNotWPError( $result );
+		$this->assertWPError( $reentrant_result );
+		$this->assertSame( 'onboarding_transition_locked', $reentrant_result->get_error_code() );
+		$this->assertCount( 1, $this->grant_events() );
+		$this->assertSame( 'delivered', get_user_meta( $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META, true )['status'] );
+	}
+
+	/**
 	 * Existing access, including a partial prior attempt, is not a conversion.
 	 */
 	public function test_already_granted_user_does_not_emit(): void {
@@ -126,9 +194,54 @@ class Test_Onboarding_Artist_Access_Grant extends WP_UnitTestCase {
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'onboarding_state_update_failed', $result->get_error_code() );
+		$this->assertSame( 'retry', $result->get_error_data()['classification'] );
+		$this->assertTrue( $result->get_error_data()['retryable'] );
 		$this->assertSame( '0', get_user_meta( $user_id, 'onboarding_completed', true ) );
 		$this->assertFalse( metadata_exists( 'user', $user_id, 'user_is_artist' ) );
 		$this->assertFalse( metadata_exists( 'user', $user_id, 'user_is_professional' ) );
+		$this->assertFalse( metadata_exists( 'user', $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META ) );
+		$this->assertCount( 0, $this->grant_events() );
+	}
+
+	/**
+	 * A failed rollback is classified for repair and cannot lose conversion.
+	 */
+	public function test_failed_rollback_requires_repair_and_blocks_silent_retry(): void {
+		$user_id          = $this->create_onboarding_user( 'grantrollbackfailure' );
+		$block_completion = static function ( $check, $object_id, $meta_key, $meta_value ) use ( $user_id ) {
+			if ( $user_id === (int) $object_id && 'onboarding_completed' === $meta_key && '1' === $meta_value ) {
+				return false;
+			}
+			return $check;
+		};
+		$block_rollback   = static function ( $check, $object_id, $meta_key ) use ( $user_id ) {
+			if ( $user_id === (int) $object_id && 'user_is_artist' === $meta_key ) {
+				return false;
+			}
+			return $check;
+		};
+		add_filter( 'update_user_metadata', $block_completion, 10, 4 );
+		add_filter( 'delete_user_metadata', $block_rollback, 10, 3 );
+
+		try {
+			$result = $this->complete( $user_id, true, false );
+		} finally {
+			remove_filter( 'update_user_metadata', $block_completion, 10 );
+			remove_filter( 'delete_user_metadata', $block_rollback, 10 );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'onboarding_state_rollback_failed', $result->get_error_code() );
+		$this->assertSame( 'manual_repair', $result->get_error_data()['classification'] );
+		$this->assertFalse( $result->get_error_data()['retryable'] );
+		$this->assertSame( '1', get_user_meta( $user_id, 'user_is_artist', true ) );
+		$this->assertSame( 'repair_required', get_user_meta( $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META, true )['status'] );
+		$this->assertCount( 0, $this->grant_events() );
+
+		$retry = $this->complete( $user_id, true, false );
+		$this->assertWPError( $retry );
+		$this->assertSame( 'onboarding_grant_repair_required', $retry->get_error_code() );
+		$this->assertSame( 'manual_repair', $retry->get_error_data()['classification'] );
 		$this->assertCount( 0, $this->grant_events() );
 	}
 

--- a/tests/unit/OnboardingArtistAccessGrantTest.php
+++ b/tests/unit/OnboardingArtistAccessGrantTest.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Onboarding-origin artist access analytics tests.
+ *
+ * @package ExtraChill\Users
+ */
+
+/**
+ * Verify grants are emitted once for a completed access transition.
+ */
+class Test_Onboarding_Artist_Access_Grant extends WP_UnitTestCase {
+
+	/**
+	 * Whether this test registered the analytics fixture.
+	 *
+	 * @var bool
+	 */
+	private $registered_fake_analytics = false;
+
+	/**
+	 * Install a bounded analytics capture ability.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['ec_onboarding_grant_events'] = array();
+
+		if ( ! wp_has_ability( 'extrachill/track-analytics-event' ) ) {
+			wp_register_ability(
+				'extrachill/track-analytics-event',
+				array(
+					'label'               => 'Test analytics',
+					'description'         => 'Captures onboarding grant events.',
+					'category'            => 'extrachill-users',
+					'input_schema'        => array( 'type' => 'object' ),
+					'output_schema'       => array( 'type' => 'integer' ),
+					'permission_callback' => '__return_true',
+					'execute_callback'    => static function ( $input ) {
+						$GLOBALS['ec_onboarding_grant_events'][] = $input;
+						return count( $GLOBALS['ec_onboarding_grant_events'] );
+					},
+				)
+			);
+			$this->registered_fake_analytics = true;
+		}
+	}
+
+	/**
+	 * Remove analytics fixtures.
+	 */
+	protected function tearDown(): void {
+		if ( $this->registered_fake_analytics ) {
+			wp_unregister_ability( 'extrachill/track-analytics-event' );
+		}
+		unset( $GLOBALS['ec_onboarding_grant_events'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * A real transition emits one exact privacy-safe payload.
+	 */
+	public function test_transition_emits_exact_bounded_payload(): void {
+		$user_id = $this->create_onboarding_user( 'granttransition' );
+
+		$result = $this->complete( $user_id, true, true );
+		$events = $this->grant_events();
+
+		$this->assertNotWPError( $result );
+		$this->assertCount( 1, $events );
+		$this->assertSame(
+			array(
+				'user_id' => $user_id,
+				'source'  => 'onboarding',
+				'method'  => 'artist_and_professional',
+			),
+			$events[0]['event_data']
+		);
+		$this->assertSame( array( 'user_id', 'source', 'method' ), array_keys( $events[0]['event_data'] ) );
+	}
+
+	/**
+	 * Replaying a completed request cannot duplicate conversion.
+	 */
+	public function test_completed_replay_does_not_duplicate_grant(): void {
+		$user_id = $this->create_onboarding_user( 'grantreplay' );
+
+		$this->complete( $user_id, true, false );
+		$replay = $this->complete( $user_id, true, false );
+
+		$this->assertWPError( $replay );
+		$this->assertSame( 'already_completed', $replay->get_error_code() );
+		$this->assertCount( 1, $this->grant_events() );
+	}
+
+	/**
+	 * Existing access, including a partial prior attempt, is not a conversion.
+	 */
+	public function test_already_granted_user_does_not_emit(): void {
+		$user_id = $this->create_onboarding_user( 'alreadygranted' );
+		update_user_meta( $user_id, 'user_is_artist', '1' );
+
+		$result = $this->complete( $user_id, false, true );
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( '1', get_user_meta( $user_id, 'user_is_professional', true ) );
+		$this->assertCount( 0, $this->grant_events() );
+	}
+
+	/**
+	 * A failed completion restores access state and emits no conversion.
+	 */
+	public function test_failed_completion_rolls_back_access_and_does_not_emit(): void {
+		$user_id = $this->create_onboarding_user( 'grantrollback' );
+		$block   = static function ( $check, $object_id, $meta_key, $meta_value ) use ( $user_id ) {
+			if ( $user_id === (int) $object_id && 'onboarding_completed' === $meta_key && '1' === $meta_value ) {
+				return false;
+			}
+			return $check;
+		};
+		add_filter( 'update_user_metadata', $block, 10, 4 );
+
+		try {
+			$result = $this->complete( $user_id, true, false );
+		} finally {
+			remove_filter( 'update_user_metadata', $block, 10 );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'onboarding_state_update_failed', $result->get_error_code() );
+		$this->assertSame( '0', get_user_meta( $user_id, 'onboarding_completed', true ) );
+		$this->assertFalse( metadata_exists( 'user', $user_id, 'user_is_artist' ) );
+		$this->assertFalse( metadata_exists( 'user', $user_id, 'user_is_professional' ) );
+		$this->assertCount( 0, $this->grant_events() );
+	}
+
+	/**
+	 * Create an incomplete user fixture.
+	 *
+	 * @param string $login User login.
+	 * @return int User ID.
+	 */
+	private function create_onboarding_user( $login ) {
+		$user_id = self::factory()->user->create(
+			array(
+				'user_login' => $login,
+				'user_email' => $login . '@example.com',
+			)
+		);
+		update_user_meta( $user_id, 'onboarding_completed', '0' );
+		return $user_id;
+	}
+
+	/**
+	 * Complete onboarding for a fixture.
+	 *
+	 * @param int  $user_id         User ID.
+	 * @param bool $artist         Artist choice.
+	 * @param bool $professional   Professional choice.
+	 * @return array|WP_Error Result.
+	 */
+	private function complete( $user_id, $artist, $professional ) {
+		return extrachill_users_ability_complete_onboarding(
+			array(
+				'user_id'              => $user_id,
+				'username'             => get_userdata( $user_id )->user_login,
+				'user_is_artist'       => $artist,
+				'user_is_professional' => $professional,
+			)
+		);
+	}
+
+	/**
+	 * Return only canonical grant events from all onboarding analytics.
+	 *
+	 * @return array[] Grant events.
+	 */
+	private function grant_events() {
+		return array_values(
+			array_filter(
+				$GLOBALS['ec_onboarding_grant_events'],
+				static function ( $event ) {
+					return EC_ANALYTICS_EVENT_ARTIST_ACCESS_GRANTED === $event['event_type'];
+				}
+			)
+		);
+	}
+}

--- a/tests/unit/OnboardingArtistAccessGrantTest.php
+++ b/tests/unit/OnboardingArtistAccessGrantTest.php
@@ -37,9 +37,10 @@ class Test_Onboarding_Artist_Access_Grant extends WP_UnitTestCase {
 		if ( ! defined( 'EC_ANALYTICS_ARTIST_ACCESS_GRANTED_METHODS' ) ) {
 			define( 'EC_ANALYTICS_ARTIST_ACCESS_GRANTED_METHODS', array( 'artist', 'professional', 'artist_and_professional' ) );
 		}
-		$GLOBALS['ec_onboarding_grant_events'] = array();
-		$locks                                 = &ec_users_onboarding_lock_registry();
-		$locks                                 = array();
+		$GLOBALS['ec_onboarding_grant_events']  = array();
+		$GLOBALS['ec_onboarding_grant_failure'] = false;
+		$locks                                  = &ec_users_onboarding_lock_registry();
+		$locks                                  = array();
 
 		if ( ! wp_has_ability( 'extrachill/track-analytics-event' ) ) {
 			wp_register_ability(
@@ -52,6 +53,9 @@ class Test_Onboarding_Artist_Access_Grant extends WP_UnitTestCase {
 					'output_schema'       => array( 'type' => 'integer' ),
 					'permission_callback' => '__return_true',
 					'execute_callback'    => static function ( $input ) {
+						if ( ! empty( $GLOBALS['ec_onboarding_grant_failure'] ) && EC_ANALYTICS_EVENT_ARTIST_ACCESS_GRANTED === $input['event_type'] ) {
+							return 0;
+						}
 						$GLOBALS['ec_onboarding_grant_events'][] = $input;
 						return count( $GLOBALS['ec_onboarding_grant_events'] );
 					},
@@ -70,7 +74,7 @@ class Test_Onboarding_Artist_Access_Grant extends WP_UnitTestCase {
 		if ( $this->registered_fake_analytics ) {
 			wp_unregister_ability( 'extrachill/track-analytics-event' );
 		}
-		unset( $GLOBALS['ec_onboarding_grant_events'] );
+		unset( $GLOBALS['ec_onboarding_grant_events'], $GLOBALS['ec_onboarding_grant_failure'] );
 		parent::tearDown();
 	}
 
@@ -107,6 +111,66 @@ class Test_Onboarding_Artist_Access_Grant extends WP_UnitTestCase {
 
 		$this->assertWPError( $replay );
 		$this->assertSame( 'already_completed', $replay->get_error_code() );
+		$this->assertCount( 1, $this->grant_events() );
+	}
+
+	/**
+	 * A confirmed delivery failure returns to pending and succeeds once on retry.
+	 */
+	public function test_pending_receipt_recovers_delivery_once_on_retry(): void {
+		$user_id = $this->create_onboarding_user( 'grantdeliveryretry' );
+
+		$GLOBALS['ec_onboarding_grant_failure'] = true;
+		$failed                                 = $this->complete( $user_id, true, false );
+
+		$GLOBALS['ec_onboarding_grant_failure'] = false;
+
+		$this->assertWPError( $failed );
+		$this->assertSame( 'onboarding_grant_delivery_failed', $failed->get_error_code() );
+		$this->assertSame( 'retry', $failed->get_error_data()['classification'] );
+		$this->assertSame( 'pending', get_user_meta( $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META, true )['status'] );
+		$this->assertCount( 0, $this->grant_events() );
+
+		$retry = $this->complete( $user_id, true, false );
+		$this->assertWPError( $retry );
+		$this->assertSame( 'already_completed', $retry->get_error_code() );
+		$this->assertSame( 'delivered', get_user_meta( $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META, true )['status'] );
+		$this->assertCount( 1, $this->grant_events() );
+	}
+
+	/**
+	 * An ambiguous post-delivery receipt remains reserved and never re-emits.
+	 */
+	public function test_reserved_receipt_requires_repair_without_duplicate_delivery(): void {
+		$user_id       = $this->create_onboarding_user( 'grantreserved' );
+		$block_receipt = static function ( $check, $object_id, $meta_key, $meta_value ) use ( $user_id ) {
+			if (
+				$user_id === (int) $object_id
+				&& EC_USERS_ONBOARDING_ARTIST_GRANT_META === $meta_key
+				&& is_array( $meta_value )
+				&& 'delivered' === ( $meta_value['status'] ?? '' )
+			) {
+				return false;
+			}
+			return $check;
+		};
+		add_filter( 'update_user_metadata', $block_receipt, 10, 4 );
+
+		try {
+			$result = $this->complete( $user_id, true, false );
+		} finally {
+			remove_filter( 'update_user_metadata', $block_receipt, 10 );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'onboarding_grant_repair_required', $result->get_error_code() );
+		$this->assertSame( 'manual_repair', $result->get_error_data()['classification'] );
+		$this->assertSame( 'reserved', get_user_meta( $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META, true )['status'] );
+		$this->assertCount( 1, $this->grant_events() );
+
+		$retry = $this->complete( $user_id, true, false );
+		$this->assertWPError( $retry );
+		$this->assertSame( 'onboarding_grant_repair_required', $retry->get_error_code() );
 		$this->assertCount( 1, $this->grant_events() );
 	}
 

--- a/tests/unit/OnboardingArtistAccessGrantTest.php
+++ b/tests/unit/OnboardingArtistAccessGrantTest.php
@@ -175,6 +175,129 @@ class Test_Onboarding_Artist_Access_Grant extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An interrupted pre-persistence receipt adopts the current retry intent.
+	 *
+	 * @dataProvider changed_incomplete_intent_provider
+	 *
+	 * @param string $initial_method Initial stale method.
+	 * @param bool   $artist         Retry artist intent.
+	 * @param bool   $professional   Retry professional intent.
+	 * @param string $expected       Expected emitted method, or empty for none.
+	 */
+	public function test_incomplete_pending_receipt_uses_current_retry_intent( $initial_method, $artist, $professional, $expected ): void {
+		$user_id = $this->create_onboarding_user( 'grantintent' . str_replace( '_', '', $initial_method ) . $expected );
+		update_user_meta(
+			$user_id,
+			EC_USERS_ONBOARDING_ARTIST_GRANT_META,
+			array(
+				'status'     => 'pending',
+				'method'     => $initial_method,
+				'created_at' => time(),
+			)
+		);
+
+		$result = $this->complete( $user_id, $artist, $professional );
+		$events = $this->grant_events();
+
+		$this->assertNotWPError( $result );
+		if ( '' === $expected ) {
+			$this->assertCount( 0, $events );
+			$this->assertFalse( metadata_exists( 'user', $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META ) );
+			return;
+		}
+		$this->assertCount( 1, $events );
+		$this->assertSame( $expected, $events[0]['event_data']['method'] );
+		$this->assertSame( 'delivered', get_user_meta( $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META, true )['status'] );
+	}
+
+	/**
+	 * Changed incomplete intent cases.
+	 *
+	 * @return array<string,array{string,bool,bool,string}>
+	 */
+	public function changed_incomplete_intent_provider() {
+		return array(
+			'professional to artist' => array( 'professional', true, false, 'artist' ),
+			'artist to professional' => array( 'artist', false, true, 'professional' ),
+			'artist to both'         => array( 'artist', true, true, 'artist_and_professional' ),
+			'both to neither'        => array( 'artist_and_professional', false, false, '' ),
+		);
+	}
+
+	/**
+	 * Persisted partial access plus changed intent requires reconciliation.
+	 */
+	public function test_incomplete_pending_receipt_rejects_changed_persisted_access(): void {
+		$user_id = $this->create_onboarding_user( 'grantintentambiguous' );
+		update_user_meta( $user_id, 'user_is_artist', '1' );
+		update_user_meta(
+			$user_id,
+			EC_USERS_ONBOARDING_ARTIST_GRANT_META,
+			array(
+				'status'     => 'pending',
+				'method'     => 'artist',
+				'created_at' => time(),
+			)
+		);
+
+		$result = $this->complete( $user_id, false, true );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'onboarding_grant_intent_repair_required', $result->get_error_code() );
+		$this->assertSame( 'manual_repair', $result->get_error_data()['classification'] );
+		$this->assertFalse( $result->get_error_data()['retryable'] );
+		$this->assertSame( 'pending', get_user_meta( $user_id, EC_USERS_ONBOARDING_ARTIST_GRANT_META, true )['status'] );
+		$this->assertCount( 0, $this->grant_events() );
+	}
+
+	/**
+	 * A completed pending receipt emits the method that actually persisted.
+	 *
+	 * @dataProvider changed_completed_intent_provider
+	 *
+	 * @param string $actual_method Actual persisted grant method.
+	 * @param bool   $artist        Retry artist intent.
+	 * @param bool   $professional  Retry professional intent.
+	 */
+	public function test_completed_pending_receipt_preserves_actual_transition( $actual_method, $artist, $professional ): void {
+		$user_id = $this->create_onboarding_user( 'grantactual' . str_replace( '_', '', $actual_method ) );
+		update_user_meta( $user_id, 'user_is_artist', in_array( $actual_method, array( 'artist', 'artist_and_professional' ), true ) ? '1' : '0' );
+		update_user_meta( $user_id, 'user_is_professional', in_array( $actual_method, array( 'professional', 'artist_and_professional' ), true ) ? '1' : '0' );
+		update_user_meta( $user_id, 'onboarding_completed', '1' );
+		update_user_meta(
+			$user_id,
+			EC_USERS_ONBOARDING_ARTIST_GRANT_META,
+			array(
+				'status'     => 'pending',
+				'method'     => $actual_method,
+				'created_at' => time(),
+			)
+		);
+
+		$result = $this->complete( $user_id, $artist, $professional );
+		$events = $this->grant_events();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'already_completed', $result->get_error_code() );
+		$this->assertCount( 1, $events );
+		$this->assertSame( $actual_method, $events[0]['event_data']['method'] );
+	}
+
+	/**
+	 * Changed post-persistence intent cases.
+	 *
+	 * @return array<string,array{string,bool,bool}>
+	 */
+	public function changed_completed_intent_provider() {
+		return array(
+			'artist then professional' => array( 'artist', false, true ),
+			'professional then artist' => array( 'professional', true, false ),
+			'both then artist'         => array( 'artist_and_professional', true, false ),
+			'artist then neither'      => array( 'artist', false, false ),
+		);
+	}
+
+	/**
 	 * A same-request contender cannot reenter an owned transition lock.
 	 */
 	public function test_transition_lock_rejects_reentrant_owner(): void {


### PR DESCRIPTION
## Summary
- emit the Analytics-owned `artist_access_granted` event only when onboarding transitions a user from no access to artist/professional access
- serialize each user's transition with a request-local reentrancy guard plus the repository's existing MySQL advisory-lock pattern
- reserve one CAS-backed `pending → reserved → delivered` receipt so concurrent workers and retries cannot duplicate or silently lose conversion
- reconcile incomplete pending receipts against current bounded intent before persistence: replace stale method for artist/professional/both, remove it for neither, and fail closed when partially persisted access makes changed intent ambiguous
- verify every access/completion rollback write and return explicit `retry` or `manual_repair` classifications when persistence cannot be restored truthfully
- preserve the explicit request and manual approval lifecycle unchanged

## Exactly-Once Semantics
- incomplete `pending` with no access: current retry intent replaces stale intent, or clears the receipt for neither
- incomplete `pending` with partially persisted access: changed intent is `manual_repair`; the transition is never relabeled
- completed `pending`: the stored method describes the transition that actually persisted and remains authoritative for delayed delivery
- `reserved`: delivery may have occurred; retries fail closed as `manual_repair` and never emit again
- `delivered`: durable success receipt; replays do not emit
- rollback failure records `repair_required`, preventing already-granted state from silently suppressing the pending conversion

## Testing
- scoped PHPCS passed on all changed files
- PHP syntax and `git diff --check` passed on all changed files
- WordPress coverage includes transition, replay, lock contention, reentrancy, clean/failed rollback, receipt recovery, ambiguous delivery, and changed retries across artist-only, professional-only, both, and neither before completion and before delivery
- focused Homeboy run selected only `OnboardingArtistAccessGrantTest.php`, but Codebox failed before WordPress or tests loaded in `wp-phpunit/includes/install.php:108` because the rewrite object was null (run `37b71b33-9d5c-45a9-af15-61b4965df8db`)
- full PHPCS was previously attempted; existing repository-wide baseline violations remain outside this change

## Dependency / Merge Order
- Extra-Chill/extrachill-analytics#217 is merged, so the canonical event constants required by this PR are on `main`.
- No cross-repository merge remains ahead of this PR.

Fixes #233
Related: Extra-Chill/extrachill-artist-platform#72