### PR TITLE
fix: enforce password policy for authenticated changes

### DIFF
--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -101,6 +101,7 @@ function extrachill_users_init() {
 	}
 	$initialized = true;
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/assets.php';
+	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/password-policy.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/gating.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/feature-rollout-admin.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/core/artist-access-admin.php';

--- a/inc/auth/password-reset.php
+++ b/inc/auth/password-reset.php
@@ -287,8 +287,9 @@ function ec_process_reset_password_submission( $key, $login, $pass1, $pass2 ) {
 		return new WP_Error( 'password_mismatch', __( 'Passwords do not match.', 'extrachill-users' ) );
 	}
 
-	if ( strlen( $pass1 ) < 8 ) {
-		return new WP_Error( 'password_too_short', __( 'Password must be at least 8 characters.', 'extrachill-users' ) );
+	$password_validation = extrachill_users_validate_password( $pass1 );
+	if ( is_wp_error( $password_validation ) ) {
+		return $password_validation;
 	}
 
 	$user = check_password_reset_key( $key, $login );
@@ -330,7 +331,7 @@ function ec_handle_reset_password() {
 
 	if ( is_wp_error( $user ) ) {
 		$query_args = array();
-		if ( in_array( $user->get_error_code(), array( 'password_mismatch', 'password_too_short' ), true ) ) {
+		if ( in_array( $user->get_error_code(), array( 'password_mismatch', 'password_too_short', 'invalid_password' ), true ) ) {
 			$query_args = array(
 				'action' => 'reset',
 				'key'    => $key,

--- a/inc/auth/register.php
+++ b/inc/auth/register.php
@@ -219,8 +219,9 @@ function extrachill_handle_registration() {
 		$redirect->error( __( 'Passwords do not match.', 'extrachill-users' ) );
 	}
 
-	if ( strlen( $password ) < 8 ) {
-		$redirect->error( __( 'Password must be at least 8 characters.', 'extrachill-users' ) );
+	$password_validation = extrachill_users_validate_password( $password );
+	if ( is_wp_error( $password_validation ) ) {
+		$redirect->error( $password_validation->get_error_message() );
 	}
 
 	if ( email_exists( $email ) ) {

--- a/inc/core/abilities/user-settings.php
+++ b/inc/core/abilities/user-settings.php
@@ -141,8 +141,14 @@ function extrachill_users_register_settings_abilities() {
 				'type'       => 'object',
 				'properties' => array(
 					'current_password' => array( 'type' => 'string' ),
-					'new_password'     => array( 'type' => 'string' ),
-					'confirm_password' => array( 'type' => 'string' ),
+					'new_password'     => array(
+						'type'      => 'string',
+						'minLength' => 8,
+					),
+					'confirm_password' => array(
+						'type'      => 'string',
+						'minLength' => 8,
+					),
 				),
 				'required'   => array( 'current_password', 'new_password', 'confirm_password' ),
 			),
@@ -790,6 +796,11 @@ function extrachill_users_ability_change_password( $input ) {
 
 	if ( $new_password !== $confirm_password ) {
 		return new WP_Error( 'password_mismatch', 'New passwords do not match.' );
+	}
+
+	$password_validation = extrachill_users_validate_password( $new_password );
+	if ( is_wp_error( $password_validation ) ) {
+		return $password_validation;
 	}
 
 	$result = wp_update_user(

--- a/inc/core/password-policy.php
+++ b/inc/core/password-policy.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Shared password policy.
+ *
+ * @package ExtraChill\Users
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Validate a password accepted by Extra Chill account entry points.
+ *
+ * @param mixed $password Password value to validate.
+ * @return true|WP_Error True when valid, otherwise a REST-safe error.
+ */
+function extrachill_users_validate_password( $password ) {
+	if ( ! is_string( $password ) ) {
+		return new WP_Error(
+			'invalid_password',
+			__( 'Password must be a string.', 'extrachill-users' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	if ( strlen( $password ) < 8 ) {
+		return new WP_Error(
+			'password_too_short',
+			__( 'Password must be at least 8 characters.', 'extrachill-users' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	if ( str_contains( $password, '\\' ) ) {
+		return new WP_Error(
+			'invalid_password',
+			__( 'Passwords cannot contain the "\\" character.', 'extrachill-users' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	return true;
+}

--- a/tests/unit/ChangeUserPasswordAbilityTest.php
+++ b/tests/unit/ChangeUserPasswordAbilityTest.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Tests for authenticated password changes.
+ *
+ * @package ExtraChill\Users
+ */
+
+class Test_Change_User_Password_Ability extends WP_UnitTestCase {
+
+	private const CURRENT_PASSWORD = 'current-password';
+
+	/**
+	 * Create and authenticate a user with a known password.
+	 *
+	 * @return WP_User
+	 */
+	private function create_current_user(): WP_User {
+		$user_id = self::factory()->user->create( array( 'user_pass' => self::CURRENT_PASSWORD ) );
+		wp_set_current_user( $user_id );
+
+		return get_userdata( $user_id );
+	}
+
+	/**
+	 * Capture mutable credential state that validation failures must preserve.
+	 *
+	 * @param WP_User $user User to inspect.
+	 * @return array
+	 */
+	private function capture_credential_state( WP_User $user ): array {
+		$reset_key = get_password_reset_key( $user );
+		$this->assertNotWPError( $reset_key );
+
+		$sessions = WP_Session_Tokens::get_instance( $user->ID );
+		$sessions->create( time() + HOUR_IN_SECONDS );
+
+		return array(
+			'hash'             => get_userdata( $user->ID )->user_pass,
+			'recovery_key'     => get_userdata( $user->ID )->user_activation_key,
+			'sessions'         => $sessions->get_all(),
+			'auth_cookie'      => isset( $_COOKIE[ AUTH_COOKIE ] ) ? $_COOKIE[ AUTH_COOKIE ] : null,
+			'logged_in_cookie' => isset( $_COOKIE[ LOGGED_IN_COOKIE ] ) ? $_COOKIE[ LOGGED_IN_COOKIE ] : null,
+		);
+	}
+
+	/**
+	 * Assert credential state was not touched.
+	 *
+	 * @param WP_User $user   User to inspect.
+	 * @param array   $before Original state.
+	 */
+	private function assert_credential_state_unchanged( WP_User $user, array $before ): void {
+		$persisted = get_userdata( $user->ID );
+
+		$this->assertSame( $before['hash'], $persisted->user_pass );
+		$this->assertSame( $before['recovery_key'], $persisted->user_activation_key );
+		$this->assertSame( $before['sessions'], WP_Session_Tokens::get_instance( $user->ID )->get_all() );
+		$this->assertSame( $before['auth_cookie'], isset( $_COOKIE[ AUTH_COOKIE ] ) ? $_COOKIE[ AUTH_COOKIE ] : null );
+		$this->assertSame( $before['logged_in_cookie'], isset( $_COOKIE[ LOGGED_IN_COOKIE ] ) ? $_COOKIE[ LOGGED_IN_COOKIE ] : null );
+	}
+
+	public function test_one_character_password_is_rejected_without_mutation(): void {
+		$user   = $this->create_current_user();
+		$before = $this->capture_credential_state( $user );
+		$result = extrachill_users_ability_change_password(
+			array(
+				'current_password' => self::CURRENT_PASSWORD,
+				'new_password'     => 'x',
+				'confirm_password' => 'x',
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'password_too_short', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+		$this->assert_credential_state_unchanged( $user, $before );
+	}
+
+	public function test_seven_character_password_is_rejected_and_eight_is_accepted(): void {
+		$user   = $this->create_current_user();
+		$before = $this->capture_credential_state( $user );
+		$result = extrachill_users_ability_change_password(
+			array(
+				'current_password' => self::CURRENT_PASSWORD,
+				'new_password'     => '1234567',
+				'confirm_password' => '1234567',
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'password_too_short', $result->get_error_code() );
+		$this->assert_credential_state_unchanged( $user, $before );
+
+		$result = extrachill_users_ability_change_password(
+			array(
+				'current_password' => self::CURRENT_PASSWORD,
+				'new_password'     => '12345678',
+				'confirm_password' => '12345678',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertTrue( wp_check_password( '12345678', get_userdata( $user->ID )->user_pass, $user->ID ) );
+	}
+
+	public function test_malformed_password_is_rejected_without_mutation(): void {
+		$user   = $this->create_current_user();
+		$before = $this->capture_credential_state( $user );
+		$result = extrachill_users_ability_change_password(
+			array(
+				'current_password' => self::CURRENT_PASSWORD,
+				'new_password'     => 'bad\\password',
+				'confirm_password' => 'bad\\password',
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_password', $result->get_error_code() );
+		$this->assert_credential_state_unchanged( $user, $before );
+	}
+
+	public function test_wrong_current_password_and_confirmation_do_not_mutate(): void {
+		$user   = $this->create_current_user();
+		$before = $this->capture_credential_state( $user );
+
+		$wrong_current = extrachill_users_ability_change_password(
+			array(
+				'current_password' => 'incorrect-password',
+				'new_password'     => 'new-password',
+				'confirm_password' => 'new-password',
+			)
+		);
+		$this->assertWPError( $wrong_current );
+		$this->assertSame( 'incorrect_password', $wrong_current->get_error_code() );
+		$this->assert_credential_state_unchanged( $user, $before );
+
+		$mismatch = extrachill_users_ability_change_password(
+			array(
+				'current_password' => self::CURRENT_PASSWORD,
+				'new_password'     => 'new-password',
+				'confirm_password' => 'other-password',
+			)
+		);
+		$this->assertWPError( $mismatch );
+		$this->assertSame( 'password_mismatch', $mismatch->get_error_code() );
+		$this->assert_credential_state_unchanged( $user, $before );
+	}
+
+	public function test_user_id_injection_cannot_change_another_user_password(): void {
+		$user         = $this->create_current_user();
+		$other_id     = self::factory()->user->create( array( 'user_pass' => 'other-password' ) );
+		$other_before = get_userdata( $other_id )->user_pass;
+		$result       = extrachill_users_ability_change_password(
+			array(
+				'user_id'          => $other_id,
+				'current_password' => self::CURRENT_PASSWORD,
+				'new_password'     => 'changed-password',
+				'confirm_password' => 'changed-password',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( wp_check_password( 'changed-password', get_userdata( $user->ID )->user_pass, $user->ID ) );
+		$this->assertSame( $other_before, get_userdata( $other_id )->user_pass );
+		$this->assertTrue( wp_check_password( 'other-password', get_userdata( $other_id )->user_pass, $other_id ) );
+	}
+}

--- a/tests/unit/PasswordValidationTest.php
+++ b/tests/unit/PasswordValidationTest.php
@@ -5,30 +5,31 @@
 
 class Test_Password_Validation extends WP_UnitTestCase {
 
-	private function is_password_valid_length( string $password ): bool {
-		return strlen( $password ) >= 8;
-	}
-
 	private function passwords_match( string $password, string $password_confirm ): bool {
 		return $password === $password_confirm;
 	}
 
-	protected function setUp(): void {
-		parent::setUp();
-		if ( function_exists( 'extrachill_users_register_onboarding_abilities' ) ) {
-			extrachill_users_register_onboarding_abilities();
-		}
-	}
-
 	public function test_password_minimum_length_fails(): void {
 		foreach ( array( '', 'a', 'abc', '1234567' ) as $password ) {
-			$this->assertFalse( $this->is_password_valid_length( $password ) );
+			$result = extrachill_users_validate_password( $password );
+			$this->assertWPError( $result );
+			$this->assertSame( 'password_too_short', $result->get_error_code() );
+			$this->assertSame( 400, $result->get_error_data()['status'] );
 		}
 	}
 
 	public function test_password_valid_length_passes(): void {
 		foreach ( array( '12345678', '123456789', 'mysecurepassword', str_repeat( 'a', 100 ) ) as $password ) {
-			$this->assertTrue( $this->is_password_valid_length( $password ) );
+			$this->assertTrue( extrachill_users_validate_password( $password ) );
+		}
+	}
+
+	public function test_password_rejects_non_string_and_backslash_values(): void {
+		foreach ( array( array( 'password' ), 'password\\value' ) as $password ) {
+			$result = extrachill_users_validate_password( $password );
+			$this->assertWPError( $result );
+			$this->assertSame( 'invalid_password', $result->get_error_code() );
+			$this->assertSame( 400, $result->get_error_data()['status'] );
 		}
 	}
 


### PR DESCRIPTION
## Summary
- route registration, custom reset, and authenticated password changes through one Users-owned password validator
- expose the 8-character minimum in the authenticated ability schema and reject WordPress REST-invalid backslash passwords consistently
- prove rejected changes preserve password hashes, recovery keys, cookies, sessions, and other users

## Root Cause
`extrachill/change-user-password` checked the current password, presence, and confirmation before calling `wp_update_user()`, but it never applied the minimum-length rule independently hard-coded in registration and reset. A logged-in user could therefore persist a one-character password.

## Canonical Policy
Extra Chill Users now owns the smallest shared policy needed by these entry points: passwords must be strings, contain at least 8 characters, and satisfy WordPress core's REST password constraint that rejects backslashes. Validation returns stable `WP_Error` codes with HTTP 400 data so direct and REST callers fail safely before mutation.

## Security Impact
Authenticated users can no longer weaken their credentials below the registration/reset boundary. Validation occurs before `wp_update_user()`, preserving the existing current-password, confirmation, and self-only controls while ensuring rejected requests do not alter credential or session state.

## Boundary Tests
- one-character and seven-character passwords are rejected
- eight-character passwords are accepted
- malformed non-string and backslash values are rejected
- injected `user_id` cannot target another account
- rejected changes preserve the password hash, recovery key, auth cookies, logged-in cookies, and native WordPress sessions
- incorrect current-password and confirmation mismatch behavior remains intact

## Verification
- `homeboy review test --placement local --skip-lint -- --filter 'Test_(Change_User_Password_Ability|Password_Validation|Password_Claim)'` (26 tests, 115 assertions passed)
- PHP syntax checks passed for all changed PHP files
- PHPCS passed for the new production helper and focused regression test
- full suite: 214 passed, 7 skipped, 106 failures, 13 errors; unrelated baseline failures are dominated by WordPress 7.0 Abilities API lifecycle notices, missing SQLite fixture tables such as `wp_datamachine_event_dates`, and existing multisite fixture type errors
- PHPStan remains blocked by existing inaccurate WordPress stubs, including two-argument `WP_Error` and one-argument translation-function signatures

Closes #255