### PR TITLE
fix: close core multisite signup surface

### DIFF
--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -116,6 +116,7 @@ function extrachill_users_init() {
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/orphan-meta-cleanup.php';
 
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/auth/login.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/auth/core-signup.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/auth/register.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/auth/logout.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/auth/password-reset.php';

--- a/inc/auth/core-signup.php
+++ b/inc/auth/core-signup.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Core Multisite Signup Policy
+ *
+ * Closes the public wp-signup.php surface without changing the network
+ * registration setting used by Extra Chill's branded registration flows.
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return the canonical branded registration URL for the network.
+ *
+ * @return string Registration URL.
+ */
+function extrachill_users_get_registration_url() {
+	return network_home_url( '/login/', 'https' ) . '#tab-register';
+}
+
+/**
+ * Close WordPress core's multisite signup endpoint.
+ *
+ * Core redirects subsite wp-signup.php requests to the main-site endpoint
+ * before firing this hook. Safe requests therefore share one canonical
+ * destination, while submissions stop before core validates or creates users.
+ */
+function extrachill_users_close_core_signup_surface() {
+	$request_method = isset( $_SERVER['REQUEST_METHOD'] ) ? strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) ) : 'GET';
+
+	if ( in_array( $request_method, array( 'GET', 'HEAD' ), true ) ) {
+		wp_safe_redirect( extrachill_users_get_registration_url() );
+		exit;
+	}
+
+	wp_die(
+		esc_html__( 'Direct signup submissions are not allowed.', 'extrachill-users' ),
+		'',
+		array( 'response' => 403 )
+	);
+}
+add_action( 'before_signup_header', 'extrachill_users_close_core_signup_surface', 0 );

