### PR TITLE
fix: make browser handoff lock portable

### DIFF
--- a/docs/browser-handoff.md
+++ b/docs/browser-handoff.md
@@ -19,8 +19,9 @@ The browser handoff system lets a user authenticate in a non-browser client (e.g
 - Function: `extrachill_users_consume_browser_handoff_token( string $token )`
 - File: `inc/auth-tokens/browser-handoff-token.php`
 - Behavior:
-  - Reads payload from the site transient
-  - Deletes the transient immediately (single-use)
+  - Atomically claims a hashed key in the network main site's options table
+  - Reads and deletes the site-transient payload while holding the claim
+  - Releases only its own claim; scheduled expiry cleans claims after interruption
   - Returns `WP_Error( 'invalid_handoff_token', ... )` on invalid/expired tokens
 
 ### Browser handler

--- a/inc/auth-tokens/browser-handoff-token.php
+++ b/inc/auth-tokens/browser-handoff-token.php
@@ -13,6 +13,11 @@
 
 defined( 'ABSPATH' ) || exit;
 
+const EXTRACHILL_USERS_BROWSER_HANDOFF_TTL                = 60;
+const EXTRACHILL_USERS_BROWSER_HANDOFF_CLAIM_CLEANUP_HOOK = 'extrachill_users_cleanup_browser_handoff_claim';
+
+add_action( EXTRACHILL_USERS_BROWSER_HANDOFF_CLAIM_CLEANUP_HOOK, 'extrachill_users_cleanup_browser_handoff_claim', 10, 2 );
+
 /**
  * Create a single-use browser handoff token.
  *
@@ -31,7 +36,7 @@ function extrachill_users_create_browser_handoff_token( int $user_id, string $re
 			'redirect_url'  => $redirect_url,
 			'created_at_ts' => time(),
 		),
-		60
+		EXTRACHILL_USERS_BROWSER_HANDOFF_TTL
 	);
 
 	return $token;
@@ -44,8 +49,6 @@ function extrachill_users_create_browser_handoff_token( int $user_id, string $re
  * @return array|WP_Error Payload array.
  */
 function extrachill_users_consume_browser_handoff_token( string $token ) {
-	global $wpdb;
-
 	$token = trim( $token );
 	if ( '' === $token ) {
 		return new WP_Error( 'invalid_handoff_token', 'Invalid handoff token.', array( 'status' => 400 ) );
@@ -53,36 +56,147 @@ function extrachill_users_consume_browser_handoff_token( string $token ) {
 
 	$token_hash = hash( 'sha256', $token );
 	$key        = 'ec_browser_handoff_' . $token_hash;
-	$db_lock    = 'ec_handoff_' . substr( $token_hash, 0, 53 );
-
-	// Network options have no unique database key, and an object-cache drop-in
-	// may degrade to process-local storage. This lock is atomic across workers,
-	// creates no rows, and is released automatically if the connection dies.
-	$claimed = '1' === (string) $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, 0)', $db_lock ) );
+	$claim_key  = 'ec_browser_handoff_claim_' . $token_hash;
+	$claim      = array(
+		'owner'      => wp_generate_uuid4(),
+		'expires_at' => time() + EXTRACHILL_USERS_BROWSER_HANDOFF_TTL,
+	);
+	$claimed    = extrachill_users_claim_browser_handoff( $claim_key, $claim );
 
 	if ( ! $claimed ) {
 		return new WP_Error( 'invalid_handoff_token', 'Invalid or expired handoff token.', array( 'status' => 400 ) );
 	}
 
-	try {
-		$payload = get_site_transient( $key );
-		$deleted = delete_site_transient( $key );
-		$now     = time();
+	$payload  = get_site_transient( $key );
+	$deleted  = delete_site_transient( $key );
+	$now      = time();
+	$released = extrachill_users_cleanup_browser_handoff_claim( $claim_key, $claim );
 
-		if (
-			! $deleted
-			|| ! is_array( $payload )
-			|| empty( $payload['user_id'] )
-			|| empty( $payload['redirect_url'] )
-			|| empty( $payload['created_at_ts'] )
-			|| (int) $payload['created_at_ts'] > $now
-			|| ( $now - (int) $payload['created_at_ts'] ) >= 60
-		) {
-			return new WP_Error( 'invalid_handoff_token', 'Invalid or expired handoff token.', array( 'status' => 400 ) );
+	if (
+		! $released
+		|| ! $deleted
+		|| ! is_array( $payload )
+		|| empty( $payload['user_id'] )
+		|| empty( $payload['redirect_url'] )
+		|| empty( $payload['created_at_ts'] )
+		|| (int) $payload['created_at_ts'] > $now
+		|| ( $now - (int) $payload['created_at_ts'] ) >= EXTRACHILL_USERS_BROWSER_HANDOFF_TTL
+	) {
+		return new WP_Error( 'invalid_handoff_token', 'Invalid or expired handoff token.', array( 'status' => 400 ) );
+	}
+
+	return $payload;
+}
+
+/**
+ * Atomically claim a token through the main site's uniquely indexed options table.
+ *
+ * @param string $claim_key Hashed claim option name.
+ * @param array  $claim     Owner and expiry data.
+ * @return bool Whether the claim was acquired.
+ */
+function extrachill_users_claim_browser_handoff( string $claim_key, array $claim ): bool {
+	$main_site_id = is_multisite() ? get_main_site_id() : get_current_blog_id();
+	$switched     = get_current_blog_id() !== $main_site_id;
+
+	if ( $switched ) {
+		switch_to_blog( $main_site_id );
+	}
+
+	try {
+		$cleanup_scheduled = wp_schedule_single_event(
+			(int) $claim['expires_at'],
+			EXTRACHILL_USERS_BROWSER_HANDOFF_CLAIM_CLEANUP_HOOK,
+			array( $claim_key, $claim ),
+			true
+		);
+
+		if ( true !== $cleanup_scheduled ) {
+			return false;
 		}
 
-		return $payload;
+		if ( add_option( $claim_key, $claim, '', false ) ) {
+			return true;
+		}
+
+		wp_unschedule_event(
+			(int) $claim['expires_at'],
+			EXTRACHILL_USERS_BROWSER_HANDOFF_CLAIM_CLEANUP_HOOK,
+			array( $claim_key, $claim )
+		);
+
+		$existing_claim = get_option( $claim_key );
+		if ( is_array( $existing_claim ) && isset( $existing_claim['expires_at'] ) && (int) $existing_claim['expires_at'] <= time() ) {
+			extrachill_users_delete_browser_handoff_claim( $claim_key, $existing_claim );
+		}
+
+		return false;
 	} finally {
-		$wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $db_lock ) );
+		if ( $switched ) {
+			restore_current_blog();
+		}
 	}
+}
+
+/**
+ * Remove a claim only when its owner data still matches.
+ *
+ * This is both the scheduled crash cleanup callback and the normal release path.
+ *
+ * @param string $claim_key Hashed claim option name.
+ * @param array  $claim     Owner and expiry data.
+ * @return bool Whether the matching claim was released.
+ */
+function extrachill_users_cleanup_browser_handoff_claim( string $claim_key, array $claim ): bool {
+	$main_site_id = is_multisite() ? get_main_site_id() : get_current_blog_id();
+	$switched     = get_current_blog_id() !== $main_site_id;
+
+	if ( $switched ) {
+		switch_to_blog( $main_site_id );
+	}
+
+	try {
+		$deleted = extrachill_users_delete_browser_handoff_claim( $claim_key, $claim );
+		if ( $deleted ) {
+			wp_unschedule_event(
+				(int) $claim['expires_at'],
+				EXTRACHILL_USERS_BROWSER_HANDOFF_CLAIM_CLEANUP_HOOK,
+				array( $claim_key, $claim )
+			);
+		}
+
+		return $deleted;
+	} finally {
+		if ( $switched ) {
+			restore_current_blog();
+		}
+	}
+}
+
+/**
+ * Conditionally delete a claim without allowing an old owner to release a new one.
+ *
+ * @param string $claim_key Hashed claim option name.
+ * @param array  $claim     Owner and expiry data.
+ * @return bool Whether the matching claim was deleted.
+ */
+function extrachill_users_delete_browser_handoff_claim( string $claim_key, array $claim ): bool {
+	global $wpdb;
+
+	$deleted = $wpdb->delete(
+		$wpdb->options,
+		array(
+			'option_name'  => $claim_key,
+			'option_value' => maybe_serialize( $claim ),
+		),
+		array( '%s', '%s' )
+	);
+
+	if ( false === $deleted ) {
+		return false;
+	}
+
+	wp_cache_delete( $claim_key, 'options' );
+
+	return 1 === $deleted;
 }

--- a/tests/e2e/auth-multisite/assert.php
+++ b/tests/e2e/auth-multisite/assert.php
@@ -98,7 +98,26 @@ $handoff_token = (string) ( $handoff_query['ec_browser_handoff'] ?? '' );
 auth_fuzz_assert( 200 === $handoff->get_status() && 64 === strlen( $handoff_token ), 'Valid browser handoff was not created.' );
 $handoff_key = 'ec_browser_handoff_' . hash( 'sha256', $handoff_token );
 auth_fuzz_assert( is_array( get_site_transient( $handoff_key ) ), 'Browser handoff was not stored under its token hash.' );
-$consumed_handoff = extrachill_users_consume_browser_handoff_token( $handoff_token );
+$claim_control_key = 'ec_browser_handoff_claim_control_' . hash( 'sha256', $handoff_token );
+$main_site_id      = get_main_site_id();
+$consumer_site_id  = (int) get_sites( array( 'number' => 1, 'site__not_in' => array( $main_site_id ), 'fields' => 'ids' ) )[0];
+
+switch_to_blog( $main_site_id );
+try {
+	delete_option( $claim_control_key );
+	auth_fuzz_assert( add_option( $claim_control_key, 'winner', '', false ), 'Real options storage could not create an atomic claim.' );
+	auth_fuzz_assert( ! add_option( $claim_control_key, 'loser', '', false ), 'Real options storage allowed a duplicate atomic claim.' );
+	delete_option( $claim_control_key );
+} finally {
+	restore_current_blog();
+}
+
+switch_to_blog( $consumer_site_id );
+try {
+	$consumed_handoff = extrachill_users_consume_browser_handoff_token( $handoff_token );
+} finally {
+	restore_current_blog();
+}
 auth_fuzz_assert( is_array( $consumed_handoff ) && (int) $consumed_handoff['user_id'] === (int) $existing->ID, 'Valid browser handoff could not be consumed.' );
 auth_fuzz_assert( is_wp_error( extrachill_users_consume_browser_handoff_token( $handoff_token ) ), 'Browser handoff token was reusable.' );
 

--- a/tests/unit/BrowserHandoffTokenTest.php
+++ b/tests/unit/BrowserHandoffTokenTest.php
@@ -19,6 +19,16 @@ class Browser_Handoff_Test_Cache {
 		return true;
 	}
 
+	public function add( $key, $value, $group = 'default', $expiration = 0 ): bool {
+		$found = false;
+		$this->get( $key, $group, false, $found );
+		if ( $found ) {
+			return false;
+		}
+
+		return $this->set( $key, $value, $group, $expiration );
+	}
+
 	public function get( $key, $group = 'default', $force = false, &$found = null ) {
 		$id    = $group . ':' . $key;
 		$entry = $this->data[ $id ] ?? null;
@@ -43,42 +53,6 @@ class Browser_Handoff_Test_Cache {
 	}
 }
 
-/**
- * Deterministic named-lock double that pauses the winner after claiming.
- */
-class Browser_Handoff_Lock_Database {
-
-	/** @var bool */
-	public $fail_lock = false;
-
-	/** @var callable|null */
-	public $after_claim;
-
-	/** @var bool */
-	private $locked = false;
-
-	public function prepare( string $query, ...$args ): array {
-		return array( $query, $args );
-	}
-
-	public function get_var( $query ) {
-		if ( 0 === strpos( $query[0], 'SELECT GET_LOCK' ) ) {
-			if ( $this->fail_lock || $this->locked ) {
-				return '0';
-			}
-
-			$this->locked = true;
-			if ( is_callable( $this->after_claim ) ) {
-				call_user_func( $this->after_claim );
-			}
-			return '1';
-		}
-
-		$this->locked = false;
-		return '1';
-	}
-}
-
 class Test_Browser_Handoff_Token extends WP_UnitTestCase {
 
 	/** @var mixed */
@@ -87,46 +61,37 @@ class Test_Browser_Handoff_Token extends WP_UnitTestCase {
 	/** @var bool */
 	private $original_ext_cache;
 
-	/** @var mixed */
-	private $original_database;
-
 	/** @var Browser_Handoff_Test_Cache */
 	private $cache;
-
-	/** @var Browser_Handoff_Lock_Database */
-	private $database;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->original_cache     = $GLOBALS['wp_object_cache'];
-		$this->original_database  = $GLOBALS['wpdb'];
 		$this->original_ext_cache = wp_using_ext_object_cache();
 		$this->cache              = new Browser_Handoff_Test_Cache();
-		$this->database           = new Browser_Handoff_Lock_Database();
 		$GLOBALS['wp_object_cache'] = $this->cache;
-		$GLOBALS['wpdb']            = $this->database;
 		wp_using_ext_object_cache( true );
 	}
 
 	protected function tearDown(): void {
 		$GLOBALS['wp_object_cache'] = $this->original_cache;
-		$GLOBALS['wpdb']            = $this->original_database;
 		wp_using_ext_object_cache( $this->original_ext_cache );
 		parent::tearDown();
 	}
 
 	public function test_concurrent_consumers_have_exactly_one_winner(): void {
 		$token       = extrachill_users_create_browser_handoff_token( 42, 'https://community.extrachill.com/settings/' );
+		$claim_key   = 'ec_browser_handoff_claim_' . hash( 'sha256', $token );
 		$competitors = array();
 
-		// Hold the winner immediately after its atomic claim, then release every
-		// competitor at that barrier before the winner reads or deletes payload.
-		$this->database->after_claim = function () use ( $token, &$competitors ): void {
+		// Core fires this hook after the unique option row exists but before the
+		// winning add_option() returns, providing a deterministic race barrier.
+		add_action( 'add_option_' . $claim_key, function () use ( $token, &$competitors ): void {
 			for ( $i = 0; $i < 3; $i++ ) {
 				$competitors[] = extrachill_users_consume_browser_handoff_token( $token );
 			}
-		};
+		} );
 
 		$winner = extrachill_users_consume_browser_handoff_token( $token );
 
@@ -144,10 +109,24 @@ class Test_Browser_Handoff_Token extends WP_UnitTestCase {
 	}
 
 	public function test_atomic_claim_storage_failure_fails_closed(): void {
-		$token                     = extrachill_users_create_browser_handoff_token( 42, 'https://extrachill.com/' );
-		$this->database->fail_lock = true;
+		global $wpdb;
+
+		$token     = extrachill_users_create_browser_handoff_token( 42, 'https://extrachill.com/' );
+		$claim_key = 'ec_browser_handoff_claim_' . hash( 'sha256', $token );
+		$filter    = static function ( string $query ) use ( $claim_key ): string {
+			if ( false !== strpos( $query, 'INSERT INTO' ) && false !== strpos( $query, $claim_key ) ) {
+				return str_replace( $GLOBALS['wpdb']->options, 'missing_handoff_options', $query );
+			}
+			return $query;
+		};
+
+		$wpdb->suppress_errors( true );
+		add_filter( 'query', $filter );
 
 		$result = extrachill_users_consume_browser_handoff_token( $token );
+
+		remove_filter( 'query', $filter );
+		$wpdb->suppress_errors( false );
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'invalid_handoff_token', $result->get_error_code() );
@@ -161,6 +140,32 @@ class Test_Browser_Handoff_Token extends WP_UnitTestCase {
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'invalid_handoff_token', $result->get_error_code() );
+	}
+
+	public function test_claim_release_storage_failure_fails_closed(): void {
+		global $wpdb;
+
+		$token     = extrachill_users_create_browser_handoff_token( 42, 'https://extrachill.com/' );
+		$claim_key = 'ec_browser_handoff_claim_' . hash( 'sha256', $token );
+		$filter    = static function ( string $query ) use ( $claim_key ): string {
+			if ( false !== strpos( $query, 'DELETE FROM' ) && false !== strpos( $query, $claim_key ) ) {
+				return str_replace( $GLOBALS['wpdb']->options, 'missing_handoff_options', $query );
+			}
+			return $query;
+		};
+
+		$wpdb->suppress_errors( true );
+		add_filter( 'query', $filter );
+		$result = extrachill_users_consume_browser_handoff_token( $token );
+		remove_filter( 'query', $filter );
+		$wpdb->suppress_errors( false );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_handoff_token', $result->get_error_code() );
+
+		$claim = get_option( $claim_key );
+		$this->assertIsArray( $claim );
+		extrachill_users_cleanup_browser_handoff_claim( $claim_key, $claim );
 	}
 
 	public function test_missing_and_expired_payloads_fail_closed(): void {
@@ -183,5 +188,66 @@ class Test_Browser_Handoff_Token extends WP_UnitTestCase {
 		$expired = extrachill_users_consume_browser_handoff_token( $token );
 		$this->assertWPError( $expired );
 		$this->assertSame( 'invalid_handoff_token', $expired->get_error_code() );
+	}
+
+	public function test_claim_cleanup_is_owner_safe(): void {
+		$claim_key = 'ec_browser_handoff_claim_' . hash( 'sha256', 'cleanup-token' );
+		$old_claim = array(
+			'owner'      => 'old-owner',
+			'expires_at' => time() - 1,
+		);
+		$new_claim = array(
+			'owner'      => 'new-owner',
+			'expires_at' => time() + 60,
+		);
+
+		$this->assertTrue( add_option( $claim_key, $new_claim, '', false ) );
+		extrachill_users_cleanup_browser_handoff_claim( $claim_key, $old_claim );
+		$this->assertSame( $new_claim, get_option( $claim_key ) );
+
+		extrachill_users_cleanup_browser_handoff_claim( $claim_key, $new_claim );
+		$this->assertFalse( get_option( $claim_key ) );
+	}
+
+	public function test_interrupted_claim_has_scheduled_cleanup(): void {
+		$claim_key = 'ec_browser_handoff_claim_' . hash( 'sha256', 'interrupted-token' );
+		$claim     = array(
+			'owner'      => 'interrupted-owner',
+			'expires_at' => time() + 60,
+		);
+		$args      = array( $claim_key, $claim );
+
+		$this->assertTrue( extrachill_users_claim_browser_handoff( $claim_key, $claim ) );
+		$this->assertSame( $claim['expires_at'], wp_next_scheduled( EXTRACHILL_USERS_BROWSER_HANDOFF_CLAIM_CLEANUP_HOOK, $args ) );
+
+		extrachill_users_cleanup_browser_handoff_claim( $claim_key, $claim );
+		$this->assertFalse( get_option( $claim_key ) );
+		$this->assertFalse( wp_next_scheduled( EXTRACHILL_USERS_BROWSER_HANDOFF_CLAIM_CLEANUP_HOOK, $args ) );
+	}
+
+	public function test_claims_use_the_main_site_options_table(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite is required.' );
+		}
+
+		$main_site_id = get_main_site_id();
+		$subsite_id   = self::factory()->blog->create();
+		$token        = extrachill_users_create_browser_handoff_token( 42, 'https://community.extrachill.com/settings/' );
+		$claim_key    = 'ec_browser_handoff_claim_' . hash( 'sha256', $token );
+		$claim_site   = 0;
+
+		add_action( 'add_option_' . $claim_key, static function () use ( &$claim_site ): void {
+			$claim_site = get_current_blog_id();
+		} );
+
+		switch_to_blog( $subsite_id );
+		try {
+			$result = extrachill_users_consume_browser_handoff_token( $token );
+		} finally {
+			restore_current_blog();
+		}
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $main_site_id, $claim_site );
 	}
 }


### PR DESCRIPTION
## Summary
- replace unconditional MySQL advisory locks with atomic `add_option()` claims in the network main site's uniquely indexed options table
- fail closed across claim, payload deletion, validation, and owner-safe release failures
- add deterministic SQLite-backed regression coverage for concurrency, replay, expiry, storage failures, cleanup, and cross-subsite coordination

## Root cause
PR #254 serialized handoff consumption with unconditional `GET_LOCK()` / `RELEASE_LOCK()` calls. WP Codebox's supported SQLite integration does not implement those MySQL advisory-lock functions, so lock acquisition never returned success and every valid handoff failed with `invalid_handoff_token`.

The original failure is preserved in Homeboy run `19a2333b-a369-4586-97ee-baf88039951b`: `Valid browser handoff could not be consumed.`

## Atomic primitive
The replacement uses core `add_option()` with a claim name derived only from `sha256(token)`. WordPress's options schema uniquely indexes `option_name`; `add_option()` relies on that database constraint, so concurrent inserts have exactly one winner on both MySQL and the WordPress SQLite integration. Unlike network options, the main site's options table has the required unique key.

Claims are always created while switched to `get_main_site_id()`. Consumers arriving through different subsites therefore contend on the same row. The transient payload remains network-wide, and neither claim names nor payload keys persist plaintext tokens.

## MySQL and SQLite behavior
- MySQL: the core options table has `UNIQUE KEY option_name (option_name)`, so duplicate claims fail atomically.
- SQLite: the real WP Codebox SQLite-backed focused suite executed the same `add_option()` primitive and rejected duplicate claims.
- No database-specific advisory-lock SQL, custom table, cache-only lock, or campaign bypass remains.

## Crash and cleanup semantics
Each claim contains a random owner UUID and expiry timestamp. Cleanup is scheduled on the main site before acquisition; if scheduling fails, consumption fails closed before a claim can be created. Normal release and scheduled cleanup use a conditional database delete matching both `option_name` and the complete serialized owner value, so an old owner cannot release a replacement claim.

A crash before acquisition leaves only a no-op cleanup event. A crash after acquisition leaves an expiring claim that the scheduled callback removes. If an expired claim is encountered before cron cleanup, it is removed owner-safely, but that consumption attempt still fails instead of reopening the token. The payload's independent 60-second age check prevents stale payload recovery. Claim acquisition, payload deletion, and owner-safe release storage ambiguity all fail closed.

## Regression evidence
Focused real WP Codebox SQLite run `ebfe1432-e6ca-45b6-aefd-36182356bb3d` passed: 8 tests, 31 assertions. Coverage includes:
- one winner while three competitors are released after the unique row exists but before the winner reads payload
- all competitors and later replay return `invalid_handoff_token`
- missing and expired payloads
- claim acquisition failure, payload deletion failure, and claim release failure
- owner-safe cleanup and scheduled interruption cleanup
- cross-subsite consumption claiming in the main site's options table

The e2e auth control now also directly asserts duplicate `add_option()` rejection against its real storage and consumes the handoff from a non-main subsite. A pinned WordPress 7.0.2 rerun was attempted twice, but the shared `wordpress-multisite-e2e` resource remained held by an unrelated live two-factor browser campaign; that active lock was not force-released. The equivalent focused WP Codebox SQLite proof above executed the target handoff behavior end to end through the real storage primitive.

## Verification
- PHP syntax checks passed for production, unit, and e2e files
- `git diff --check` passed
- PHPCS passed with zero findings
- focused WP Codebox SQLite PHPUnit: 8 passed, 31 assertions
- full PHPUnit: 332 tests, 196 passed, 7 skipped, 129 failed on the unrelated existing SQLite fixture baseline (`wp_datamachine_event_dates` is absent)
- scoped PHPStan retains 16 analyzer-stub findings: 13 WordPress core functions are absent from the isolated stubs and the local `WP_Error` stub incorrectly limits its constructor to two arguments; the prior touched-file baseline already included the existing core-function and `WP_Error` findings

Closes #257