### PR TITLE
fix: make browser handoff consumption atomic

### DIFF
--- a/inc/auth-tokens/browser-handoff-token.php
+++ b/inc/auth-tokens/browser-handoff-token.php
@@ -44,18 +44,45 @@ function extrachill_users_create_browser_handoff_token( int $user_id, string $re
  * @return array|WP_Error Payload array.
  */
 function extrachill_users_consume_browser_handoff_token( string $token ) {
+	global $wpdb;
+
 	$token = trim( $token );
 	if ( '' === $token ) {
 		return new WP_Error( 'invalid_handoff_token', 'Invalid handoff token.', array( 'status' => 400 ) );
 	}
 
-	$key     = 'ec_browser_handoff_' . hash( 'sha256', $token );
-	$payload = get_site_transient( $key );
-	delete_site_transient( $key );
+	$token_hash = hash( 'sha256', $token );
+	$key        = 'ec_browser_handoff_' . $token_hash;
+	$db_lock    = 'ec_handoff_' . substr( $token_hash, 0, 53 );
 
-	if ( ! is_array( $payload ) || empty( $payload['user_id'] ) || empty( $payload['redirect_url'] ) ) {
+	// Network options have no unique database key, and an object-cache drop-in
+	// may degrade to process-local storage. This lock is atomic across workers,
+	// creates no rows, and is released automatically if the connection dies.
+	$claimed = '1' === (string) $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, 0)', $db_lock ) );
+
+	if ( ! $claimed ) {
 		return new WP_Error( 'invalid_handoff_token', 'Invalid or expired handoff token.', array( 'status' => 400 ) );
 	}
 
-	return $payload;
+	try {
+		$payload = get_site_transient( $key );
+		$deleted = delete_site_transient( $key );
+		$now     = time();
+
+		if (
+			! $deleted
+			|| ! is_array( $payload )
+			|| empty( $payload['user_id'] )
+			|| empty( $payload['redirect_url'] )
+			|| empty( $payload['created_at_ts'] )
+			|| (int) $payload['created_at_ts'] > $now
+			|| ( $now - (int) $payload['created_at_ts'] ) >= 60
+		) {
+			return new WP_Error( 'invalid_handoff_token', 'Invalid or expired handoff token.', array( 'status' => 400 ) );
+		}
+
+		return $payload;
+	} finally {
+		$wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $db_lock ) );
+	}
 }

--- a/tests/unit/BrowserHandoffTokenTest.php
+++ b/tests/unit/BrowserHandoffTokenTest.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Unit tests for atomic browser handoff token consumption.
+ */
+
+class Browser_Handoff_Test_Cache {
+
+	/** @var array */
+	private $data = array();
+
+	/** @var bool */
+	public $fail_delete = false;
+
+	public function set( $key, $value, $group = 'default', $expiration = 0 ): bool {
+		$this->data[ $group . ':' . $key ] = array(
+			'value'      => $value,
+			'expires_at' => $expiration ? time() + (int) $expiration : 0,
+		);
+		return true;
+	}
+
+	public function get( $key, $group = 'default', $force = false, &$found = null ) {
+		$id    = $group . ':' . $key;
+		$entry = $this->data[ $id ] ?? null;
+		if ( is_array( $entry ) && ( empty( $entry['expires_at'] ) || $entry['expires_at'] > time() ) ) {
+			$found = true;
+			return $entry['value'];
+		}
+
+		unset( $this->data[ $id ] );
+		$found = false;
+		return false;
+	}
+
+	public function delete( $key, $group = 'default' ): bool {
+		$id = $group . ':' . $key;
+		if ( $this->fail_delete || ! isset( $this->data[ $id ] ) ) {
+			return false;
+		}
+
+		unset( $this->data[ $id ] );
+		return true;
+	}
+}
+
+/**
+ * Deterministic named-lock double that pauses the winner after claiming.
+ */
+class Browser_Handoff_Lock_Database {
+
+	/** @var bool */
+	public $fail_lock = false;
+
+	/** @var callable|null */
+	public $after_claim;
+
+	/** @var bool */
+	private $locked = false;
+
+	public function prepare( string $query, ...$args ): array {
+		return array( $query, $args );
+	}
+
+	public function get_var( $query ) {
+		if ( 0 === strpos( $query[0], 'SELECT GET_LOCK' ) ) {
+			if ( $this->fail_lock || $this->locked ) {
+				return '0';
+			}
+
+			$this->locked = true;
+			if ( is_callable( $this->after_claim ) ) {
+				call_user_func( $this->after_claim );
+			}
+			return '1';
+		}
+
+		$this->locked = false;
+		return '1';
+	}
+}
+
+class Test_Browser_Handoff_Token extends WP_UnitTestCase {
+
+	/** @var mixed */
+	private $original_cache;
+
+	/** @var bool */
+	private $original_ext_cache;
+
+	/** @var mixed */
+	private $original_database;
+
+	/** @var Browser_Handoff_Test_Cache */
+	private $cache;
+
+	/** @var Browser_Handoff_Lock_Database */
+	private $database;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->original_cache     = $GLOBALS['wp_object_cache'];
+		$this->original_database  = $GLOBALS['wpdb'];
+		$this->original_ext_cache = wp_using_ext_object_cache();
+		$this->cache              = new Browser_Handoff_Test_Cache();
+		$this->database           = new Browser_Handoff_Lock_Database();
+		$GLOBALS['wp_object_cache'] = $this->cache;
+		$GLOBALS['wpdb']            = $this->database;
+		wp_using_ext_object_cache( true );
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['wp_object_cache'] = $this->original_cache;
+		$GLOBALS['wpdb']            = $this->original_database;
+		wp_using_ext_object_cache( $this->original_ext_cache );
+		parent::tearDown();
+	}
+
+	public function test_concurrent_consumers_have_exactly_one_winner(): void {
+		$token       = extrachill_users_create_browser_handoff_token( 42, 'https://community.extrachill.com/settings/' );
+		$competitors = array();
+
+		// Hold the winner immediately after its atomic claim, then release every
+		// competitor at that barrier before the winner reads or deletes payload.
+		$this->database->after_claim = function () use ( $token, &$competitors ): void {
+			for ( $i = 0; $i < 3; $i++ ) {
+				$competitors[] = extrachill_users_consume_browser_handoff_token( $token );
+			}
+		};
+
+		$winner = extrachill_users_consume_browser_handoff_token( $token );
+
+		$this->assertIsArray( $winner, 'Exactly one concurrent consumer must receive the payload.' );
+		$this->assertSame( 42, (int) $winner['user_id'] );
+		$this->assertCount( 3, $competitors );
+		foreach ( $competitors as $competitor ) {
+			$this->assertWPError( $competitor );
+			$this->assertSame( 'invalid_handoff_token', $competitor->get_error_code() );
+		}
+
+		$replay = extrachill_users_consume_browser_handoff_token( $token );
+		$this->assertWPError( $replay );
+		$this->assertSame( 'invalid_handoff_token', $replay->get_error_code() );
+	}
+
+	public function test_atomic_claim_storage_failure_fails_closed(): void {
+		$token                     = extrachill_users_create_browser_handoff_token( 42, 'https://extrachill.com/' );
+		$this->database->fail_lock = true;
+
+		$result = extrachill_users_consume_browser_handoff_token( $token );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_handoff_token', $result->get_error_code() );
+	}
+
+	public function test_payload_delete_failure_fails_closed(): void {
+		$token                    = extrachill_users_create_browser_handoff_token( 42, 'https://extrachill.com/' );
+		$this->cache->fail_delete = true;
+
+		$result = extrachill_users_consume_browser_handoff_token( $token );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_handoff_token', $result->get_error_code() );
+	}
+
+	public function test_missing_and_expired_payloads_fail_closed(): void {
+		$missing = extrachill_users_consume_browser_handoff_token( 'missing-token' );
+		$this->assertWPError( $missing );
+		$this->assertSame( 'invalid_handoff_token', $missing->get_error_code() );
+
+		$token = 'expired-token';
+		$key   = 'ec_browser_handoff_' . hash( 'sha256', $token );
+		set_site_transient(
+			$key,
+			array(
+				'user_id'       => 42,
+				'redirect_url'  => 'https://extrachill.com/',
+				'created_at_ts' => time() - 60,
+			),
+			60
+		);
+
+		$expired = extrachill_users_consume_browser_handoff_token( $token );
+		$this->assertWPError( $expired );
+		$this->assertSame( 'invalid_handoff_token', $expired->get_error_code() );
+	}
+}