--- a/tests/unit/CoreSignupSurfaceTest.php
+++ b/tests/unit/CoreSignupSurfaceTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Coverage for the public core multisite signup surface (#239).
+ */
+
+class Test_Core_Signup_Surface extends WP_UnitTestCase {
+	/**
+	 * Original request server state.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $original_server;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->original_server = $_SERVER;
+	}
+
+	public function test_policy_is_attached_before_core_processes_signup(): void {
+		$this->assertSame( 0, has_action( 'before_signup_header', 'extrachill_users_close_core_signup_surface' ) );
+	}
+
+	public function test_main_site_get_redirects_to_branded_registration(): void {
+		$this->assertCoreSignupRedirectsToBrandedRegistration();
+	}
+
+	public function test_subsite_get_uses_network_branded_registration_after_core_canonicalization(): void {
+		$this->assertCoreCanonicalizesSubsiteSignup();
+		$this->assertCoreSignupRedirectsToBrandedRegistration();
+	}
+
+	public function test_post_is_rejected_before_an_account_can_be_created(): void {
+		$this->assertCoreSignupPostIsRejected();
+	}
+
+	public function test_subsite_post_is_rejected_after_core_canonicalization(): void {
+		$this->assertCoreCanonicalizesSubsiteSignup();
+		$this->assertCoreSignupPostIsRejected();
+	}
+
+	public function test_branded_registration_and_login_handlers_remain_registered(): void {
+		$this->assertNotFalse( has_action( 'admin_post_nopriv_extrachill_register_user', 'extrachill_handle_registration' ) );
+		$this->assertNotFalse( has_filter( 'extrachill_create_community_user', 'ec_multisite_create_community_user' ) );
+		$this->assertNotFalse( has_action( 'init', 'extrachill_redirect_wp_login_access' ) );
+	}
+
+	/**
+	 * Exercise the real rejection callback without allowing wp_die() to exit.
+	 */
+	private function assertCoreSignupPostIsRejected(): void {
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$user_count                = count_users()['total_users'];
+		$die_handler               = static function () {
+			return static function ( $message, $title, $args ) {
+				throw new RuntimeException(
+					wp_json_encode(
+						array(
+							'message' => $message,
+							'args'    => $args,
+						)
+					)
+				);
+			};
+		};
+		add_filter( 'wp_die_handler', $die_handler );
+
+		try {
+			extrachill_users_close_core_signup_surface();
+			$this->fail( 'Expected a direct core signup POST to be rejected.' );
+		} catch ( RuntimeException $exception ) {
+			$failure = json_decode( $exception->getMessage(), true );
+			$this->assertSame( 403, $failure['args']['response'] );
+			$this->assertSame( 'Direct signup submissions are not allowed.', $failure['message'] );
+			$this->assertSame( $user_count, count_users()['total_users'] );
+		} finally {
+			remove_filter( 'wp_die_handler', $die_handler );
+		}
+	}
+
+	/**
+	 * Exercise the real redirect callback without allowing it to exit PHPUnit.
+	 */
+	private function assertCoreSignupRedirectsToBrandedRegistration(): void {
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$registration_setting      = get_site_option( 'registration' );
+		$redirect_filter           = static function ( $location, $status ) {
+			throw new RuntimeException( wp_json_encode( compact( 'location', 'status' ) ) );
+		};
+		add_filter( 'wp_redirect', $redirect_filter, 10, 2 );
+
+		try {
+			extrachill_users_close_core_signup_surface();
+			$this->fail( 'Expected a direct core signup GET to redirect.' );
+		} catch ( RuntimeException $exception ) {
+			$redirect = json_decode( $exception->getMessage(), true );
+			$this->assertSame( network_home_url( '/login/', 'https' ) . '#tab-register', $redirect['location'] );
+			$this->assertSame( 302, $redirect['status'] );
+			$this->assertSame( $registration_setting, get_site_option( 'registration' ) );
+		} finally {
+			remove_filter( 'wp_redirect', $redirect_filter, 10 );
+		}
+	}
+
+	/**
+	 * Confirm core's subsite endpoint resolves to the network signup endpoint.
+	 */
+	private function assertCoreCanonicalizesSubsiteSignup(): void {
+		$subsite_id = self::factory()->blog->create();
+		switch_to_blog( $subsite_id );
+
+		try {
+			$this->assertSame( network_site_url( 'wp-signup.php' ), get_site_url( get_main_site_id(), 'wp-signup.php' ) );
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	protected function tearDown(): void {
+		$_SERVER = $this->original_server;
+		parent::tearDown();
+	}
+}


### PR DESCRIPTION
## Summary

- close the public WordPress multisite `wp-signup.php` path without changing the network registration setting used by branded registration
- redirect direct GET/HEAD traffic to `https://extrachill.com/login/#tab-register`
- reject direct core signup submissions with HTTP 403 before core validation or account creation
- add focused main-site/subsite GET and POST coverage while asserting branded registration/login hooks remain intact

## Security impact

Production exposed a second unauthenticated account-registration path outside Extra Chill Users policy and Turnstile. Hiding the link and serving `noindex` do not restrict requests or submissions, so bots could still discover and use the functional core form.

Before this fix, `https://extrachill.com/wp-signup.php` returned HTTP 200 with the core username/email form, and `https://community.extrachill.com/wp-signup.php` redirected to that main-site form. The branded UI and `wp-login.php?action=register` already route users to `/login/#tab-register`.

## Implementation

The policy hooks `before_signup_header` at priority 0. This is the narrow WordPress multisite hook fired on the main signup endpoint after core has canonicalized subsite requests, but before core renders the form or reaches `validate_user_signup()` / `wpmu_signup_user()`.

GET and HEAD requests redirect to the network's HTTPS branded registration route. Any state-changing or unexpected method fails closed with HTTP 403. The implementation does not filter `wpmu_active_signup`, mutate the `registration=user` network option, or touch branded admin-post, REST, OAuth, token, and user-creation paths. Network administration remains available through wp-admin.

## Multisite behavior

- Main-site GET/HEAD: 302 to `https://extrachill.com/login/#tab-register`.
- Subsite GET/HEAD: core canonicalizes `wp-signup.php` to the network main endpoint, which redirects to the same branded URL.
- Main-site POST: HTTP 403 before signup validation or user creation.
- Subsite POST: core canonicalizes to the network endpoint; any preserved POST is rejected by the same policy, while ordinary redirect handling becomes the branded GET flow.
- Branded registration and login handlers remain registered, and the network registration option remains `user`.

## Verification

- `php -l` on all changed PHP files: passed.
- `git diff --check`: passed.
- Homeboy changed-file PHPCS: passed.
- WP-CLI runtime GET check on main and Community contexts: both resolved to `https://extrachill.com/login/#tab-register` with status 302.
- WP-CLI runtime POST checks: HTTP 403; user counts unchanged (`52 -> 52` on main and `637 -> 637` in Community context); network registration remained `user`.
- WP-CLI hook check: branded admin-post registration, community user-creation filter, and login redirect remained registered.
- Focused PHPUnit coverage was added in `tests/unit/CoreSignupSurfaceTest.php`. Two controller runs failed before PHPUnit executed because WP Codebox timed out on a stale WordPress archive cache lock, tracked upstream in Automattic/wp-codebox#1941.
- `homeboy review extrachill-users`: audit ran and PHPCS passed; PHPStan could not complete because this repository does not load WordPress core symbols and reports existing core calls as undefined. Tracked in #240.
- Lab fallback was unavailable because no eligible Lab runner was connected.

Closes #239