### PR TITLE
fix: clear unclaimed state after password claim

### DIFF
--- a/inc/auth/password-reset.php
+++ b/inc/auth/password-reset.php
@@ -258,6 +258,39 @@ add_action( 'admin_post_nopriv_ec_password_reset_request', 'ec_handle_password_r
 add_action( 'admin_post_ec_password_reset_request', 'ec_handle_password_reset_request' );
 
 /**
+ * Validate and complete a custom password reset submission.
+ *
+ * This is the non-redirecting seam used by the admin-post handler. Successful
+ * submissions delegate to reset_password(), which owns both the core password
+ * write and the after_password_reset completion action.
+ *
+ * @param string $key   Password reset key.
+ * @param string $login User login.
+ * @param string $pass1 New password.
+ * @param string $pass2 Password confirmation.
+ * @return WP_User|WP_Error Reset user on success, error otherwise.
+ */
+function ec_process_reset_password_submission( $key, $login, $pass1, $pass2 ) {
+	if ( $pass1 !== $pass2 ) {
+		return new WP_Error( 'password_mismatch', __( 'Passwords do not match.', 'extrachill-users' ) );
+	}
+
+	if ( strlen( $pass1 ) < 8 ) {
+		return new WP_Error( 'password_too_short', __( 'Password must be at least 8 characters.', 'extrachill-users' ) );
+	}
+
+	$user = check_password_reset_key( $key, $login );
+
+	if ( is_wp_error( $user ) ) {
+		return new WP_Error( 'invalid_reset_key', __( 'Invalid or expired reset link. Please request a new one.', 'extrachill-users' ) );
+	}
+
+	reset_password( $user, $pass1 );
+
+	return $user;
+}
+
+/**
  * Handle password reset form submission (setting new password).
  */
 function ec_handle_reset_password() {
@@ -272,35 +305,20 @@ function ec_handle_reset_password() {
 	$pass2 = isset( $_POST['pass2'] ) ? wp_unslash( $_POST['pass2'] ) : '';
 	// phpcs:enable WordPress.Security.NonceVerification.Missing
 
-	if ( $pass1 !== $pass2 ) {
-		$redirect->error(
-			__( 'Passwords do not match.', 'extrachill-users' ),
-			array(
-				'action' => 'reset',
-				'key'    => $key,
-				'login'  => $login,
-			)
-		);
-	}
-
-	if ( strlen( $pass1 ) < 8 ) {
-		$redirect->error(
-			__( 'Password must be at least 8 characters.', 'extrachill-users' ),
-			array(
-				'action' => 'reset',
-				'key'    => $key,
-				'login'  => $login,
-			)
-		);
-	}
-
-	$user = check_password_reset_key( $key, $login );
+	$user = ec_process_reset_password_submission( $key, $login, $pass1, $pass2 );
 
 	if ( is_wp_error( $user ) ) {
-		$redirect->error( __( 'Invalid or expired reset link. Please request a new one.', 'extrachill-users' ) );
+		$query_args = array();
+		if ( in_array( $user->get_error_code(), array( 'password_mismatch', 'password_too_short' ), true ) ) {
+			$query_args = array(
+				'action' => 'reset',
+				'key'    => $key,
+				'login'  => $login,
+			);
+		}
+		$redirect->error( $user->get_error_message(), $query_args );
 	}
 
-	reset_password( $user, $pass1 );
 	wp_set_auth_cookie( $user->ID, true );
 
 	wp_safe_redirect( home_url() );

--- a/inc/auth/password-reset.php
+++ b/inc/auth/password-reset.php
@@ -117,12 +117,24 @@ add_filter( 'wp_new_user_notification_email', 'ec_filter_new_user_notification_e
  * password. This covers both the Extra Chill reset handler and core reset
  * flows without clearing the marker for invalid or failed attempts.
  *
- * @param WP_User $user User whose password was reset.
+ * @param WP_User $user     User whose password was reset.
+ * @param string  $new_pass New password supplied to WordPress.
+ * @return bool Whether the password and claimed state are both persisted.
  */
-function extrachill_users_clear_unclaimed_after_password_reset( $user ) {
+function extrachill_users_clear_unclaimed_after_password_reset( $user, $new_pass ) {
+	$persisted_user = get_userdata( $user->ID );
+	if ( ! $persisted_user || ! wp_check_password( $new_pass, $persisted_user->user_pass, $user->ID ) ) {
+		return false;
+	}
+
+	if ( ! metadata_exists( 'user', $user->ID, 'ec_unclaimed' ) ) {
+		return true;
+	}
+
 	delete_user_meta( $user->ID, 'ec_unclaimed' );
+	return ! metadata_exists( 'user', $user->ID, 'ec_unclaimed' );
 }
-add_action( 'after_password_reset', 'extrachill_users_clear_unclaimed_after_password_reset' );
+add_action( 'after_password_reset', 'extrachill_users_clear_unclaimed_after_password_reset', 10, 2 );
 
 /**
  * Get the transient key for password reset attempts.
@@ -286,8 +298,17 @@ function ec_process_reset_password_submission( $key, $login, $pass1, $pass2 ) {
 	}
 
 	reset_password( $user, $pass1 );
+	$persisted_user = get_userdata( $user->ID );
 
-	return $user;
+	if ( ! $persisted_user || ! wp_check_password( $pass1, $persisted_user->user_pass, $user->ID ) ) {
+		return new WP_Error( 'password_update_failed', __( 'Unable to update your password. Please request a new reset link and try again.', 'extrachill-users' ) );
+	}
+
+	if ( metadata_exists( 'user', $user->ID, 'ec_unclaimed' ) ) {
+		return new WP_Error( 'unclaimed_state_clear_failed', __( 'Your password was updated, but the account claim could not be completed. Please request a new reset link and try again.', 'extrachill-users' ) );
+	}
+
+	return $persisted_user;
 }
 
 /**

--- a/inc/auth/password-reset.php
+++ b/inc/auth/password-reset.php
@@ -111,6 +111,20 @@ function ec_filter_new_user_notification_email( $email, $user, $blogname ) {
 add_filter( 'wp_new_user_notification_email', 'ec_filter_new_user_notification_email', 10, 3 );
 
 /**
+ * Mark an unclaimed account as claimed after its password reset completes.
+ *
+ * WordPress fires this hook only after reset_password() has persisted the new
+ * password. This covers both the Extra Chill reset handler and core reset
+ * flows without clearing the marker for invalid or failed attempts.
+ *
+ * @param WP_User $user User whose password was reset.
+ */
+function extrachill_users_clear_unclaimed_after_password_reset( $user ) {
+	delete_user_meta( $user->ID, 'ec_unclaimed' );
+}
+add_action( 'after_password_reset', 'extrachill_users_clear_unclaimed_after_password_reset' );
+
+/**
  * Get the transient key for password reset attempts.
  *
  * Keyed on requester IP only (not on submitted user_login) so attackers

--- a/inc/core/abilities/create-user.php
+++ b/inc/core/abilities/create-user.php
@@ -143,19 +143,23 @@ function extrachill_users_sanitize_utm( $raw ) {
  * @return bool Whether the user no longer exists.
  */
 function extrachill_users_rollback_created_user( $user_id ) {
+	if ( ! get_userdata( $user_id ) ) {
+		return true;
+	}
+
 	if ( is_multisite() ) {
 		if ( ! function_exists( 'wpmu_delete_user' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/ms.php';
 		}
-		$deleted = wpmu_delete_user( $user_id );
+		wpmu_delete_user( $user_id );
 	} else {
 		if ( ! function_exists( 'wp_delete_user' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/user.php';
 		}
-		$deleted = wp_delete_user( $user_id );
+		wp_delete_user( $user_id );
 	}
 
-	return $deleted && ! get_userdata( $user_id );
+	return ! get_userdata( $user_id );
 }
 
 /**
@@ -224,8 +228,8 @@ function extrachill_users_ability_create_user( $input ) {
 				'Unable to store the unclaimed account state. The created account was rolled back.',
 				array(
 					'status'         => 500,
-					'classification' => 'retry',
-					'retryable'      => true,
+					'classification' => 'rolled_back',
+					'retryable'      => false,
 				)
 			);
 		}

--- a/inc/core/abilities/create-user.php
+++ b/inc/core/abilities/create-user.php
@@ -134,6 +134,31 @@ function extrachill_users_sanitize_utm( $raw ) {
 }
 
 /**
+ * Roll back a user created by the create-user ability.
+ *
+ * Multisite requires network deletion. Removing the user from only the
+ * Community site would leave the generated-password global account intact.
+ *
+ * @param int $user_id User ID to delete.
+ * @return bool Whether the user no longer exists.
+ */
+function extrachill_users_rollback_created_user( $user_id ) {
+	if ( is_multisite() ) {
+		if ( ! function_exists( 'wpmu_delete_user' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/ms.php';
+		}
+		$deleted = wpmu_delete_user( $user_id );
+	} else {
+		if ( ! function_exists( 'wp_delete_user' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/user.php';
+		}
+		$deleted = wp_delete_user( $user_id );
+	}
+
+	return $deleted && ! get_userdata( $user_id );
+}
+
+/**
  * Create a community user account.
  *
  * Switches to the community blog, creates the WordPress user, sets onboarding
@@ -171,6 +196,41 @@ function extrachill_users_ability_create_user( $input ) {
 
 	$user_id = wp_create_user( $username, $password, $email );
 
+	if ( ! is_wp_error( $user_id ) && $unclaimed ) {
+		update_user_meta( $user_id, 'ec_unclaimed', 1 );
+
+		if ( '1' !== (string) get_user_meta( $user_id, 'ec_unclaimed', true ) ) {
+			$rolled_back = extrachill_users_rollback_created_user( $user_id );
+
+			if ( $switched ) {
+				restore_current_blog();
+			}
+
+			if ( ! $rolled_back ) {
+				return new WP_Error(
+					'unclaimed_state_reconciliation_required',
+					'Unable to store the unclaimed account state or roll back the created account. Manual reconciliation is required.',
+					array(
+						'status'         => 500,
+						'classification' => 'manual_reconciliation',
+						'retryable'      => false,
+						'user_id'        => $user_id,
+					)
+				);
+			}
+
+			return new WP_Error(
+				'unclaimed_state_persistence_failed',
+				'Unable to store the unclaimed account state. The created account was rolled back.',
+				array(
+					'status'         => 500,
+					'classification' => 'retry',
+					'retryable'      => true,
+				)
+			);
+		}
+	}
+
 	if ( ! is_wp_error( $user_id ) ) {
 		if ( ! empty( $registration_page ) ) {
 			update_user_meta( $user_id, 'registration_page', esc_url_raw( (string) $registration_page ) );
@@ -192,14 +252,6 @@ function extrachill_users_ability_create_user( $input ) {
 		if ( ! empty( $role ) ) {
 			$user = new WP_User( $user_id );
 			$user->set_role( $role );
-		}
-
-		// Unclaimed flag: accounts created on a user's behalf (e.g. an anonymous
-		// event submitter) are subscriber-role and flagged ec_unclaimed=1 until
-		// the user sets their password via the claim link, so the account can't
-		// be logged into before the rightful owner claims it.
-		if ( $unclaimed ) {
-			update_user_meta( $user_id, 'ec_unclaimed', 1 );
 		}
 
 		// Source attribution (last-touch): persist the external referrer and any

--- a/tests/integration/UserCreationTest.php
+++ b/tests/integration/UserCreationTest.php
@@ -171,6 +171,116 @@ class Test_User_Creation extends WP_UnitTestCase {
 		$this->assertSame( 'existing_user_email', $result->get_error_code() );
 	}
 
+	public function test_create_unclaimed_user_verifies_persisted_marker(): void {
+		$user_id = $this->create_user(
+			array(
+				'username'  => 'unclaimeduser',
+				'email'     => 'unclaimed@example.com',
+				'unclaimed' => true,
+			)
+		);
+
+		$this->assertIsInt( $user_id );
+		$this->assertSame( '1', get_user_meta( $user_id, 'ec_unclaimed', true ) );
+	}
+
+	public function test_unclaimed_marker_failure_rolls_back_created_account(): void {
+		$created_user_id = 0;
+		$block_marker    = static function ( $check, $object_id, $meta_key ) use ( &$created_user_id ) {
+			if ( 'ec_unclaimed' === $meta_key ) {
+				$created_user_id = (int) $object_id;
+				return false;
+			}
+			return $check;
+		};
+		add_filter( 'update_user_metadata', $block_marker, 10, 3 );
+
+		try {
+			$result = $this->create_user(
+				array(
+					'username'  => 'rollbackuser',
+					'email'     => 'rollback@example.com',
+					'unclaimed' => true,
+				)
+			);
+		} finally {
+			remove_filter( 'update_user_metadata', $block_marker, 10 );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'unclaimed_state_persistence_failed', $result->get_error_code() );
+		$this->assertSame( 'retry', $result->get_error_data()['classification'] );
+		$this->assertTrue( $result->get_error_data()['retryable'] );
+		$this->assertGreaterThan( 0, $created_user_id );
+		$this->assertFalse( get_userdata( $created_user_id ) );
+		$this->assertFalse( username_exists( 'rollbackuser' ) );
+	}
+
+	public function test_unclaimed_marker_and_rollback_failure_requires_reconciliation(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Rollback failure coverage requires multisite network deletion.' );
+		}
+
+		$created_user_id = 0;
+		$block_marker    = static function ( $check, $object_id, $meta_key ) use ( &$created_user_id ) {
+			if ( 'ec_unclaimed' === $meta_key ) {
+				$created_user_id = (int) $object_id;
+				grant_super_admin( $created_user_id );
+				return false;
+			}
+			return $check;
+		};
+		add_filter( 'update_user_metadata', $block_marker, 10, 3 );
+
+		try {
+			$result = $this->create_user(
+				array(
+					'username'  => 'reconcileuser',
+					'email'     => 'reconcile@example.com',
+					'unclaimed' => true,
+				)
+			);
+		} finally {
+			remove_filter( 'update_user_metadata', $block_marker, 10 );
+		}
+
+		try {
+			$this->assertWPError( $result );
+			$this->assertSame( 'unclaimed_state_reconciliation_required', $result->get_error_code() );
+			$this->assertSame( 'manual_reconciliation', $result->get_error_data()['classification'] );
+			$this->assertFalse( $result->get_error_data()['retryable'] );
+			$this->assertSame( $created_user_id, $result->get_error_data()['user_id'] );
+			$this->assertInstanceOf( WP_User::class, get_userdata( $created_user_id ) );
+		} finally {
+			if ( $created_user_id ) {
+				revoke_super_admin( $created_user_id );
+				extrachill_users_rollback_created_user( $created_user_id );
+			}
+		}
+	}
+
+	public function test_existing_user_race_never_marks_or_deletes_existing_account(): void {
+		$existing_user_id = self::factory()->user->create(
+			array(
+				'user_login' => 'raceuser',
+				'user_email' => 'race@example.com',
+			)
+		);
+
+		$result = $this->create_user(
+			array(
+				'username'  => 'raceuser',
+				'email'     => 'raceretry@example.com',
+				'unclaimed' => true,
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'existing_user_login', $result->get_error_code() );
+		$this->assertSame( $existing_user_id, username_exists( 'raceuser' ) );
+		$this->assertFalse( metadata_exists( 'user', $existing_user_id, 'ec_unclaimed' ) );
+	}
+
 	public function test_create_user_fires_action(): void {
 		$this->create_user(
 			array(

--- a/tests/integration/UserCreationTest.php
+++ b/tests/integration/UserCreationTest.php
@@ -7,8 +7,11 @@ class Test_User_Creation extends WP_UnitTestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		if ( function_exists( 'extrachill_users_register_create_user_ability' ) ) {
-			extrachill_users_register_create_user_ability();
+		if ( ! wp_has_ability_category( 'extrachill-users' ) ) {
+			do_action( 'wp_abilities_api_categories_init' );
+		}
+		if ( ! wp_has_ability( 'extrachill/create-user' ) ) {
+			do_action( 'wp_abilities_api_init' );
 		}
 	}
 
@@ -209,11 +212,12 @@ class Test_User_Creation extends WP_UnitTestCase {
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'unclaimed_state_persistence_failed', $result->get_error_code() );
-		$this->assertSame( 'retry', $result->get_error_data()['classification'] );
-		$this->assertTrue( $result->get_error_data()['retryable'] );
+		$this->assertSame( 'rolled_back', $result->get_error_data()['classification'] );
+		$this->assertFalse( $result->get_error_data()['retryable'] );
 		$this->assertGreaterThan( 0, $created_user_id );
 		$this->assertFalse( get_userdata( $created_user_id ) );
 		$this->assertFalse( username_exists( 'rollbackuser' ) );
+		$this->assertTrue( extrachill_users_rollback_created_user( $created_user_id ) );
 	}
 
 	public function test_unclaimed_marker_and_rollback_failure_requires_reconciliation(): void {

--- a/tests/unit/PasswordClaimTest.php
+++ b/tests/unit/PasswordClaimTest.php
@@ -89,9 +89,44 @@ class Test_Password_Claim extends WP_UnitTestCase {
 		$this->assertSame( '', get_user_meta( $user->ID, 'ec_unclaimed', true ) );
 	}
 
+	public function test_completion_does_not_clear_marker_without_persisted_password(): void {
+		$user = $this->create_user();
+
+		$result = extrachill_users_clear_unclaimed_after_password_reset( $user, 'password-that-was-not-stored' );
+
+		$this->assertFalse( $result );
+		$this->assertSame( '1', get_user_meta( $user->ID, 'ec_unclaimed', true ) );
+	}
+
+	public function test_custom_claim_reports_marker_deletion_failure(): void {
+		$user = $this->create_user();
+		$key  = get_password_reset_key( $user );
+		$block_deletion = static function ( $check, $object_id, $meta_key ) use ( $user ) {
+			if ( $user->ID === (int) $object_id && 'ec_unclaimed' === $meta_key ) {
+				return false;
+			}
+			return $check;
+		};
+		add_filter( 'delete_user_metadata', $block_deletion, 10, 3 );
+
+		$this->assertNotWPError( $key );
+
+		try {
+			$result = ec_process_reset_password_submission( $key, $user->user_login, 'new-secure-password', 'new-secure-password' );
+		} finally {
+			remove_filter( 'delete_user_metadata', $block_deletion, 10 );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'unclaimed_state_clear_failed', $result->get_error_code() );
+		$this->assertSame( '1', get_user_meta( $user->ID, 'ec_unclaimed', true ) );
+		$this->assertTrue( wp_check_password( 'new-secure-password', get_userdata( $user->ID )->user_pass, $user->ID ) );
+	}
+
 	public function test_repeated_completion_hook_is_harmless(): void {
 		$user = $this->create_user();
 
+		reset_password( $user, 'new-secure-password' );
 		do_action( 'after_password_reset', $user, 'new-secure-password' );
 		do_action( 'after_password_reset', $user, 'new-secure-password' );
 

--- a/tests/unit/PasswordClaimTest.php
+++ b/tests/unit/PasswordClaimTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Unit tests for claiming accounts through password reset completion.
+ */
+
+class Test_Password_Claim extends WP_UnitTestCase {
+
+	private function create_user( bool $unclaimed = true ): WP_User {
+		$user_id = self::factory()->user->create();
+
+		if ( $unclaimed ) {
+			update_user_meta( $user_id, 'ec_unclaimed', 1 );
+		}
+
+		return get_user_by( 'ID', $user_id );
+	}
+
+	public function test_successful_password_claim_clears_unclaimed_marker(): void {
+		$user = $this->create_user();
+		$key  = get_password_reset_key( $user );
+
+		$this->assertNotWPError( $key );
+
+		$verified_user = check_password_reset_key( $key, $user->user_login );
+		$this->assertNotWPError( $verified_user );
+
+		reset_password( $verified_user, 'new-secure-password' );
+
+		$this->assertSame( '', get_user_meta( $user->ID, 'ec_unclaimed', true ) );
+		$this->assertTrue( wp_check_password( 'new-secure-password', get_userdata( $user->ID )->user_pass, $user->ID ) );
+	}
+
+	public function test_invalid_or_expired_key_does_not_clear_unclaimed_marker(): void {
+		$user = $this->create_user();
+		$key  = get_password_reset_key( $user );
+
+		$this->assertNotWPError( $key );
+		wp_set_password( 'replacement-password', $user->ID );
+
+		$this->assertWPError( check_password_reset_key( $key, $user->user_login ) );
+		$this->assertSame( '1', get_user_meta( $user->ID, 'ec_unclaimed', true ) );
+	}
+
+	public function test_failure_before_password_reset_does_not_clear_unclaimed_marker(): void {
+		$user = $this->create_user();
+
+		do_action( 'password_reset', $user, 'new-secure-password' );
+
+		$this->assertSame( '1', get_user_meta( $user->ID, 'ec_unclaimed', true ) );
+	}
+
+	public function test_repeated_completion_hook_is_harmless(): void {
+		$user = $this->create_user();
+
+		do_action( 'after_password_reset', $user, 'new-secure-password' );
+		do_action( 'after_password_reset', $user, 'new-secure-password' );
+
+		$this->assertSame( '', get_user_meta( $user->ID, 'ec_unclaimed', true ) );
+	}
+
+	public function test_password_reset_for_already_claimed_account_is_harmless(): void {
+		$user = $this->create_user( false );
+
+		reset_password( $user, 'new-secure-password' );
+
+		$this->assertSame( '', get_user_meta( $user->ID, 'ec_unclaimed', true ) );
+		$this->assertTrue( wp_check_password( 'new-secure-password', get_userdata( $user->ID )->user_pass, $user->ID ) );
+	}
+}

--- a/tests/unit/PasswordClaimTest.php
+++ b/tests/unit/PasswordClaimTest.php
@@ -6,7 +6,7 @@
 class Test_Password_Claim extends WP_UnitTestCase {
 
 	private function create_user( bool $unclaimed = true ): WP_User {
-		$user_id = self::factory()->user->create();
+		$user_id = self::factory()->user->create( array( 'user_pass' => 'original-password' ) );
 
 		if ( $unclaimed ) {
 			update_user_meta( $user_id, 'ec_unclaimed', 1 );
@@ -15,38 +15,78 @@ class Test_Password_Claim extends WP_UnitTestCase {
 		return get_user_by( 'ID', $user_id );
 	}
 
-	public function test_successful_password_claim_clears_unclaimed_marker(): void {
+	public function test_successful_custom_password_claim_runs_completion_in_order(): void {
 		$user = $this->create_user();
 		$key  = get_password_reset_key( $user );
+		$order = array();
+		$before_reset = static function ( $reset_user ) use ( &$order ): void {
+			$order[] = 'password_reset:' . get_user_meta( $reset_user->ID, 'ec_unclaimed', true );
+		};
+		$after_reset  = static function ( $reset_user ) use ( &$order ): void {
+			$order[] = 'after_password_reset:' . get_user_meta( $reset_user->ID, 'ec_unclaimed', true );
+		};
+		add_action( 'password_reset', $before_reset );
+		add_action( 'after_password_reset', $after_reset, 20 );
 
 		$this->assertNotWPError( $key );
 
-		$verified_user = check_password_reset_key( $key, $user->user_login );
-		$this->assertNotWPError( $verified_user );
+		try {
+			$result = ec_process_reset_password_submission( $key, $user->user_login, 'new-secure-password', 'new-secure-password' );
+		} finally {
+			remove_action( 'password_reset', $before_reset );
+			remove_action( 'after_password_reset', $after_reset, 20 );
+		}
 
-		reset_password( $verified_user, 'new-secure-password' );
-
+		$this->assertInstanceOf( WP_User::class, $result );
+		$this->assertSame( array( 'password_reset:1', 'after_password_reset:' ), $order );
 		$this->assertSame( '', get_user_meta( $user->ID, 'ec_unclaimed', true ) );
 		$this->assertTrue( wp_check_password( 'new-secure-password', get_userdata( $user->ID )->user_pass, $user->ID ) );
 	}
 
-	public function test_invalid_or_expired_key_does_not_clear_unclaimed_marker(): void {
+	public function test_invalid_custom_reset_key_does_not_clear_unclaimed_marker(): void {
+		$user = $this->create_user();
+		$result = ec_process_reset_password_submission( 'invalid-key', $user->user_login, 'new-secure-password', 'new-secure-password' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_reset_key', $result->get_error_code() );
+		$this->assertSame( '1', get_user_meta( $user->ID, 'ec_unclaimed', true ) );
+		$this->assertTrue( wp_check_password( 'original-password', get_userdata( $user->ID )->user_pass, $user->ID ) );
+	}
+
+	public function test_custom_password_mismatch_does_not_clear_unclaimed_marker(): void {
 		$user = $this->create_user();
 		$key  = get_password_reset_key( $user );
 
 		$this->assertNotWPError( $key );
-		wp_set_password( 'replacement-password', $user->ID );
+		$result = ec_process_reset_password_submission( $key, $user->user_login, 'new-secure-password', 'different-password' );
 
-		$this->assertWPError( check_password_reset_key( $key, $user->user_login ) );
+		$this->assertWPError( $result );
+		$this->assertSame( 'password_mismatch', $result->get_error_code() );
 		$this->assertSame( '1', get_user_meta( $user->ID, 'ec_unclaimed', true ) );
+		$this->assertNotWPError( check_password_reset_key( $key, $user->user_login ) );
+		$this->assertTrue( wp_check_password( 'original-password', get_userdata( $user->ID )->user_pass, $user->ID ) );
 	}
 
-	public function test_failure_before_password_reset_does_not_clear_unclaimed_marker(): void {
+	public function test_custom_password_validation_failure_does_not_clear_unclaimed_marker(): void {
+		$user = $this->create_user();
+		$key  = get_password_reset_key( $user );
+
+		$this->assertNotWPError( $key );
+		$result = ec_process_reset_password_submission( $key, $user->user_login, 'short', 'short' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'password_too_short', $result->get_error_code() );
+		$this->assertSame( '1', get_user_meta( $user->ID, 'ec_unclaimed', true ) );
+		$this->assertNotWPError( check_password_reset_key( $key, $user->user_login ) );
+		$this->assertTrue( wp_check_password( 'original-password', get_userdata( $user->ID )->user_pass, $user->ID ) );
+	}
+
+	public function test_core_password_reset_clears_unclaimed_marker(): void {
 		$user = $this->create_user();
 
-		do_action( 'password_reset', $user, 'new-secure-password' );
+		reset_password( $user, 'new-secure-password' );
 
-		$this->assertSame( '1', get_user_meta( $user->ID, 'ec_unclaimed', true ) );
+		$this->assertSame( '', get_user_meta( $user->ID, 'ec_unclaimed', true ) );
 	}
 
 	public function test_repeated_completion_hook_is_harmless(): void {

--- a/tests/unit/PasswordClaimTest.php
+++ b/tests/unit/PasswordClaimTest.php
@@ -89,6 +89,26 @@ class Test_Password_Claim extends WP_UnitTestCase {
 		$this->assertSame( '', get_user_meta( $user->ID, 'ec_unclaimed', true ) );
 	}
 
+	public function test_core_reset_preserves_unclaimed_marker_when_deletion_fails(): void {
+		$user = $this->create_user();
+		$block_deletion = static function ( $check, $object_id, $meta_key ) use ( $user ) {
+			if ( $user->ID === (int) $object_id && 'ec_unclaimed' === $meta_key ) {
+				return false;
+			}
+			return $check;
+		};
+		add_filter( 'delete_user_metadata', $block_deletion, 10, 3 );
+
+		try {
+			reset_password( $user, 'new-secure-password' );
+		} finally {
+			remove_filter( 'delete_user_metadata', $block_deletion, 10 );
+		}
+
+		$this->assertSame( '1', get_user_meta( $user->ID, 'ec_unclaimed', true ) );
+		$this->assertTrue( wp_check_password( 'new-secure-password', get_userdata( $user->ID )->user_pass, $user->ID ) );
+	}
+
 	public function test_completion_does_not_clear_marker_without_persisted_password(): void {
 		$user = $this->create_user();
 


### PR DESCRIPTION
## Summary
- clear `ec_unclaimed` only after WordPress has persisted and verified the claimed password
- require `unclaimed=true` account creation to verify `ec_unclaimed=1`, otherwise network-delete the new account or return an explicit manual-reconciliation error
- exercise the real Extra Chill reset submission seam plus supported core `reset_password()` behavior
- retain current `main` protections, including the core multisite signup lockout

## Root cause
The create-user owner primitive wrote `ec_unclaimed=1` without verifying persistence, so it could return a generated-password user ID that downstream trusted automation treated as claimed. Separately, no owner-layer reset completion path removed the marker after a legitimate password claim.

## Creation contract
For `unclaimed=true`, the ability now:
- writes the marker immediately after `wp_create_user()`
- reads it back and returns a user ID only when the persisted value is exactly `1`
- uses `wpmu_delete_user()` on multisite so rollback removes the global generated-password account, not only one site membership
- treats an already-absent account as a successful idempotent rollback
- returns `unclaimed_state_persistence_failed` after successful rollback and marks it non-auto-retryable because `user_register` side effects may already have fired
- returns `unclaimed_state_reconciliation_required` with the orphaned `user_id`, `manual_reconciliation`, and `retryable=false` when rollback cannot remove the account
- never runs Extra Chill registration hooks/analytics or returns a normal ID after marker verification fails

## Claim contract
The canonical completion seam is WordPress's `after_password_reset` action. Unlike `password_reset`, it runs after `wp_set_password()`.

The owner callback reloads the user and verifies the supplied password against the persisted hash before deleting `ec_unclaimed`. It verifies marker deletion afterward. This covers both the Extra Chill handler and core reset paths without clearing state for invalid keys, validation failures, failed password persistence, direct authenticated password changes, or ordinary requests.

The custom handler now delegates its non-redirecting work to `ec_process_reset_password_submission()`, preserving the existing nonce, messages, redirects, and auth-cookie behavior while allowing real integration-style execution. It returns explicit errors if the password or claimed state cannot be verified, so the handler does not authenticate a partially completed claim. On a core marker-deletion failure, `ec_unclaimed` remains the durable reconciliation signal.

## Tests
Added coverage for:
- verified unclaimed marker persistence
- persistent marker write failure with successful rollback
- rollback failure requiring manual reconciliation
- idempotent already-absent rollback
- existing-user/create-race behavior without marking or deleting the existing account
- successful custom reset ordering across `password_reset` and `after_password_reset`
- invalid key, password mismatch, and password-length rejection through the custom seam
- failed password verification preserving `ec_unclaimed`
- custom marker-deletion failure returning an error
- core reset success and core marker-deletion failure
- repeated completion and already-claimed accounts

Validation:
- isolated WP Codebox repository harness on WordPress 7.0.1: **31 tests, 85 assertions passed; 1 skipped**
- the skip is the multisite-only `wpmu_delete_user()` super-admin refusal test because project-bootstrap mode reuses a single-site Playground install; the test remains enabled for multisite CI
- PHP syntax checks passed for all four changed PHP files
- `git diff --check origin/main` passed
- Homeboy changed-file lint passed with no findings
- fresh review of the complete merged diff reported no actionable findings
- Homeboy audit completed its detector set once but exceeded the 10-minute command limit during a repeated dead-code pass; no finding was emitted before timeout

No Artist Platform, booking, venue, Roadie, or other consumer-specific concepts entered this owner layer. This unblocks Extra-Chill/extrachill-artist-platform#151.

Closes #235