### PR DESCRIPTION
## Summary
- serialize browser handoff consumption with a hashed MySQL advisory lock
- fail closed when the lock, payload, expiry validation, or payload deletion fails
- add a deterministic barrier-controlled race test covering one winner, competing losers, replay, expiry, and storage failures

## Root cause
`extrachill_users_consume_browser_handoff_token()` read the site transient and deleted it in separate operations. Concurrent workers could both read the payload before either deletion completed, allowing one documented single-use token to authenticate twice.

## Atomic primitive
Consumption now claims `GET_LOCK()` with a 64-character name derived from the token's SHA-256 hash and a zero-second timeout. MySQL advisory locks serialize workers without adding a table or persistent row. Network options were rejected because multisite `sitemeta` does not uniquely constrain `(site_id, meta_key)`, and object-cache claims were rejected because a drop-in may degrade to process-local storage during a backend failure.

The payload is returned only after a successful claim, successful transient deletion, structural validation, and explicit 60-second age validation. Lock acquisition, cache misses, malformed/expired payloads, and deletion failures all return `invalid_handoff_token`.

## Crash and cleanup semantics
The lock is released in `finally`, and MySQL releases it automatically if the connection dies. No per-token lock rows or cache keys remain. A crash before payload deletion leaves the unexpired token available because no authentication payload was returned; a crash after deletion burns the token. Lock names and transient keys contain only token hashes, never plaintext tokens.

## Concurrency test
`Test_Browser_Handoff_Token::test_concurrent_consumers_have_exactly_one_winner()` pauses the winning consumer immediately after advisory-lock acquisition, releases three competitors before the winner reads or deletes the payload, and asserts:
- exactly one payload winner
- all three competitors return `invalid_handoff_token`
- a later replay returns `invalid_handoff_token`

Additional tests cover lock storage failure, transient deletion failure, missing payloads, and expired payloads.

## Verification
- `php -l inc/auth-tokens/browser-handoff-token.php` passed
- `php -l tests/unit/BrowserHandoffTokenTest.php` passed
- `git diff --check` passed
- `homeboy --placement local review test --path /var/lib/datamachine/workspace/extrachill-users@fix-253-atomic-handoff --skip-lint -- --filter Test_Browser_Handoff_Token` passed: 4 tests, 19 assertions
- PHPCS passed for both changed files
- Scoped PHPStan remains red with 7 WordPress-stub findings in the touched production file: four core functions are absent from the analyzer stubs and its `WP_Error` constructor stub incorrectly allows only two arguments
- Full PHPUnit baseline reached 317 tests (182 passed, 7 skipped, 128 failed); failures are unrelated fixture errors because the WP Codebox SQLite environment lacks `wp_datamachine_event_dates`

## Security impact
This closes the concurrent replay window for browser handoff tokens and makes storage ambiguity fail closed rather than authenticating.

Closes #253