### PR TITLE
Harden password registration against automated abuse

### DIFF
--- a/inc/auth-tokens/service.php
+++ b/inc/auth-tokens/service.php
@@ -342,14 +342,9 @@ function extrachill_users_register_with_tokens( array $payload ) {
 		? extrachill_users_sanitize_utm( $payload['utm'] )
 		: array();
 
-	$is_app_client = isset( $_SERVER['HTTP_EXTRACHILL_CLIENT'] )
-		&& 'app' === sanitize_text_field( wp_unslash( $_SERVER['HTTP_EXTRACHILL_CLIENT'] ) );
-
-	if ( ! $is_app_client ) {
-		$check = ec_turnstile_check_request( $turnstile_token );
-		if ( is_wp_error( $check ) ) {
-			return $check;
-		}
+	$check = extrachill_users_validate_password_registration( $email, $turnstile_token );
+	if ( is_wp_error( $check ) ) {
+		return $check;
 	}
 
 	if ( empty( $email ) || empty( $password ) || empty( $password_confirm ) ) {
@@ -444,16 +439,6 @@ function extrachill_users_register_with_tokens( array $payload ) {
 
 	if ( ! empty( $utm ) ) {
 		$registration_data['utm'] = $utm;
-	}
-
-	if ( $is_app_client ) {
-		if ( empty( $registration_data['registration_source'] ) ) {
-			$registration_data['registration_source'] = 'extrachill-app';
-		}
-
-		if ( empty( $registration_data['registration_method'] ) ) {
-			$registration_data['registration_method'] = 'standard';
-		}
 	}
 
 	$has_artist_invitation = false;

--- a/inc/auth/register.php
+++ b/inc/auth/register.php
@@ -11,6 +11,132 @@
 
 defined( 'ABSPATH' ) || exit;
 
+const EXTRACHILL_USERS_REGISTRATION_RATE_LIMIT  = 5;
+const EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW = 15 * MINUTE_IN_SECONDS;
+
+/**
+ * Get the registration attempt key for the current requester.
+ *
+ * The IP-only key prevents callers from evading the limit by rotating email
+ * addresses. The stored value includes a fixed expiry so later attempts do not
+ * extend the window.
+ *
+ * @return string Transient key.
+ */
+function extrachill_users_registration_attempt_key(): string {
+	$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+
+	return 'ec_registration_attempts_' . md5( $ip );
+}
+
+/**
+ * Return the current registration throttle state.
+ *
+ * @return array{attempts:int,expires_at:int}
+ */
+function extrachill_users_registration_attempt_state(): array {
+	$state = get_transient( extrachill_users_registration_attempt_key() );
+	if ( ! is_array( $state ) || ! isset( $state['attempts'], $state['expires_at'] ) || (int) $state['expires_at'] <= time() ) {
+		return array(
+			'attempts'   => 0,
+			'expires_at' => 0,
+		);
+	}
+
+	return array(
+		'attempts'   => max( 0, (int) $state['attempts'] ),
+		'expires_at' => (int) $state['expires_at'],
+	);
+}
+
+/**
+ * Check whether the current requester has exhausted registration attempts.
+ *
+ * @return true|WP_Error True when another attempt is allowed.
+ */
+function extrachill_users_check_registration_rate_limit() {
+	$state = extrachill_users_registration_attempt_state();
+	if ( $state['attempts'] < EXTRACHILL_USERS_REGISTRATION_RATE_LIMIT ) {
+		return true;
+	}
+
+	$retry_after = max( 1, $state['expires_at'] - time() );
+
+	return new WP_Error(
+		'registration_rate_limited',
+		__( 'Too many registration attempts. Please try again in 15 minutes.', 'extrachill-users' ),
+		array(
+			'status'      => 429,
+			'retry_after' => $retry_after,
+			'expires_at'  => $state['expires_at'],
+		)
+	);
+}
+
+/**
+ * Record a registration attempt without extending the current window.
+ */
+function extrachill_users_record_registration_attempt(): void {
+	$key   = extrachill_users_registration_attempt_key();
+	$state = extrachill_users_registration_attempt_state();
+
+	if ( 0 === $state['expires_at'] ) {
+		$state['expires_at'] = time() + EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW;
+	}
+
+	++$state['attempts'];
+	set_transient( $key, $state, max( 1, $state['expires_at'] - time() ) );
+}
+
+/**
+ * Apply shared anti-abuse policy to branded password registration.
+ *
+ * @param string $email            Sanitized registration email.
+ * @param string $turnstile_token  Turnstile response token.
+ * @return true|WP_Error True when registration may continue.
+ */
+function extrachill_users_validate_password_registration( string $email, string $turnstile_token ) {
+	$rate_limit = extrachill_users_check_registration_rate_limit();
+	if ( is_wp_error( $rate_limit ) ) {
+		return $rate_limit;
+	}
+
+	// Count failed CAPTCHA and validation requests as attempts too.
+	extrachill_users_record_registration_attempt();
+
+	/**
+	 * Filter the Turnstile verifier used by password registration.
+	 *
+	 * Production uses Extra Chill Network's verifier. Tests can substitute a
+	 * deterministic callable without making external Cloudflare requests.
+	 *
+	 * @param callable $verifier Turnstile verifier callable.
+	 */
+	$turnstile_verifier = apply_filters( 'extrachill_users_registration_turnstile_verifier', 'ec_turnstile_check_request' );
+	if ( ! is_callable( $turnstile_verifier ) ) {
+		return new WP_Error(
+			'turnstile_missing',
+			__( 'Security verification unavailable.', 'extrachill-users' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	$turnstile_check = call_user_func( $turnstile_verifier, $turnstile_token );
+	if ( is_wp_error( $turnstile_check ) ) {
+		return $turnstile_check;
+	}
+
+	if ( is_email( $email ) && is_email_address_unsafe( $email ) ) {
+		return new WP_Error(
+			'unsafe_email',
+			__( 'That email address is not allowed. Please use another email provider.', 'extrachill-users' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	return true;
+}
+
 /**
  * Handle registration form submission.
  *
@@ -31,7 +157,7 @@ function extrachill_handle_registration() {
 	$turnstile_token = isset( $_POST['cf-turnstile-response'] )
 		? wp_unslash( $_POST['cf-turnstile-response'] )
 		: '';
-	$check           = ec_turnstile_check_request( $turnstile_token );
+	$check           = extrachill_users_validate_password_registration( $email, $turnstile_token );
 	if ( is_wp_error( $check ) ) {
 		$redirect->error( $check->get_error_message() );
 	}

--- a/inc/auth/register.php
+++ b/inc/auth/register.php
@@ -13,79 +13,108 @@ defined( 'ABSPATH' ) || exit;
 
 const EXTRACHILL_USERS_REGISTRATION_RATE_LIMIT  = 5;
 const EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW = 15 * MINUTE_IN_SECONDS;
+const EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP = 'extrachill-users-registration-admission';
 
 /**
- * Get the registration attempt key for the current requester.
+ * Get the registration limiter key for the current requester and window.
  *
- * The IP-only key prevents callers from evading the limit by rotating email
- * addresses. The stored value includes a fixed expiry so later attempts do not
- * extend the window.
+ * The custom cache group is registered as global so all sites in the network
+ * share one IP budget. Network ID remains in the key to isolate separate
+ * networks when a cache backend serves more than one.
  *
- * @return string Transient key.
+ * @param int|null $now Optional Unix timestamp. Defaults to now.
+ * @return string Cache key, or an empty string when the requester IP is unavailable.
  */
-function extrachill_users_registration_attempt_key(): string {
+function extrachill_users_registration_attempt_key( ?int $now = null ): string {
 	$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+	if ( '' === $ip ) {
+		return '';
+	}
 
-	return 'ec_registration_attempts_' . md5( $ip );
+	$now       = null === $now ? time() : $now;
+	$window_id = intdiv( $now, EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW );
+	$ip_hash   = substr( hash_hmac( 'sha256', $ip, wp_salt( 'nonce' ) ), 0, 32 );
+
+	return sprintf( 'network_%d_window_%d_ip_%s', get_current_network_id(), $window_id, $ip_hash );
 }
 
 /**
- * Return the current registration throttle state.
+ * Build a stable registration rate-limit error.
  *
- * @return array{attempts:int,expires_at:int}
+ * @param int $expires_at Fixed-window expiry timestamp.
+ * @return WP_Error Rate-limit response with REST-safe metadata.
  */
-function extrachill_users_registration_attempt_state(): array {
-	$state = get_transient( extrachill_users_registration_attempt_key() );
-	if ( ! is_array( $state ) || ! isset( $state['attempts'], $state['expires_at'] ) || (int) $state['expires_at'] <= time() ) {
-		return array(
-			'attempts'   => 0,
-			'expires_at' => 0,
-		);
-	}
-
-	return array(
-		'attempts'   => max( 0, (int) $state['attempts'] ),
-		'expires_at' => (int) $state['expires_at'],
-	);
-}
-
-/**
- * Check whether the current requester has exhausted registration attempts.
- *
- * @return true|WP_Error True when another attempt is allowed.
- */
-function extrachill_users_check_registration_rate_limit() {
-	$state = extrachill_users_registration_attempt_state();
-	if ( $state['attempts'] < EXTRACHILL_USERS_REGISTRATION_RATE_LIMIT ) {
-		return true;
-	}
-
-	$retry_after = max( 1, $state['expires_at'] - time() );
-
+function extrachill_users_registration_rate_limit_error( int $expires_at ): WP_Error {
 	return new WP_Error(
 		'registration_rate_limited',
-		__( 'Too many registration attempts. Please try again in 15 minutes.', 'extrachill-users' ),
+		__( 'Too many registration attempts. Please try again later.', 'extrachill-users' ),
 		array(
 			'status'      => 429,
-			'retry_after' => $retry_after,
-			'expires_at'  => $state['expires_at'],
+			'retry_after' => max( 1, $expires_at - time() ),
+			'expires_at'  => $expires_at,
 		)
 	);
 }
 
 /**
- * Record a registration attempt without extending the current window.
+ * Atomically increment and admit one registration attempt.
+ *
+ * `wp_cache_add()` admits the first request and `wp_cache_incr()` atomically
+ * admits every concurrent follower without a separate read/write race. Redis
+ * preserves the original TTL on increment, keeping the fixed expiry stable.
+ *
+ * @param string $key        Network-global cache key.
+ * @param int    $expires_at Fixed-window expiry timestamp.
+ * @return true|WP_Error True when admitted, otherwise a stable error.
  */
-function extrachill_users_record_registration_attempt(): void {
-	$key   = extrachill_users_registration_attempt_key();
-	$state = extrachill_users_registration_attempt_state();
+function extrachill_users_increment_registration_attempt( string $key, int $expires_at ) {
+	wp_cache_add_global_groups( EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP );
 
-	if ( 0 === $state['expires_at'] ) {
-		$state['expires_at'] = time() + EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW;
+	$ttl = max( 1, $expires_at - time() );
+	if ( wp_cache_add( $key, 1, EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP, $ttl ) ) {
+		$count = 1;
+	} else {
+		$count = wp_cache_incr( $key, 1, EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP );
 	}
 
-	++$state['attempts'];
-	set_transient( $key, $state, max( 1, $state['expires_at'] - time() ) );
+	if ( false === $count || ! is_numeric( $count ) ) {
+		return new WP_Error(
+			'registration_limiter_unavailable',
+			__( 'Registration is temporarily unavailable. Please try again.', 'extrachill-users' ),
+			array( 'status' => 503 )
+		);
+	}
+
+	return (int) $count > EXTRACHILL_USERS_REGISTRATION_RATE_LIMIT
+		? extrachill_users_registration_rate_limit_error( $expires_at )
+		: true;
+}
+
+/**
+ * Admit the current requester through the network-wide registration limiter.
+ *
+ * @return true|WP_Error True when admitted, otherwise a fail-closed error.
+ */
+function extrachill_users_admit_registration_attempt() {
+	$key = extrachill_users_registration_attempt_key();
+	if ( '' === $key
+		|| ! function_exists( 'wp_using_ext_object_cache' )
+		|| ! wp_using_ext_object_cache()
+		|| ! function_exists( 'wp_cache_add' )
+		|| ! function_exists( 'wp_cache_incr' )
+		|| ! function_exists( 'wp_cache_add_global_groups' )
+	) {
+		return new WP_Error(
+			'registration_limiter_unavailable',
+			__( 'Registration is temporarily unavailable. Please try again.', 'extrachill-users' ),
+			array( 'status' => 503 )
+		);
+	}
+
+	$now        = time();
+	$expires_at = ( intdiv( $now, EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW ) + 1 ) * EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW;
+
+	return extrachill_users_increment_registration_attempt( $key, $expires_at );
 }
 
 /**
@@ -96,14 +125,6 @@ function extrachill_users_record_registration_attempt(): void {
  * @return true|WP_Error True when registration may continue.
  */
 function extrachill_users_validate_password_registration( string $email, string $turnstile_token ) {
-	$rate_limit = extrachill_users_check_registration_rate_limit();
-	if ( is_wp_error( $rate_limit ) ) {
-		return $rate_limit;
-	}
-
-	// Count failed CAPTCHA and validation requests as attempts too.
-	extrachill_users_record_registration_attempt();
-
 	/**
 	 * Filter the Turnstile verifier used by password registration.
 	 *
@@ -126,6 +147,28 @@ function extrachill_users_validate_password_registration( string $email, string 
 		return $turnstile_check;
 	}
 
+	/**
+	 * Filter the atomic registration admission callable.
+	 *
+	 * Tests may substitute a deterministic concurrency seam. Production uses
+	 * the network-global persistent-object-cache implementation above.
+	 *
+	 * @param callable $admitter Atomic admission callable.
+	 */
+	$admitter = apply_filters( 'extrachill_users_registration_admitter', 'extrachill_users_admit_registration_attempt' );
+	if ( ! is_callable( $admitter ) ) {
+		return new WP_Error(
+			'registration_limiter_unavailable',
+			__( 'Registration is temporarily unavailable. Please try again.', 'extrachill-users' ),
+			array( 'status' => 503 )
+		);
+	}
+
+	$admission = call_user_func( $admitter );
+	if ( is_wp_error( $admission ) ) {
+		return $admission;
+	}
+
 	if ( is_email( $email ) && is_email_address_unsafe( $email ) ) {
 		return new WP_Error(
 			'unsafe_email',
@@ -135,6 +178,19 @@ function extrachill_users_validate_password_registration( string $email, string 
 	}
 
 	return true;
+}
+
+/**
+ * Validate the anti-abuse policy fields from a registration form request.
+ *
+ * @param array $request Form request values.
+ * @return true|WP_Error True when the form request may continue.
+ */
+function extrachill_users_validate_registration_form_request( array $request ) {
+	$email = isset( $request['extrachill_email'] ) ? sanitize_email( wp_unslash( $request['extrachill_email'] ) ) : '';
+	$token = isset( $request['cf-turnstile-response'] ) ? wp_unslash( $request['cf-turnstile-response'] ) : '';
+
+	return extrachill_users_validate_password_registration( $email, $token );
 }
 
 /**
@@ -154,10 +210,7 @@ function extrachill_handle_registration() {
 	$password         = isset( $_POST['extrachill_password'] ) ? wp_unslash( $_POST['extrachill_password'] ) : '';
 	$password_confirm = isset( $_POST['extrachill_password_confirm'] ) ? wp_unslash( $_POST['extrachill_password_confirm'] ) : '';
 
-	$turnstile_token = isset( $_POST['cf-turnstile-response'] )
-		? wp_unslash( $_POST['cf-turnstile-response'] )
-		: '';
-	$check           = extrachill_users_validate_password_registration( $email, $turnstile_token );
+	$check = extrachill_users_validate_registration_form_request( $_POST );
 	if ( is_wp_error( $check ) ) {
 		$redirect->error( $check->get_error_message() );
 	}

--- a/inc/wp-native-bridge.php
+++ b/inc/wp-native-bridge.php
@@ -169,38 +169,33 @@ function extrachill_users_wp_native_after_login( int $user_id, string $device_id
 add_action( 'wp_native_auth_after_login', 'extrachill_users_wp_native_after_login', 10, 3 );
 
 /**
- * Pre-register gate: override username generation for EC conventions.
+ * Pre-register gate: fail closed when site registration policy cannot run.
  *
- * Delegates to ec_generate_username_from_email() — the same function used by
- * the existing extrachill_users_register_with_tokens() service in
- * inc/auth-tokens/service.php. The framework's default deterministic hash-based
- * username is replaced with EC's human-readable convention.
- *
- * Out-of-scope concerns (deferred to follow-up issues):
- *  - Turnstile verification: wp-native-auth's input schema doesn't accept a
- *    turnstile_response field. Turnstile enforcement remains web-only via the
- *    existing /extrachill/v1/auth/register REST route (same constraint as the
- *    pre_authenticate handler above).
- *  - Invite-token redemption: wp-native-auth's input schema doesn't accept
- *    invite_token / invite_artist_id. Invite-flow registrations stay on the
- *    existing REST route.
+ * wp-native-auth deliberately exposes a generic registration ability, but its
+ * schema cannot carry Extra Chill's Turnstile proof. Block that path before
+ * user creation; branded registration remains the only public site surface.
  *
  * @param null|WP_Error $result            Pass-through from earlier filters, or null.
  * @param array         $registration_data Registration data: [email, password, username]. Passed by reference by the caller.
  * @param array         $context           Contextual data from wp-native-auth (device_id, etc.).
- * @return null|WP_Error Null to continue, WP_Error to abort registration.
+ * @return WP_Error Existing policy error or the fail-closed site policy error.
  */
 function extrachill_users_wp_native_pre_register( null|WP_Error $result, array &$registration_data, array $context ): null|WP_Error {
 	if ( $result instanceof WP_Error ) {
 		return $result; // Earlier filter already blocked.
 	}
 
-	// Override username with EC convention if the helper exists.
-	if ( function_exists( 'ec_generate_username_from_email' ) && ! empty( $registration_data['email'] ) ) {
-		$registration_data['username'] = ec_generate_username_from_email( $registration_data['email'] );
-	}
-
-	return $result;
+	/*
+	 * wp-native/auth-register is public but cannot carry Extra Chill's required
+	 * Turnstile proof. Keep it fail-closed at the consumer policy layer. Future
+	 * exposure must route through the branded registration boundary or supply a
+	 * server-verifiable context that can execute the same site policy first.
+	 */
+	return new WP_Error(
+		'extrachill_registration_surface_unavailable',
+		__( 'Registration is not available through this endpoint.', 'extrachill-users' ),
+		array( 'status' => 403 )
+	);
 }
 add_filter( 'wp_native_auth_pre_register', 'extrachill_users_wp_native_pre_register', 10, 3 );
 

--- a/tests/unit/ArtistInvitationRegistrationTest.php
+++ b/tests/unit/ArtistInvitationRegistrationTest.php
@@ -14,12 +14,14 @@ class Test_Artist_Invitation_Registration extends WP_UnitTestCase {
 	protected function tearDown(): void {
 		unset( $_SERVER['HTTP_EXTRACHILL_CLIENT'] );
 		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'extrachill_users_registration_turnstile_verifier' );
+		delete_transient( extrachill_users_registration_attempt_key() );
 		parent::tearDown();
 	}
 
 	public function test_incomplete_invitation_is_rejected_before_token_registration_creates_user(): void {
-		$_SERVER['HTTP_EXTRACHILL_CLIENT'] = 'app';
-		$email                             = 'failed-invite@example.com';
+		add_filter( 'extrachill_users_registration_turnstile_verifier', array( $this, 'pass_turnstile' ) );
+		$email = 'failed-invite@example.com';
 
 		$result = extrachill_users_register_with_tokens(
 			array(
@@ -104,8 +106,8 @@ class Test_Artist_Invitation_Registration extends WP_UnitTestCase {
 	}
 
 	private function assert_token_registration_invitation_outcome( string $error_code, int $error_status, string $expected_status, bool $expected_retryable ): void {
-		$_SERVER['HTTP_EXTRACHILL_CLIENT'] = 'app';
-		$request_count                     = 0;
+		add_filter( 'extrachill_users_registration_turnstile_verifier', array( $this, 'pass_turnstile' ) );
+		$request_count = 0;
 		add_filter(
 			'pre_http_request',
 			static function () use ( &$request_count, $error_code, $error_status ) {
@@ -165,6 +167,10 @@ class Test_Artist_Invitation_Registration extends WP_UnitTestCase {
 		$this->assertSame( $error_status, $result['artist_invitation_error']['status'] );
 		$this->assertNotFalse( email_exists( $email ) );
 		$this->assertSame( 2, $request_count );
+	}
+
+	public function pass_turnstile(): bool {
+		return true;
 	}
 
 	private function assert_browser_invitation_outcome( string $error_code, int $error_status, string $expected_status, bool $expected_retryable ): void {

--- a/tests/unit/ArtistInvitationRegistrationTest.php
+++ b/tests/unit/ArtistInvitationRegistrationTest.php
@@ -15,12 +15,13 @@ class Test_Artist_Invitation_Registration extends WP_UnitTestCase {
 		unset( $_SERVER['HTTP_EXTRACHILL_CLIENT'] );
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'extrachill_users_registration_turnstile_verifier' );
-		delete_transient( extrachill_users_registration_attempt_key() );
+		remove_all_filters( 'extrachill_users_registration_admitter' );
 		parent::tearDown();
 	}
 
 	public function test_incomplete_invitation_is_rejected_before_token_registration_creates_user(): void {
 		add_filter( 'extrachill_users_registration_turnstile_verifier', array( $this, 'pass_turnstile' ) );
+		add_filter( 'extrachill_users_registration_admitter', array( $this, 'admit_registration' ) );
 		$email = 'failed-invite@example.com';
 
 		$result = extrachill_users_register_with_tokens(
@@ -107,6 +108,7 @@ class Test_Artist_Invitation_Registration extends WP_UnitTestCase {
 
 	private function assert_token_registration_invitation_outcome( string $error_code, int $error_status, string $expected_status, bool $expected_retryable ): void {
 		add_filter( 'extrachill_users_registration_turnstile_verifier', array( $this, 'pass_turnstile' ) );
+		add_filter( 'extrachill_users_registration_admitter', array( $this, 'admit_registration' ) );
 		$request_count = 0;
 		add_filter(
 			'pre_http_request',
@@ -170,6 +172,10 @@ class Test_Artist_Invitation_Registration extends WP_UnitTestCase {
 	}
 
 	public function pass_turnstile(): bool {
+		return true;
+	}
+
+	public function admit_registration(): bool {
 		return true;
 	}
 

--- a/tests/unit/RegistrationAntiAutomationTest.php
+++ b/tests/unit/RegistrationAntiAutomationTest.php
@@ -12,12 +12,14 @@ class Test_Registration_Anti_Automation extends WP_UnitTestCase {
 		parent::setUp();
 		$_SERVER['REMOTE_ADDR'] = self::IP;
 		unset( $_SERVER['HTTP_EXTRACHILL_CLIENT'] );
-		delete_transient( extrachill_users_registration_attempt_key() );
+		wp_cache_add_global_groups( EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP );
+		$this->clear_registration_counter();
 	}
 
 	protected function tearDown(): void {
-		delete_transient( extrachill_users_registration_attempt_key() );
+		$this->clear_registration_counter();
 		remove_all_filters( 'extrachill_users_registration_turnstile_verifier' );
+		remove_all_filters( 'extrachill_users_registration_admitter' );
 		delete_site_option( 'banned_email_domains' );
 		unset( $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_EXTRACHILL_CLIENT'] );
 		parent::tearDown();
@@ -25,26 +27,30 @@ class Test_Registration_Anti_Automation extends WP_UnitTestCase {
 
 	public function test_valid_registration_policy_passes(): void {
 		$this->use_turnstile_result( true );
+		$this->use_admission_result( true );
 
 		$this->assertTrue( extrachill_users_validate_password_registration( 'person@example.com', 'valid-token' ) );
 	}
 
-	public function test_missing_turnstile_is_rejected(): void {
+	public function test_missing_and_invalid_turnstile_do_not_consume_admission(): void {
+		$admission_calls = 0;
+		$this->use_admission_callback(
+			static function () use ( &$admission_calls ) {
+				++$admission_calls;
+				return true;
+			}
+		);
 		$this->use_turnstile_error_for_token( '', 'turnstile_missing_token' );
 
-		$result = extrachill_users_validate_password_registration( 'person@example.com', '' );
+		$missing = extrachill_users_validate_password_registration( 'person@example.com', '' );
+		$this->assertSame( 'turnstile_missing_token', $missing->get_error_code() );
+		$this->assertSame( 0, $admission_calls );
 
-		$this->assertWPError( $result );
-		$this->assertSame( 'turnstile_missing_token', $result->get_error_code() );
-	}
-
-	public function test_invalid_turnstile_is_rejected(): void {
+		remove_all_filters( 'extrachill_users_registration_turnstile_verifier' );
 		$this->use_turnstile_error_for_token( 'invalid-token', 'turnstile_failed' );
-
-		$result = extrachill_users_validate_password_registration( 'person@example.com', 'invalid-token' );
-
-		$this->assertWPError( $result );
-		$this->assertSame( 'turnstile_failed', $result->get_error_code() );
+		$invalid = extrachill_users_validate_password_registration( 'person@example.com', 'invalid-token' );
+		$this->assertSame( 'turnstile_failed', $invalid->get_error_code() );
+		$this->assertSame( 0, $admission_calls );
 	}
 
 	public function test_spoofed_app_header_does_not_bypass_turnstile(): void {
@@ -53,91 +59,166 @@ class Test_Registration_Anti_Automation extends WP_UnitTestCase {
 
 		$result = extrachill_users_validate_password_registration( 'person@example.com', '' );
 
-		$this->assertWPError( $result );
 		$this->assertSame( 'turnstile_missing_token', $result->get_error_code() );
 	}
 
-	public function test_sixth_attempt_is_blocked_at_exact_boundary(): void {
-		$this->use_turnstile_result( true );
-
-		for ( $attempt = 1; $attempt <= EXTRACHILL_USERS_REGISTRATION_RATE_LIMIT; ++$attempt ) {
-			$this->assertTrue( extrachill_users_validate_password_registration( "person{$attempt}@example.com", 'valid-token' ) );
-		}
-
-		$result = extrachill_users_validate_password_registration( 'blocked@example.com', 'valid-token' );
-		$this->assertWPError( $result );
-		$this->assertSame( 'registration_rate_limited', $result->get_error_code() );
-		$this->assertSame( 429, $result->get_error_data()['status'] );
-	}
-
-	public function test_attempts_do_not_extend_expiry_and_reset_after_expiration(): void {
-		$this->use_turnstile_result( true );
-		extrachill_users_validate_password_registration( 'first@example.com', 'valid-token' );
-		$first_state = extrachill_users_registration_attempt_state();
-		extrachill_users_validate_password_registration( 'second@example.com', 'valid-token' );
-		$second_state = extrachill_users_registration_attempt_state();
-
-		$this->assertSame( $first_state['expires_at'], $second_state['expires_at'] );
-
-		set_transient(
-			extrachill_users_registration_attempt_key(),
-			array(
-				'attempts'   => EXTRACHILL_USERS_REGISTRATION_RATE_LIMIT,
-				'expires_at' => time() - 1,
-			),
-			MINUTE_IN_SECONDS
+	public function test_turnstile_runs_before_atomic_admission(): void {
+		$order = array();
+		add_filter(
+			'extrachill_users_registration_turnstile_verifier',
+			static function () use ( &$order ) {
+				return static function () use ( &$order ) {
+					$order[] = 'turnstile';
+					return true;
+				};
+			}
+		);
+		$this->use_admission_callback(
+			static function () use ( &$order ) {
+				$order[] = 'admission';
+				return true;
+			}
 		);
 
-		$this->assertTrue( extrachill_users_validate_password_registration( 'reset@example.com', 'valid-token' ) );
-		$this->assertSame( 1, extrachill_users_registration_attempt_state()['attempts'] );
+		extrachill_users_validate_password_registration( 'person@example.com', 'valid-token' );
+
+		$this->assertSame( array( 'turnstile', 'admission' ), $order );
 	}
 
-	public function test_rate_limit_response_preserves_fixed_expiry(): void {
-		$this->use_turnstile_result( true );
-		for ( $attempt = 0; $attempt < EXTRACHILL_USERS_REGISTRATION_RATE_LIMIT; ++$attempt ) {
-			extrachill_users_validate_password_registration( "person{$attempt}@example.com", 'valid-token' );
+	public function test_atomic_increment_admits_exactly_five_attempts(): void {
+		$key        = extrachill_users_registration_attempt_key();
+		$expires_at = time() + EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW;
+
+		for ( $attempt = 1; $attempt <= EXTRACHILL_USERS_REGISTRATION_RATE_LIMIT; ++$attempt ) {
+			$this->assertTrue( extrachill_users_increment_registration_attempt( $key, $expires_at ) );
 		}
 
-		$first  = extrachill_users_check_registration_rate_limit();
-		$second = extrachill_users_check_registration_rate_limit();
-
-		$this->assertSame( $first->get_error_data()['expires_at'], $second->get_error_data()['expires_at'] );
-		$this->assertGreaterThan( 0, $first->get_error_data()['retry_after'] );
+		$result = extrachill_users_increment_registration_attempt( $key, $expires_at );
+		$this->assertSame( 'registration_rate_limited', $result->get_error_code() );
+		$this->assertSame( 429, $result->get_error_data()['status'] );
+		$this->assertSame( $expires_at, $result->get_error_data()['expires_at'] );
+		$this->assertSame( 6, wp_cache_get( $key, EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP ) );
 	}
 
-	public function test_network_banned_domain_is_rejected(): void {
+	public function test_counter_is_network_global_when_switching_blogs(): void {
+		$key        = extrachill_users_registration_attempt_key();
+		$expires_at = time() + EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW;
+		extrachill_users_increment_registration_attempt( $key, $expires_at );
+
+		$blog_id = self::factory()->blog->create();
+		switch_to_blog( $blog_id );
+		try {
+			$this->assertSame( $key, extrachill_users_registration_attempt_key() );
+			extrachill_users_increment_registration_attempt( $key, $expires_at );
+			$this->assertSame( 2, wp_cache_get( $key, EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP ) );
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	public function test_fixed_window_key_resets_at_expiry_boundary(): void {
+		$now         = time();
+		$window      = intdiv( $now, EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW );
+		$expires_at  = ( $window + 1 ) * EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW;
+		$current_key = extrachill_users_registration_attempt_key( $now );
+		$next_key    = extrachill_users_registration_attempt_key( $expires_at );
+
+		$this->assertNotSame( $current_key, $next_key );
+		for ( $attempt = 0; $attempt < EXTRACHILL_USERS_REGISTRATION_RATE_LIMIT; ++$attempt ) {
+			extrachill_users_increment_registration_attempt( $current_key, $expires_at );
+		}
+		$this->assertSame(
+			'registration_rate_limited',
+			extrachill_users_increment_registration_attempt( $current_key, $expires_at )->get_error_code()
+		);
+		$this->assertTrue(
+			extrachill_users_increment_registration_attempt(
+				$next_key,
+				$expires_at + EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW
+			)
+		);
+
+		wp_cache_delete( $next_key, EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP );
+	}
+
+	public function test_missing_remote_addr_fails_closed_after_turnstile(): void {
+		unset( $_SERVER['REMOTE_ADDR'] );
 		$this->use_turnstile_result( true );
+
+		$result = extrachill_users_validate_password_registration( 'person@example.com', 'valid-token' );
+
+		$this->assertSame( 'registration_limiter_unavailable', $result->get_error_code() );
+		$this->assertSame( 503, $result->get_error_data()['status'] );
+	}
+
+	public function test_network_banned_domain_is_rejected_after_admission(): void {
+		$this->use_turnstile_result( true );
+		$this->use_admission_result( true );
 		update_site_option( 'banned_email_domains', array( 'blocked.example' ) );
 
 		$result = extrachill_users_validate_password_registration( 'person@sub.blocked.example', 'valid-token' );
 
-		$this->assertWPError( $result );
 		$this->assertSame( 'unsafe_email', $result->get_error_code() );
 	}
 
-	public function test_rest_and_form_paths_use_shared_policy(): void {
-		$root         = dirname( __DIR__, 2 );
-		$form_source  = file_get_contents( $root . '/inc/auth/register.php' );
-		$token_source = file_get_contents( $root . '/inc/auth-tokens/service.php' );
+	public function test_rest_service_preserves_structured_rate_limit_error(): void {
+		$this->use_turnstile_result( true );
+		$error = extrachill_users_registration_rate_limit_error( time() + 300 );
+		$this->use_admission_result( $error );
 
-		$this->assertGreaterThanOrEqual( 2, substr_count( $form_source, 'extrachill_users_validate_password_registration' ) );
-		$this->assertStringContainsString( 'extrachill_users_validate_password_registration( $email, $turnstile_token )', $token_source );
+		$result = extrachill_users_register_with_tokens(
+			array(
+				'email'              => 'person@example.com',
+				'password'           => 'secure-password',
+				'password_confirm'   => 'secure-password',
+				'device_id'          => '123e4567-e89b-42d3-a456-426614174000',
+				'turnstile_response' => 'valid-token',
+			)
+		);
+
+		$this->assertSame( $error, $result );
+		$this->assertSame( 429, $result->get_error_data()['status'] );
+		$this->assertArrayHasKey( 'retry_after', $result->get_error_data() );
+		$this->assertArrayHasKey( 'expires_at', $result->get_error_data() );
+	}
+
+	public function test_form_adapter_propagates_safe_policy_error(): void {
+		$this->use_turnstile_result( true );
+		$this->use_admission_result( new WP_Error( 'registration_rate_limited', 'Try later.', array( 'status' => 429 ) ) );
+
+		$result = extrachill_users_validate_registration_form_request(
+			array(
+				'extrachill_email'      => 'person@example.com',
+				'cf-turnstile-response' => 'valid-token',
+			)
+		);
+
+		$this->assertSame( 'registration_rate_limited', $result->get_error_code() );
+		$this->assertSame( 'Try later.', $result->get_error_message() );
+		$this->assertSame( 429, $result->get_error_data()['status'] );
 	}
 
 	public function test_google_registration_does_not_enter_password_policy(): void {
 		$this->use_turnstile_result( new WP_Error( 'unexpected_turnstile', 'Password policy ran.' ) );
-		update_site_option( 'banned_email_domains', array( 'blocked.example' ) );
+		$this->use_admission_result( new WP_Error( 'unexpected_admission', 'Password policy ran.' ) );
 
 		$result = ec_oauth_google_user(
 			array(
 				'google_id' => 'google-registration-policy-test',
-				'email'     => 'google-user@blocked.example',
+				'email'     => 'google-user@example.com',
 				'name'      => 'Google User',
 			)
 		);
 
 		$this->assertIsArray( $result );
 		$this->assertTrue( $result['is_new'] );
+	}
+
+	private function clear_registration_counter(): void {
+		$key = extrachill_users_registration_attempt_key();
+		if ( '' !== $key ) {
+			wp_cache_delete( $key, EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP );
+		}
 	}
 
 	private function use_turnstile_result( $result ): void {
@@ -159,6 +240,23 @@ class Test_Registration_Anti_Automation extends WP_UnitTestCase {
 					$this->assertSame( $expected_token, $token );
 					return new WP_Error( $code, 'Turnstile rejected.', array( 'status' => 403 ) );
 				};
+			}
+		);
+	}
+
+	private function use_admission_result( $result ): void {
+		$this->use_admission_callback(
+			static function () use ( $result ) {
+				return $result;
+			}
+		);
+	}
+
+	private function use_admission_callback( callable $callback ): void {
+		add_filter(
+			'extrachill_users_registration_admitter',
+			static function () use ( $callback ) {
+				return $callback;
 			}
 		);
 	}

--- a/tests/unit/RegistrationAntiAutomationTest.php
+++ b/tests/unit/RegistrationAntiAutomationTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Password registration anti-automation policy tests.
+ *
+ * @package ExtraChill\Users
+ */
+
+class Test_Registration_Anti_Automation extends WP_UnitTestCase {
+	private const IP = '203.0.113.30';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$_SERVER['REMOTE_ADDR'] = self::IP;
+		unset( $_SERVER['HTTP_EXTRACHILL_CLIENT'] );
+		delete_transient( extrachill_users_registration_attempt_key() );
+	}
+
+	protected function tearDown(): void {
+		delete_transient( extrachill_users_registration_attempt_key() );
+		remove_all_filters( 'extrachill_users_registration_turnstile_verifier' );
+		delete_site_option( 'banned_email_domains' );
+		unset( $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_EXTRACHILL_CLIENT'] );
+		parent::tearDown();
+	}
+
+	public function test_valid_registration_policy_passes(): void {
+		$this->use_turnstile_result( true );
+
+		$this->assertTrue( extrachill_users_validate_password_registration( 'person@example.com', 'valid-token' ) );
+	}
+
+	public function test_missing_turnstile_is_rejected(): void {
+		$this->use_turnstile_error_for_token( '', 'turnstile_missing_token' );
+
+		$result = extrachill_users_validate_password_registration( 'person@example.com', '' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'turnstile_missing_token', $result->get_error_code() );
+	}
+
+	public function test_invalid_turnstile_is_rejected(): void {
+		$this->use_turnstile_error_for_token( 'invalid-token', 'turnstile_failed' );
+
+		$result = extrachill_users_validate_password_registration( 'person@example.com', 'invalid-token' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'turnstile_failed', $result->get_error_code() );
+	}
+
+	public function test_spoofed_app_header_does_not_bypass_turnstile(): void {
+		$_SERVER['HTTP_EXTRACHILL_CLIENT'] = 'app';
+		$this->use_turnstile_error_for_token( '', 'turnstile_missing_token' );
+
+		$result = extrachill_users_validate_password_registration( 'person@example.com', '' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'turnstile_missing_token', $result->get_error_code() );
+	}
+
+	public function test_sixth_attempt_is_blocked_at_exact_boundary(): void {
+		$this->use_turnstile_result( true );
+
+		for ( $attempt = 1; $attempt <= EXTRACHILL_USERS_REGISTRATION_RATE_LIMIT; ++$attempt ) {
+			$this->assertTrue( extrachill_users_validate_password_registration( "person{$attempt}@example.com", 'valid-token' ) );
+		}
+
+		$result = extrachill_users_validate_password_registration( 'blocked@example.com', 'valid-token' );
+		$this->assertWPError( $result );
+		$this->assertSame( 'registration_rate_limited', $result->get_error_code() );
+		$this->assertSame( 429, $result->get_error_data()['status'] );
+	}
+
+	public function test_attempts_do_not_extend_expiry_and_reset_after_expiration(): void {
+		$this->use_turnstile_result( true );
+		extrachill_users_validate_password_registration( 'first@example.com', 'valid-token' );
+		$first_state = extrachill_users_registration_attempt_state();
+		extrachill_users_validate_password_registration( 'second@example.com', 'valid-token' );
+		$second_state = extrachill_users_registration_attempt_state();
+
+		$this->assertSame( $first_state['expires_at'], $second_state['expires_at'] );
+
+		set_transient(
+			extrachill_users_registration_attempt_key(),
+			array(
+				'attempts'   => EXTRACHILL_USERS_REGISTRATION_RATE_LIMIT,
+				'expires_at' => time() - 1,
+			),
+			MINUTE_IN_SECONDS
+		);
+
+		$this->assertTrue( extrachill_users_validate_password_registration( 'reset@example.com', 'valid-token' ) );
+		$this->assertSame( 1, extrachill_users_registration_attempt_state()['attempts'] );
+	}
+
+	public function test_rate_limit_response_preserves_fixed_expiry(): void {
+		$this->use_turnstile_result( true );
+		for ( $attempt = 0; $attempt < EXTRACHILL_USERS_REGISTRATION_RATE_LIMIT; ++$attempt ) {
+			extrachill_users_validate_password_registration( "person{$attempt}@example.com", 'valid-token' );
+		}
+
+		$first  = extrachill_users_check_registration_rate_limit();
+		$second = extrachill_users_check_registration_rate_limit();
+
+		$this->assertSame( $first->get_error_data()['expires_at'], $second->get_error_data()['expires_at'] );
+		$this->assertGreaterThan( 0, $first->get_error_data()['retry_after'] );
+	}
+
+	public function test_network_banned_domain_is_rejected(): void {
+		$this->use_turnstile_result( true );
+		update_site_option( 'banned_email_domains', array( 'blocked.example' ) );
+
+		$result = extrachill_users_validate_password_registration( 'person@sub.blocked.example', 'valid-token' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'unsafe_email', $result->get_error_code() );
+	}
+
+	public function test_rest_and_form_paths_use_shared_policy(): void {
+		$root         = dirname( __DIR__, 2 );
+		$form_source  = file_get_contents( $root . '/inc/auth/register.php' );
+		$token_source = file_get_contents( $root . '/inc/auth-tokens/service.php' );
+
+		$this->assertGreaterThanOrEqual( 2, substr_count( $form_source, 'extrachill_users_validate_password_registration' ) );
+		$this->assertStringContainsString( 'extrachill_users_validate_password_registration( $email, $turnstile_token )', $token_source );
+	}
+
+	public function test_google_registration_does_not_enter_password_policy(): void {
+		$this->use_turnstile_result( new WP_Error( 'unexpected_turnstile', 'Password policy ran.' ) );
+		update_site_option( 'banned_email_domains', array( 'blocked.example' ) );
+
+		$result = ec_oauth_google_user(
+			array(
+				'google_id' => 'google-registration-policy-test',
+				'email'     => 'google-user@blocked.example',
+				'name'      => 'Google User',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['is_new'] );
+	}
+
+	private function use_turnstile_result( $result ): void {
+		add_filter(
+			'extrachill_users_registration_turnstile_verifier',
+			static function () use ( $result ) {
+				return static function () use ( $result ) {
+					return $result;
+				};
+			}
+		);
+	}
+
+	private function use_turnstile_error_for_token( string $expected_token, string $code ): void {
+		add_filter(
+			'extrachill_users_registration_turnstile_verifier',
+			function () use ( $expected_token, $code ) {
+				return function ( string $token ) use ( $expected_token, $code ) {
+					$this->assertSame( $expected_token, $token );
+					return new WP_Error( $code, 'Turnstile rejected.', array( 'status' => 403 ) );
+				};
+			}
+		);
+	}
+}

--- a/tests/unit/WpNativeRegistrationPolicyTest.php
+++ b/tests/unit/WpNativeRegistrationPolicyTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Extra Chill policy for the generic wp-native registration ability.
+ *
+ * @package ExtraChill\Users
+ */
+
+class Test_Wp_Native_Registration_Policy extends WP_UnitTestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		if ( ! function_exists( 'extrachill_users_wp_native_pre_register' ) ) {
+			require_once dirname( __DIR__, 2 ) . '/inc/wp-native-bridge.php';
+		}
+	}
+
+	public function test_native_registration_fails_closed_before_user_creation(): void {
+		$registration_data = array(
+			'email'    => 'native-registration@example.com',
+			'password' => 'secure-password',
+			'username' => 'nativeuser',
+		);
+
+		$result = extrachill_users_wp_native_pre_register( null, $registration_data, array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'extrachill_registration_surface_unavailable', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+		$this->assertFalse( email_exists( 'native-registration@example.com' ) );
+	}
+}


### PR DESCRIPTION
## Summary

- require Turnstile for every branded email/password registration request, including callers that spoof `X-ExtraChill-Client: app`
- atomically enforce one network-wide registration budget across all multisite hostnames after Turnstile succeeds
- apply WordPress multisite unsafe-domain validation consistently and fail the generic wp-native registration ability closed at the Extra Chill consumer layer
- add behavioral and atomic-seam coverage for ordering, concurrency boundaries, multisite scope, status propagation, and unaffected Google registration

## Threat model and prior behavior

Anonymous callers control request headers, registration payloads, and which Extra Chill hostname receives a request. Before this change:

- `extrachill_users_register_with_tokens()` trusted `X-ExtraChill-Client: app` and skipped Turnstile, with no edge signature, shared secret, authenticated proxy assertion, or other server-verifiable proof protecting that header
- password registration had no dedicated attempt bound
- direct branded registration did not apply the multisite network's banned-domain policy
- the generic public `wp-native/auth-register` ability could create a password account without carrying Extra Chill's required Turnstile proof

## Policy boundary

The shared site policy remains in Extra Chill Users as `extrachill_users_validate_password_registration()`. Both branded password entrypoints execute it before user creation:

- `POST /wp-json/extrachill/v1/auth/register` delegates to `extrachill_users_register_with_tokens()`
- `admin-post.php?action=extrachill_register_user` delegates through `extrachill_users_validate_registration_form_request()`

The boundary directly reuses Extra Chill Network's `ec_turnstile_check_request()` verifier and WordPress core's `is_email_address_unsafe()` primitive. No policy was added to generic wp-native Auth.

The generic `wp-native/auth-register` ability is publicly registered upstream with `__return_true`, but its schema cannot carry a Turnstile response. Extra Chill Users now returns `extrachill_registration_surface_unavailable` from its existing `wp_native_auth_pre_register` consumer filter before user creation. Future site exposure must either route through the branded policy boundary or provide server-verifiable context capable of running the same site policy first.

Google OAuth remains outside the password boundary because it requires a cryptographically verified `email_verified=true` claim. Email activation remains scoped to #245.

## Atomic network throttle

The corrected order is:

1. Verify Turnstile.
2. Atomically admit/count the verified request.
3. Apply unsafe-domain and remaining registration validation.
4. Create the user only if all checks pass.

Missing or invalid CAPTCHA requests do **not** consume the IP budget, preventing cheap shared-NAT lockouts.

Throttle semantics:

- Dimension: requester IP, stored only as a salted HMAC fragment
- Scope: one global object-cache group shared across every blog in the current network; network ID remains in the key to isolate separate multisite networks
- Primitive: established persistent-cache `wp_cache_add()` for the first request and atomic `wp_cache_incr()` for concurrent followers, matching the existing Extra Chill analytics admission pattern
- Limit: five Turnstile-verified password-registration attempts per IP
- Window: aligned fixed 15-minute bucket; the key and expiry are deterministic for the bucket and increments preserve the original TTL
- Boundary: counts 1-5 are admitted; count 6+ returns `registration_rate_limited`
- Failure behavior: missing `REMOTE_ADDR`, unavailable persistent object cache, unavailable atomic primitives, or failed increments return `registration_limiter_unavailable` with HTTP 503 rather than weakening enforcement
- Response: HTTP 429 with canonical `retry_after` and `expires_at` metadata preserved through the REST service

## Unsafe domains

After Turnstile and atomic admission, syntactically valid emails are checked with core `is_email_address_unsafe()`. Exact banned domains and their subdomains are rejected consistently in both branded paths with `unsafe_email` and HTTP 400. No plugin-owned domain list was introduced.

## Tests

Focused coverage now includes:

- valid registration policy
- missing/invalid Turnstile and spoofed app headers
- CAPTCHA-before-throttle ordering and proof that failed CAPTCHA does not consume admission
- atomic exact boundary (five admitted, sixth rejected, atomic counter reaches six)
- fixed-window reset behavior
- global counter behavior across `switch_to_blog()`
- fail-closed missing `REMOTE_ADDR`
- unsafe network domains
- behavioral REST service propagation of the exact structured 429 `WP_Error`
- behavioral form adapter propagation of safe policy errors
- Google registration remaining outside password policy
- generic wp-native registration failing closed before user creation
- existing artist-invitation registration behavior through deterministic Turnstile/admission seams

The former source-string consistency assertions were removed.

## Verification

Passing:

- `php -l` on all six changed PHP files
- `git diff --check origin/main...HEAD`
- changed-file PHPCS: no findings, Homeboy run `cbbb5834-1f6b-4c99-95a8-5735805b5cda`
- PR architecture audit: no introduced findings, Homeboy run `5c157aaf-97a6-4d7c-8f22-6c90d546854d`
- branch rebased onto current `origin/main` (`8cd921d`)

Focused PHPUnit was rerun for `RegistrationAntiAutomationTest.php`, `ArtistInvitationRegistrationTest.php`, and `WpNativeRegistrationPolicyTest.php`, but WP Codebox again failed before PHPUnit execution. Homeboy run `66b3fdb9-c635-4692-91c7-4ae2ac2fe0d9` records `executions: []`, `commands: []`, failure phase `preview:loading-wordpress`, and `wp-codebox-playground-startup-asset-unavailable` after timing out on `/mnt/extrachill-workspace/playground-cache/7.0.2.zip.lock`. This is the known infrastructure blocker Automattic/wp-codebox#1941, not a PHPUnit result.

The known full-lint PHPStan WordPress-symbol blocker remains tracked in #240; repository-wide PHPCS debt remains #243. Changed-file PHPCS is clean.

Structured retry metadata is canonical and behaviorally covered here. Countdown/disable UX for the React form and any richer legacy redirect presentation are deliberately scoped to #247.

Closes #244