### PR TITLE
chore: pin release tests to PHP 8.4

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -2,7 +2,11 @@
   "auto_cleanup": false,
   "changelog_target": "docs/CHANGELOG.md",
   "extensions": {
-    "wordpress": {}
+    "wordpress": {
+      "settings": {
+        "wordpress_runtime_php_version": "8.4"
+      }
+    }
   },
   "id": "extrachill-users",
   "remote_path": "wp-content/plugins/extrachill-users",


### PR DESCRIPTION
## Summary
- run disposable WP Codebox release tests on PHP 8.4
- match the production server and Composer dependency resolution environment

## Verification
- Homeboy configuration parses successfully
- `git diff --check`