### PR TITLE
fix: make auth rate counters atomic

### DIFF
--- a/inc/auth/login.php
+++ b/inc/auth/login.php
@@ -59,6 +59,7 @@ function ec_login_rate_limit_cache_operation( $operation, $key ) {
 		|| ! wp_using_ext_object_cache()
 		|| ! function_exists( 'wp_cache_add' )
 		|| ! function_exists( 'wp_cache_incr' )
+		|| ! function_exists( 'wp_cache_set' )
 	) {
 		return ec_login_limiter_unavailable_error();
 	}
@@ -67,26 +68,28 @@ function ec_login_rate_limit_cache_operation( $operation, $key ) {
 	$found          = false;
 	$generation     = wp_cache_get( $generation_key, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, true, $found );
 	if ( ! $found ) {
-		if ( ! wp_cache_add( $generation_key, 0, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, 2 * EXTRACHILL_USERS_LOGIN_RATE_WINDOW ) ) {
+		$generation = wp_generate_uuid4();
+		if ( ! wp_cache_add( $generation_key, $generation, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, 2 * EXTRACHILL_USERS_LOGIN_RATE_WINDOW ) ) {
 			$generation = wp_cache_get( $generation_key, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, true, $found );
 		} else {
-			$generation = 0;
-			$found      = true;
+			$found = true;
 		}
 	}
 
-	if ( ! $found || ! is_numeric( $generation ) ) {
+	if ( ! $found || ! is_string( $generation ) || '' === $generation ) {
 		return ec_login_limiter_unavailable_error();
 	}
 
 	if ( 'clear' === $operation ) {
-		$generation = wp_cache_incr( $generation_key, 1, EXTRACHILL_USERS_LOGIN_CACHE_GROUP );
-		return false === $generation || ! is_numeric( $generation )
-			? ec_login_limiter_unavailable_error()
-			: 0;
+		// Replacing the token linearizes concurrent clears and refreshes its
+		// bounded TTL beyond every counter that can reference it.
+		$generation = wp_generate_uuid4();
+		return wp_cache_set( $generation_key, $generation, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, 2 * EXTRACHILL_USERS_LOGIN_RATE_WINDOW )
+			? 0
+			: ec_login_limiter_unavailable_error();
 	}
 
-	$counter_key = $key . '_generation_' . (int) $generation;
+	$counter_key = $key . '_generation_' . $generation;
 	if ( 'get' === $operation ) {
 		$count = wp_cache_get( $counter_key, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, true, $found );
 		if ( $found ) {

--- a/inc/auth/login.php
+++ b/inc/auth/login.php
@@ -10,6 +10,10 @@
 
 defined( 'ABSPATH' ) || exit;
 
+const EXTRACHILL_USERS_LOGIN_RATE_LIMIT  = 5;
+const EXTRACHILL_USERS_LOGIN_RATE_WINDOW = 15 * MINUTE_IN_SECONDS;
+const EXTRACHILL_USERS_LOGIN_CACHE_GROUP = 'extrachill-users-login-rate-limit';
+
 /**
  * Get the transient key for login attempts.
  *
@@ -17,11 +21,124 @@ defined( 'ABSPATH' ) || exit;
  * @return string Transient key.
  */
 function ec_get_login_attempt_key( $username ) {
-	$ip         = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+	$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+	if ( '' === $ip ) {
+		return '';
+	}
+
 	$identifier = trim( (string) $username );
 	$user       = is_email( $identifier ) ? get_user_by( 'email', $identifier ) : get_user_by( 'login', $identifier );
 	$identity   = $user instanceof WP_User ? 'user:' . $user->ID : 'identifier:' . strtolower( $identifier );
 	return 'ec_login_attempts_' . md5( $ip . '|' . $identity );
+}
+
+/**
+ * Return a stable error when atomic login accounting is unavailable.
+ *
+ * @return WP_Error Storage error.
+ */
+function ec_login_limiter_unavailable_error() {
+	return new WP_Error(
+		'ec_login_limiter_unavailable',
+		__( 'Login is temporarily unavailable. Please try again.', 'extrachill-users' )
+	);
+}
+
+/**
+ * Run one login rate-limit storage operation.
+ *
+ * Production uses the persistent object cache. Tests may replace this callable
+ * through `extrachill_users_login_rate_limit_store` to control race ordering.
+ *
+ * @param string $operation Operation name: get, increment, or clear.
+ * @param string $key       Hashed requester and identity key.
+ * @return int|WP_Error Current attempt count, or an error on storage failure.
+ */
+function ec_login_rate_limit_cache_operation( $operation, $key ) {
+	if ( ! function_exists( 'wp_using_ext_object_cache' )
+		|| ! wp_using_ext_object_cache()
+		|| ! function_exists( 'wp_cache_add' )
+		|| ! function_exists( 'wp_cache_incr' )
+	) {
+		return ec_login_limiter_unavailable_error();
+	}
+
+	$generation_key = $key . '_generation';
+	$found          = false;
+	$generation     = wp_cache_get( $generation_key, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, true, $found );
+	if ( ! $found ) {
+		if ( ! wp_cache_add( $generation_key, 0, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, 2 * EXTRACHILL_USERS_LOGIN_RATE_WINDOW ) ) {
+			$generation = wp_cache_get( $generation_key, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, true, $found );
+		} else {
+			$generation = 0;
+			$found      = true;
+		}
+	}
+
+	if ( ! $found || ! is_numeric( $generation ) ) {
+		return ec_login_limiter_unavailable_error();
+	}
+
+	if ( 'clear' === $operation ) {
+		$generation = wp_cache_incr( $generation_key, 1, EXTRACHILL_USERS_LOGIN_CACHE_GROUP );
+		return false === $generation || ! is_numeric( $generation )
+			? ec_login_limiter_unavailable_error()
+			: 0;
+	}
+
+	$counter_key = $key . '_generation_' . (int) $generation;
+	if ( 'get' === $operation ) {
+		$count = wp_cache_get( $counter_key, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, true, $found );
+		if ( $found ) {
+			return is_numeric( $count ) ? (int) $count : ec_login_limiter_unavailable_error();
+		}
+
+		if ( wp_cache_add( $counter_key, 0, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, EXTRACHILL_USERS_LOGIN_RATE_WINDOW ) ) {
+			return 0;
+		}
+
+		$count = wp_cache_get( $counter_key, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, true, $found );
+		return $found && is_numeric( $count ) ? (int) $count : ec_login_limiter_unavailable_error();
+	}
+
+	if ( 'increment' !== $operation ) {
+		return ec_login_limiter_unavailable_error();
+	}
+
+	if ( wp_cache_add( $counter_key, 1, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, EXTRACHILL_USERS_LOGIN_RATE_WINDOW ) ) {
+		return 1;
+	}
+
+	$count = wp_cache_incr( $counter_key, 1, EXTRACHILL_USERS_LOGIN_CACHE_GROUP );
+	return false === $count || ! is_numeric( $count ) ? ec_login_limiter_unavailable_error() : (int) $count;
+}
+
+/**
+ * Use the configured login rate-limit store.
+ *
+ * @param string $operation Operation name.
+ * @param string $key       Hashed limiter key.
+ * @return int|WP_Error Current attempt count, or an error on storage failure.
+ */
+function ec_login_rate_limit_store( $operation, $key ) {
+	if ( '' === $key ) {
+		return ec_login_limiter_unavailable_error();
+	}
+
+	/**
+	 * Filter the atomic login rate-limit storage callable.
+	 *
+	 * @param callable $store Storage callable accepting operation and key.
+	 */
+	$store = apply_filters( 'extrachill_users_login_rate_limit_store', 'ec_login_rate_limit_cache_operation' );
+	if ( ! is_callable( $store ) ) {
+		return ec_login_limiter_unavailable_error();
+	}
+
+	$result = call_user_func( $store, $operation, $key );
+	return is_wp_error( $result ) || is_numeric( $result )
+		? $result
+		: ec_login_limiter_unavailable_error();
 }
 
 /**
@@ -34,36 +151,37 @@ function ec_is_login_blocked( $username ) {
 	if ( empty( $username ) ) {
 		return false;
 	}
-	$key      = ec_get_login_attempt_key( $username );
-	$attempts = get_transient( $key );
-	return $attempts && $attempts >= 5;
+
+	$attempts = ec_login_rate_limit_store( 'get', ec_get_login_attempt_key( $username ) );
+	return is_wp_error( $attempts ) || $attempts >= EXTRACHILL_USERS_LOGIN_RATE_LIMIT;
 }
 
 /**
  * Record a failed login attempt.
  *
  * @param string $username Username that failed.
+ * @return int|WP_Error Current attempt count, or an error on storage failure.
  */
 function ec_record_failed_login( $username ) {
 	if ( empty( $username ) ) {
-		return;
+		return ec_login_limiter_unavailable_error();
 	}
-	$key      = ec_get_login_attempt_key( $username );
-	$attempts = get_transient( $key );
-	$attempts = $attempts ? $attempts + 1 : 1;
-	set_transient( $key, $attempts, 15 * MINUTE_IN_SECONDS );
+
+	return ec_login_rate_limit_store( 'increment', ec_get_login_attempt_key( $username ) );
 }
 
 /**
  * Clear login attempts after successful login.
  *
  * @param string $username Username that succeeded.
+ * @return int|WP_Error Zero on success, or an error on storage failure.
  */
 function ec_clear_login_attempts( $username ) {
 	if ( empty( $username ) ) {
-		return;
+		return ec_login_limiter_unavailable_error();
 	}
-	delete_transient( ec_get_login_attempt_key( $username ) );
+
+	return ec_login_rate_limit_store( 'clear', ec_get_login_attempt_key( $username ) );
 }
 
 /**
@@ -78,7 +196,19 @@ function ec_rate_limit_login( $user, $username ) {
 		return $user;
 	}
 
-	if ( ec_is_login_blocked( $username ) ) {
+	if ( is_wp_error( $user ) ) {
+		$attempts = ec_record_failed_login( $username );
+		if ( is_wp_error( $attempts ) ) {
+			return $attempts;
+		}
+	} else {
+		$attempts = ec_login_rate_limit_store( 'get', ec_get_login_attempt_key( $username ) );
+		if ( is_wp_error( $attempts ) ) {
+			return $attempts;
+		}
+	}
+
+	if ( $attempts > EXTRACHILL_USERS_LOGIN_RATE_LIMIT || ( ! is_wp_error( $user ) && $attempts >= EXTRACHILL_USERS_LOGIN_RATE_LIMIT ) ) {
 		return new WP_Error(
 			'ec_login_blocked',
 			__( 'Too many failed login attempts. Please try again in 15 minutes.', 'extrachill-users' )
@@ -123,7 +253,6 @@ add_action( 'two_factor_user_authenticated', 'ec_clear_attempts_on_two_factor' )
  * @param string $username Username attempted
  */
 function extrachill_handle_login_failed( $username ) {
-	ec_record_failed_login( $username );
 	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
 		return;
 	}

--- a/inc/auth/login.php
+++ b/inc/auth/login.php
@@ -50,11 +50,12 @@ function ec_login_limiter_unavailable_error() {
  * Production uses the persistent object cache. Tests may replace this callable
  * through `extrachill_users_login_rate_limit_store` to control race ordering.
  *
- * @param string $operation Operation name: get, increment, or clear.
- * @param string $key       Hashed requester and identity key.
- * @return int|WP_Error Current attempt count, or an error on storage failure.
+ * @param string   $operation Operation name: get, increment, or clear.
+ * @param string   $key       Hashed requester and identity key.
+ * @param int|null $now       Optional Unix timestamp for deterministic tests.
+ * @return int|WP_Error Effective attempt count, or an error on storage failure.
  */
-function ec_login_rate_limit_cache_operation( $operation, $key ) {
+function ec_login_rate_limit_cache_operation( $operation, $key, $now = null ) {
 	if ( ! function_exists( 'wp_using_ext_object_cache' )
 		|| ! wp_using_ext_object_cache()
 		|| ! function_exists( 'wp_cache_add' )
@@ -64,56 +65,61 @@ function ec_login_rate_limit_cache_operation( $operation, $key ) {
 		return ec_login_limiter_unavailable_error();
 	}
 
-	$generation_key = $key . '_generation';
-	$found          = false;
-	$generation     = wp_cache_get( $generation_key, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, true, $found );
-	if ( ! $found ) {
-		$generation = wp_generate_uuid4();
-		if ( ! wp_cache_add( $generation_key, $generation, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, 2 * EXTRACHILL_USERS_LOGIN_RATE_WINDOW ) ) {
-			$generation = wp_cache_get( $generation_key, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, true, $found );
-		} else {
-			$found = true;
-		}
-	}
-
-	if ( ! $found || ! is_string( $generation ) || '' === $generation ) {
-		return ec_login_limiter_unavailable_error();
-	}
-
-	if ( 'clear' === $operation ) {
-		// Replacing the token linearizes concurrent clears and refreshes its
-		// bounded TTL beyond every counter that can reference it.
-		$generation = wp_generate_uuid4();
-		return wp_cache_set( $generation_key, $generation, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, 2 * EXTRACHILL_USERS_LOGIN_RATE_WINDOW )
-			? 0
-			: ec_login_limiter_unavailable_error();
-	}
-
-	$counter_key = $key . '_generation_' . $generation;
-	if ( 'get' === $operation ) {
+	$now          = null === $now ? time() : (int) $now;
+	$window_key   = $key . '_window_' . intdiv( $now, EXTRACHILL_USERS_LOGIN_RATE_WINDOW );
+	$total_key    = $window_key . '_total';
+	$cleared_key  = $window_key . '_cleared';
+	$storage_ttl  = 2 * EXTRACHILL_USERS_LOGIN_RATE_WINDOW;
+	$read_counter = static function ( $counter_key ) use ( $storage_ttl ) {
+		$found = false;
 		$count = wp_cache_get( $counter_key, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, true, $found );
 		if ( $found ) {
 			return is_numeric( $count ) ? (int) $count : ec_login_limiter_unavailable_error();
 		}
 
-		if ( wp_cache_add( $counter_key, 0, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, EXTRACHILL_USERS_LOGIN_RATE_WINDOW ) ) {
+		if ( wp_cache_add( $counter_key, 0, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, $storage_ttl ) ) {
 			return 0;
 		}
 
 		$count = wp_cache_get( $counter_key, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, true, $found );
 		return $found && is_numeric( $count ) ? (int) $count : ec_login_limiter_unavailable_error();
+	};
+
+	if ( 'clear' === $operation ) {
+		$total = $read_counter( $total_key );
+		if ( is_wp_error( $total ) ) {
+			return $total;
+		}
+
+		// A failure before this read is cleared; an increment after it remains
+		// above the marker. Concurrent marker regression can only overcount.
+		return wp_cache_set( $cleared_key, $total, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, $storage_ttl )
+			? 0
+			: ec_login_limiter_unavailable_error();
 	}
 
-	if ( 'increment' !== $operation ) {
+	if ( 'get' !== $operation && 'increment' !== $operation ) {
 		return ec_login_limiter_unavailable_error();
 	}
 
-	if ( wp_cache_add( $counter_key, 1, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, EXTRACHILL_USERS_LOGIN_RATE_WINDOW ) ) {
-		return 1;
+	if ( 'increment' === $operation ) {
+		if ( wp_cache_add( $total_key, 1, EXTRACHILL_USERS_LOGIN_CACHE_GROUP, $storage_ttl ) ) {
+			$total = 1;
+		} else {
+			$total = wp_cache_incr( $total_key, 1, EXTRACHILL_USERS_LOGIN_CACHE_GROUP );
+			if ( false === $total || ! is_numeric( $total ) ) {
+				return ec_login_limiter_unavailable_error();
+			}
+		}
+	} else {
+		$total = $read_counter( $total_key );
+		if ( is_wp_error( $total ) ) {
+			return $total;
+		}
 	}
 
-	$count = wp_cache_incr( $counter_key, 1, EXTRACHILL_USERS_LOGIN_CACHE_GROUP );
-	return false === $count || ! is_numeric( $count ) ? ec_login_limiter_unavailable_error() : (int) $count;
+	$cleared = $read_counter( $cleared_key );
+	return is_wp_error( $cleared ) ? $cleared : max( 0, (int) $total - $cleared );
 }
 
 /**
@@ -138,7 +144,7 @@ function ec_login_rate_limit_store( $operation, $key ) {
 		return ec_login_limiter_unavailable_error();
 	}
 
-	$result = call_user_func( $store, $operation, $key );
+	$result = call_user_func( $store, $operation, $key, null );
 	return is_wp_error( $result ) || is_numeric( $result )
 		? $result
 		: ec_login_limiter_unavailable_error();

--- a/inc/auth/password-reset.php
+++ b/inc/auth/password-reset.php
@@ -172,11 +172,12 @@ function ec_password_reset_limiter_unavailable_error() {
 /**
  * Run one password-reset rate-limit storage operation.
  *
- * @param string $operation Operation name: get or increment.
- * @param string $key       Hashed requester key.
+ * @param string   $operation Operation name: get or increment.
+ * @param string   $key       Hashed requester key.
+ * @param int|null $now       Optional Unix timestamp for deterministic tests.
  * @return int|WP_Error Current attempt count, or an error on storage failure.
  */
-function ec_password_reset_rate_limit_cache_operation( $operation, $key ) {
+function ec_password_reset_rate_limit_cache_operation( $operation, $key, $now = null ) {
 	if ( ! function_exists( 'wp_using_ext_object_cache' )
 		|| ! wp_using_ext_object_cache()
 		|| ! function_exists( 'wp_cache_add' )
@@ -185,14 +186,17 @@ function ec_password_reset_rate_limit_cache_operation( $operation, $key ) {
 		return ec_password_reset_limiter_unavailable_error();
 	}
 
-	$found = false;
+	$now         = null === $now ? time() : (int) $now;
+	$key        .= '_window_' . intdiv( $now, EXTRACHILL_USERS_PASSWORD_RESET_RATE_WINDOW );
+	$storage_ttl = 2 * EXTRACHILL_USERS_PASSWORD_RESET_RATE_WINDOW;
+	$found       = false;
 	if ( 'get' === $operation ) {
 		$count = wp_cache_get( $key, EXTRACHILL_USERS_PASSWORD_RESET_CACHE_GROUP, true, $found );
 		if ( $found ) {
 			return is_numeric( $count ) ? (int) $count : ec_password_reset_limiter_unavailable_error();
 		}
 
-		if ( wp_cache_add( $key, 0, EXTRACHILL_USERS_PASSWORD_RESET_CACHE_GROUP, EXTRACHILL_USERS_PASSWORD_RESET_RATE_WINDOW ) ) {
+		if ( wp_cache_add( $key, 0, EXTRACHILL_USERS_PASSWORD_RESET_CACHE_GROUP, $storage_ttl ) ) {
 			return 0;
 		}
 
@@ -204,7 +208,7 @@ function ec_password_reset_rate_limit_cache_operation( $operation, $key ) {
 		return ec_password_reset_limiter_unavailable_error();
 	}
 
-	if ( wp_cache_add( $key, 1, EXTRACHILL_USERS_PASSWORD_RESET_CACHE_GROUP, EXTRACHILL_USERS_PASSWORD_RESET_RATE_WINDOW ) ) {
+	if ( wp_cache_add( $key, 1, EXTRACHILL_USERS_PASSWORD_RESET_CACHE_GROUP, $storage_ttl ) ) {
 		return 1;
 	}
 
@@ -237,7 +241,7 @@ function ec_password_reset_rate_limit_store( $operation, $key ) {
 		return ec_password_reset_limiter_unavailable_error();
 	}
 
-	$result = call_user_func( $store, $operation, $key );
+	$result = call_user_func( $store, $operation, $key, null );
 	return is_wp_error( $result ) || is_numeric( $result )
 		? $result
 		: ec_password_reset_limiter_unavailable_error();

--- a/inc/auth/password-reset.php
+++ b/inc/auth/password-reset.php
@@ -146,7 +146,101 @@ add_action( 'after_password_reset', 'extrachill_users_clear_unclaimed_after_pass
  */
 function ec_get_password_reset_attempt_key() {
 	$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+	if ( '' === $ip ) {
+		return '';
+	}
+
 	return 'ec_password_reset_attempts_' . md5( $ip );
+}
+
+const EXTRACHILL_USERS_PASSWORD_RESET_RATE_LIMIT  = 5;
+const EXTRACHILL_USERS_PASSWORD_RESET_RATE_WINDOW = 15 * MINUTE_IN_SECONDS;
+const EXTRACHILL_USERS_PASSWORD_RESET_CACHE_GROUP = 'extrachill-users-password-reset-rate-limit';
+
+/**
+ * Return a stable error when atomic password-reset accounting is unavailable.
+ *
+ * @return WP_Error Storage error.
+ */
+function ec_password_reset_limiter_unavailable_error() {
+	return new WP_Error(
+		'ec_password_reset_limiter_unavailable',
+		__( 'Password reset is temporarily unavailable. Please try again.', 'extrachill-users' )
+	);
+}
+
+/**
+ * Run one password-reset rate-limit storage operation.
+ *
+ * @param string $operation Operation name: get or increment.
+ * @param string $key       Hashed requester key.
+ * @return int|WP_Error Current attempt count, or an error on storage failure.
+ */
+function ec_password_reset_rate_limit_cache_operation( $operation, $key ) {
+	if ( ! function_exists( 'wp_using_ext_object_cache' )
+		|| ! wp_using_ext_object_cache()
+		|| ! function_exists( 'wp_cache_add' )
+		|| ! function_exists( 'wp_cache_incr' )
+	) {
+		return ec_password_reset_limiter_unavailable_error();
+	}
+
+	$found = false;
+	if ( 'get' === $operation ) {
+		$count = wp_cache_get( $key, EXTRACHILL_USERS_PASSWORD_RESET_CACHE_GROUP, true, $found );
+		if ( $found ) {
+			return is_numeric( $count ) ? (int) $count : ec_password_reset_limiter_unavailable_error();
+		}
+
+		if ( wp_cache_add( $key, 0, EXTRACHILL_USERS_PASSWORD_RESET_CACHE_GROUP, EXTRACHILL_USERS_PASSWORD_RESET_RATE_WINDOW ) ) {
+			return 0;
+		}
+
+		$count = wp_cache_get( $key, EXTRACHILL_USERS_PASSWORD_RESET_CACHE_GROUP, true, $found );
+		return $found && is_numeric( $count ) ? (int) $count : ec_password_reset_limiter_unavailable_error();
+	}
+
+	if ( 'increment' !== $operation ) {
+		return ec_password_reset_limiter_unavailable_error();
+	}
+
+	if ( wp_cache_add( $key, 1, EXTRACHILL_USERS_PASSWORD_RESET_CACHE_GROUP, EXTRACHILL_USERS_PASSWORD_RESET_RATE_WINDOW ) ) {
+		return 1;
+	}
+
+	$count = wp_cache_incr( $key, 1, EXTRACHILL_USERS_PASSWORD_RESET_CACHE_GROUP );
+	return false === $count || ! is_numeric( $count ) ? ec_password_reset_limiter_unavailable_error() : (int) $count;
+}
+
+/**
+ * Use the configured password-reset rate-limit store.
+ *
+ * Tests can replace this callable to provide deterministic barriers without a
+ * persistent object cache in the WP Codebox SQLite runtime.
+ *
+ * @param string $operation Operation name.
+ * @param string $key       Hashed limiter key.
+ * @return int|WP_Error Current attempt count, or an error on storage failure.
+ */
+function ec_password_reset_rate_limit_store( $operation, $key ) {
+	if ( '' === $key ) {
+		return ec_password_reset_limiter_unavailable_error();
+	}
+
+	/**
+	 * Filter the atomic password-reset rate-limit storage callable.
+	 *
+	 * @param callable $store Storage callable accepting operation and key.
+	 */
+	$store = apply_filters( 'extrachill_users_password_reset_rate_limit_store', 'ec_password_reset_rate_limit_cache_operation' );
+	if ( ! is_callable( $store ) ) {
+		return ec_password_reset_limiter_unavailable_error();
+	}
+
+	$result = call_user_func( $store, $operation, $key );
+	return is_wp_error( $result ) || is_numeric( $result )
+		? $result
+		: ec_password_reset_limiter_unavailable_error();
 }
 
 /**
@@ -155,18 +249,17 @@ function ec_get_password_reset_attempt_key() {
  * @return bool True if blocked.
  */
 function ec_is_password_reset_blocked() {
-	$attempts = get_transient( ec_get_password_reset_attempt_key() );
-	return $attempts && $attempts >= 5;
+	$attempts = ec_password_reset_rate_limit_store( 'get', ec_get_password_reset_attempt_key() );
+	return is_wp_error( $attempts ) || $attempts >= EXTRACHILL_USERS_PASSWORD_RESET_RATE_LIMIT;
 }
 
 /**
  * Record a password reset request attempt.
+ *
+ * @return int|WP_Error Current attempt count, or an error on storage failure.
  */
 function ec_record_password_reset_attempt() {
-	$key      = ec_get_password_reset_attempt_key();
-	$attempts = get_transient( $key );
-	$attempts = $attempts ? $attempts + 1 : 1;
-	set_transient( $key, $attempts, 15 * MINUTE_IN_SECONDS );
+	return ec_password_reset_rate_limit_store( 'increment', ec_get_password_reset_attempt_key() );
 }
 
 /**
@@ -177,10 +270,6 @@ function ec_handle_password_reset_request() {
 
 	$redirect->verify_nonce( 'ec_password_reset_nonce', 'ec_password_reset_request' );
 
-	if ( ec_is_password_reset_blocked() ) {
-		$redirect->error( __( 'Too many password reset requests. Please try again in 15 minutes.', 'extrachill-users' ) );
-	}
-
 	// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce verified above through EC_Redirect_Handler.
 	$user_login = isset( $_POST['user_login'] ) ? trim( sanitize_text_field( wp_unslash( $_POST['user_login'] ) ) ) : '';
 
@@ -188,7 +277,13 @@ function ec_handle_password_reset_request() {
 		$redirect->error( __( 'Please enter your email or username.', 'extrachill-users' ) );
 	}
 
-	ec_record_password_reset_attempt();
+	$attempts = ec_record_password_reset_attempt();
+	if ( is_wp_error( $attempts ) ) {
+		$redirect->error( $attempts->get_error_message() );
+	}
+	if ( $attempts > EXTRACHILL_USERS_PASSWORD_RESET_RATE_LIMIT ) {
+		$redirect->error( __( 'Too many password reset requests. Please try again in 15 minutes.', 'extrachill-users' ) );
+	}
 
 	/**
 	 * Fires before password reset processing.

--- a/tests/unit/PasswordResetRateLimitTest.php
+++ b/tests/unit/PasswordResetRateLimitTest.php
@@ -126,6 +126,17 @@ class Auth_Rate_Limit_Test_Cache {
 		// Authentication groups intentionally remain blog-scoped.
 	}
 
+	public function ttl( $key, $group ): int {
+		$found = false;
+		$this->get( $key, $group, false, $found );
+		if ( ! $found ) {
+			return -2;
+		}
+
+		$expires_at = $this->data[ $this->id( $key, $group ) ]['expires_at'];
+		return 0 === $expires_at ? -1 : $expires_at - $this->now;
+	}
+
 	private function id( $key, $group ): string {
 		return $this->blog_id . ':' . $group . ':' . $key;
 	}
@@ -152,6 +163,23 @@ class Test_Authentication_Rate_Limits extends WP_UnitTestCase {
 		$this->cache                = new Auth_Rate_Limit_Test_Cache();
 		$GLOBALS['wp_object_cache'] = $this->cache;
 		wp_using_ext_object_cache( true );
+
+		add_filter(
+			'extrachill_users_login_rate_limit_store',
+			function () {
+				return function ( $operation, $key ) {
+					return ec_login_rate_limit_cache_operation( $operation, $key, $this->cache->now );
+				};
+			}
+		);
+		add_filter(
+			'extrachill_users_password_reset_rate_limit_store',
+			function () {
+				return function ( $operation, $key ) {
+					return ec_password_reset_rate_limit_cache_operation( $operation, $key, $this->cache->now );
+				};
+			}
+		);
 	}
 
 	protected function tearDown(): void {
@@ -165,7 +193,7 @@ class Test_Authentication_Rate_Limits extends WP_UnitTestCase {
 
 	public function test_login_barrier_records_every_concurrent_failure(): void {
 		$key                           = ec_get_login_attempt_key( 'person@example.com' );
-		$this->cache->after_add_pattern = '_generation_';
+		$this->cache->after_add_pattern = '_total';
 		$this->cache->after_add         = static function (): void {
 			for ( $attempt = 0; $attempt < 5; ++$attempt ) {
 				ec_record_failed_login( 'person@example.com' );
@@ -204,9 +232,9 @@ class Test_Authentication_Rate_Limits extends WP_UnitTestCase {
 		$this->assertSame( 'ec_login_blocked', $result->get_error_code() );
 	}
 
-	public function test_successful_login_clear_does_not_erase_newer_failure(): void {
+	public function test_failure_before_clear_is_cleared_and_failure_after_clear_survives(): void {
 		ec_record_failed_login( 'person@example.com' );
-		$this->cache->after_set_pattern = '_generation';
+		$this->cache->after_set_pattern = '_cleared';
 		$this->cache->after_set         = static function (): void {
 			ec_record_failed_login( 'person@example.com' );
 		};
@@ -215,15 +243,42 @@ class Test_Authentication_Rate_Limits extends WP_UnitTestCase {
 		$this->assertSame( 1, ec_login_rate_limit_store( 'get', ec_get_login_attempt_key( 'person@example.com' ) ) );
 	}
 
-	public function test_clear_near_generation_expiry_keeps_new_failures_visible(): void {
+	public function test_login_total_and_marker_share_bounded_fixed_window_lifetime(): void {
 		ec_record_failed_login( 'person@example.com' );
-		$this->cache->now += ( 2 * EXTRACHILL_USERS_LOGIN_RATE_WINDOW ) - 1;
-
 		$this->assertSame( 0, ec_clear_login_attempts( 'person@example.com' ) );
+
+		$window_key = ec_get_login_attempt_key( 'person@example.com' ) . '_window_' . intdiv( $this->cache->now, EXTRACHILL_USERS_LOGIN_RATE_WINDOW );
+		$this->assertSame( 2 * EXTRACHILL_USERS_LOGIN_RATE_WINDOW, $this->cache->ttl( $window_key . '_total', EXTRACHILL_USERS_LOGIN_CACHE_GROUP ) );
+		$this->assertSame( 2 * EXTRACHILL_USERS_LOGIN_RATE_WINDOW, $this->cache->ttl( $window_key . '_cleared', EXTRACHILL_USERS_LOGIN_CACHE_GROUP ) );
+		$this->assertSame( -2, $this->cache->ttl( ec_get_login_attempt_key( 'person@example.com' ) . '_generation', EXTRACHILL_USERS_LOGIN_CACHE_GROUP ) );
+	}
+
+	public function test_login_add_loser_cannot_create_ttl_less_key_at_boundary(): void {
+		$window_end = ( intdiv( $this->cache->now, EXTRACHILL_USERS_LOGIN_RATE_WINDOW ) + 1 ) * EXTRACHILL_USERS_LOGIN_RATE_WINDOW;
+		$this->cache->now               = $window_end - 1;
+		$this->cache->after_add_pattern = '_total';
+		$this->cache->after_add         = static function (): void {
+			ec_record_failed_login( 'person@example.com' );
+		};
+
 		ec_record_failed_login( 'person@example.com' );
+		$old_total_key = ec_get_login_attempt_key( 'person@example.com' ) . '_window_' . intdiv( $this->cache->now, EXTRACHILL_USERS_LOGIN_RATE_WINDOW ) . '_total';
 		$this->cache->now += 2;
 
+		$this->assertSame( ( 2 * EXTRACHILL_USERS_LOGIN_RATE_WINDOW ) - 2, $this->cache->ttl( $old_total_key, EXTRACHILL_USERS_LOGIN_CACHE_GROUP ) );
+		$this->assertSame( 0, ec_login_rate_limit_store( 'get', ec_get_login_attempt_key( 'person@example.com' ) ) );
+	}
+
+	public function test_login_fixed_window_rollover_ignores_stale_clear_marker(): void {
+		ec_record_failed_login( 'person@example.com' );
+		ec_record_failed_login( 'person@example.com' );
+		ec_clear_login_attempts( 'person@example.com' );
+		ec_record_failed_login( 'person@example.com' );
 		$this->assertSame( 1, ec_login_rate_limit_store( 'get', ec_get_login_attempt_key( 'person@example.com' ) ) );
+
+		$this->cache->now = ( intdiv( $this->cache->now, EXTRACHILL_USERS_LOGIN_RATE_WINDOW ) + 1 ) * EXTRACHILL_USERS_LOGIN_RATE_WINDOW;
+		$this->assertSame( 0, ec_login_rate_limit_store( 'get', ec_get_login_attempt_key( 'person@example.com' ) ) );
+		$this->assertSame( 1, ec_record_failed_login( 'person@example.com' ) );
 	}
 
 	public function test_login_counter_expires_after_original_window(): void {
@@ -255,6 +310,22 @@ class Test_Authentication_Rate_Limits extends WP_UnitTestCase {
 
 		$this->assertSame( 1, ec_record_password_reset_attempt() );
 		$this->assertSame( 6, ec_password_reset_rate_limit_store( 'get', ec_get_password_reset_attempt_key() ) );
+	}
+
+	public function test_password_reset_add_loser_cannot_create_ttl_less_key_at_boundary(): void {
+		$window_end = ( intdiv( $this->cache->now, EXTRACHILL_USERS_PASSWORD_RESET_RATE_WINDOW ) + 1 ) * EXTRACHILL_USERS_PASSWORD_RESET_RATE_WINDOW;
+		$this->cache->now               = $window_end - 1;
+		$this->cache->after_add_pattern = 'ec_password_reset_attempts_';
+		$this->cache->after_add         = static function (): void {
+			ec_record_password_reset_attempt();
+		};
+
+		ec_record_password_reset_attempt();
+		$old_key = ec_get_password_reset_attempt_key() . '_window_' . intdiv( $this->cache->now, EXTRACHILL_USERS_PASSWORD_RESET_RATE_WINDOW );
+		$this->cache->now += 2;
+
+		$this->assertSame( ( 2 * EXTRACHILL_USERS_PASSWORD_RESET_RATE_WINDOW ) - 2, $this->cache->ttl( $old_key, EXTRACHILL_USERS_PASSWORD_RESET_CACHE_GROUP ) );
+		$this->assertSame( 0, ec_password_reset_rate_limit_store( 'get', ec_get_password_reset_attempt_key() ) );
 	}
 
 	public function test_password_reset_fifth_and_sixth_boundary_is_exact(): void {

--- a/tests/unit/PasswordResetRateLimitTest.php
+++ b/tests/unit/PasswordResetRateLimitTest.php
@@ -1,190 +1,289 @@
 <?php
 /**
- * Unit tests for password reset rate-limiter functions.
+ * Deterministic authentication rate-limit concurrency tests.
  *
- * Covers the trio added in #35:
- *   - ec_get_password_reset_attempt_key()
- *   - ec_is_password_reset_blocked()
- *   - ec_record_password_reset_attempt()
- *
- * The rate limit is intentionally keyed on requester IP only (not on
- * submitted user_login) so attackers cannot bypass it by varying input.
- * Threshold is 5 attempts per 15-minute window.
+ * @package ExtraChill\Users
  */
 
-class Test_Password_Reset_Rate_Limit extends WP_UnitTestCase {
+class Auth_Rate_Limit_Test_Cache {
+	/** @var array<string,array{value:mixed,expires_at:int}> */
+	private $data = array();
 
-	private const IP_A = '203.0.113.10';
-	private const IP_B = '203.0.113.20';
+	/** @var int */
+	private $blog_id = 1;
+
+	/** @var int */
+	public $now = 1000;
+
+	/** @var bool */
+	public $fail = false;
+
+	/** @var callable|null */
+	public $after_add;
+
+	/** @var string */
+	public $after_add_pattern = '';
+
+	/** @var callable|null */
+	public $after_incr;
+
+	/** @var string */
+	public $after_incr_pattern = '';
+
+	public function add( $key, $value, $group = 'default', $expiration = 0 ): bool {
+		if ( $this->fail ) {
+			return false;
+		}
+
+		$found = false;
+		$this->get( $key, $group, false, $found );
+		if ( $found ) {
+			return false;
+		}
+
+		$this->set( $key, $value, $group, $expiration );
+		if ( is_callable( $this->after_add ) && false !== strpos( (string) $key, $this->after_add_pattern ) ) {
+			$callback        = $this->after_add;
+			$this->after_add = null;
+			$callback();
+		}
+
+		return true;
+	}
+
+	public function set( $key, $value, $group = 'default', $expiration = 0 ): bool {
+		if ( $this->fail ) {
+			return false;
+		}
+
+		$this->data[ $this->id( $key, $group ) ] = array(
+			'value'      => $value,
+			'expires_at' => $expiration ? $this->now + (int) $expiration : 0,
+		);
+		return true;
+	}
+
+	public function get( $key, $group = 'default', $force = false, &$found = null ) {
+		if ( $this->fail ) {
+			$found = false;
+			return false;
+		}
+
+		$id    = $this->id( $key, $group );
+		$entry = $this->data[ $id ] ?? null;
+		if ( is_array( $entry ) && ( 0 === $entry['expires_at'] || $entry['expires_at'] > $this->now ) ) {
+			$found = true;
+			return $entry['value'];
+		}
+
+		unset( $this->data[ $id ] );
+		$found = false;
+		return false;
+	}
+
+	public function get_multiple( $keys, $group = 'default', $force = false ): array {
+		$values = array();
+		foreach ( $keys as $key ) {
+			$values[ $key ] = $this->get( $key, $group, $force );
+		}
+
+		return $values;
+	}
+
+	public function incr( $key, $offset = 1, $group = 'default' ) {
+		$found = false;
+		$value = $this->get( $key, $group, false, $found );
+		if ( $this->fail || ! $found || ! is_numeric( $value ) ) {
+			return false;
+		}
+
+		$id                         = $this->id( $key, $group );
+		$this->data[ $id ]['value'] = (int) $value + (int) $offset;
+		if ( is_callable( $this->after_incr ) && false !== strpos( (string) $key, $this->after_incr_pattern ) ) {
+			$callback         = $this->after_incr;
+			$this->after_incr = null;
+			$callback();
+		}
+
+		return $this->data[ $id ]['value'];
+	}
+
+	public function delete( $key, $group = 'default' ): bool {
+		$id = $this->id( $key, $group );
+		if ( ! isset( $this->data[ $id ] ) ) {
+			return false;
+		}
+
+		unset( $this->data[ $id ] );
+		return true;
+	}
+
+	public function switch_to_blog( $blog_id ): void {
+		$this->blog_id = (int) $blog_id;
+	}
+
+	public function add_global_groups( $groups ): void {
+		// Authentication groups intentionally remain blog-scoped.
+	}
+
+	private function id( $key, $group ): string {
+		return $this->blog_id . ':' . $group . ':' . $key;
+	}
+}
+
+class Test_Authentication_Rate_Limits extends WP_UnitTestCase {
+	private const IP = '203.0.113.10';
+
+	/** @var mixed */
+	private $original_cache;
+
+	/** @var bool */
+	private $original_ext_cache;
+
+	/** @var Auth_Rate_Limit_Test_Cache */
+	private $cache;
 
 	protected function setUp(): void {
 		parent::setUp();
+		$_SERVER['REMOTE_ADDR'] = self::IP;
 
-		// Defensive: the plugin loader pulls this file in, but ensure the
-		// functions are available even if a test runs in isolation.
-		if ( ! function_exists( 'ec_get_password_reset_attempt_key' ) ) {
-			require_once dirname( __DIR__, 2 ) . '/inc/auth/password-reset.php';
-		}
-
-		unset( $_SERVER['REMOTE_ADDR'] );
+		$this->original_cache       = $GLOBALS['wp_object_cache'];
+		$this->original_ext_cache   = wp_using_ext_object_cache();
+		$this->cache                = new Auth_Rate_Limit_Test_Cache();
+		$GLOBALS['wp_object_cache'] = $this->cache;
+		wp_using_ext_object_cache( true );
 	}
 
 	protected function tearDown(): void {
-		// Clean transients for both IPs and the empty-IP case so tests don't bleed.
-		foreach ( array( self::IP_A, self::IP_B, '' ) as $ip ) {
-			delete_transient( 'ec_password_reset_attempts_' . md5( $ip ) );
-		}
-
+		$GLOBALS['wp_object_cache'] = $this->original_cache;
+		wp_using_ext_object_cache( $this->original_ext_cache );
+		remove_all_filters( 'extrachill_users_login_rate_limit_store' );
+		remove_all_filters( 'extrachill_users_password_reset_rate_limit_store' );
 		unset( $_SERVER['REMOTE_ADDR'] );
 		parent::tearDown();
 	}
 
-	// ---------------------------------------------------------------------
-	// ec_get_password_reset_attempt_key()
-	// ---------------------------------------------------------------------
+	public function test_login_barrier_records_every_concurrent_failure(): void {
+		$key                           = ec_get_login_attempt_key( 'person@example.com' );
+		$this->cache->after_add_pattern = '_generation_0';
+		$this->cache->after_add         = static function (): void {
+			for ( $attempt = 0; $attempt < 5; ++$attempt ) {
+				ec_record_failed_login( 'person@example.com' );
+			}
+		};
 
-	public function test_key_uses_expected_prefix_and_md5_format(): void {
-		$_SERVER['REMOTE_ADDR'] = self::IP_A;
-		$key                    = ec_get_password_reset_attempt_key();
-
-		$this->assertStringStartsWith( 'ec_password_reset_attempts_', $key );
-		$this->assertMatchesRegularExpression( '/^ec_password_reset_attempts_[a-f0-9]{32}$/', $key );
+		$this->assertSame( 1, ec_record_failed_login( 'person@example.com' ) );
+		$this->assertSame( 6, ec_login_rate_limit_store( 'get', $key ) );
 	}
 
-	public function test_key_is_deterministic_for_same_ip(): void {
-		$_SERVER['REMOTE_ADDR'] = self::IP_A;
+	public function test_login_identity_aliases_share_canonical_counter_key(): void {
+		$GLOBALS['wp_object_cache'] = $this->original_cache;
+		wp_using_ext_object_cache( $this->original_ext_cache );
+		$user_id = self::factory()->user->create(
+			array(
+				'user_login' => 'canonical-person',
+				'user_email' => 'canonical@example.com',
+			)
+		);
+		$login_key = ec_get_login_attempt_key( 'canonical-person' );
+		$email_key = ec_get_login_attempt_key( 'canonical@example.com' );
+		$GLOBALS['wp_object_cache'] = $this->cache;
+		wp_using_ext_object_cache( true );
 
-		$this->assertSame( ec_get_password_reset_attempt_key(), ec_get_password_reset_attempt_key() );
+		$this->assertIsInt( $user_id );
+		$this->assertSame( $login_key, $email_key );
 	}
 
-	public function test_key_differs_per_ip(): void {
-		$_SERVER['REMOTE_ADDR'] = self::IP_A;
-		$key_a                  = ec_get_password_reset_attempt_key();
+	public function test_login_admits_fifth_failure_and_blocks_sixth(): void {
+		for ( $attempt = 1; $attempt <= EXTRACHILL_USERS_LOGIN_RATE_LIMIT; ++$attempt ) {
+			$result = ec_rate_limit_login( new WP_Error( 'incorrect_password', 'No.' ), 'person@example.com' );
+			$this->assertSame( 'incorrect_password', $result->get_error_code() );
+		}
 
-		$_SERVER['REMOTE_ADDR'] = self::IP_B;
-		$key_b                  = ec_get_password_reset_attempt_key();
-
-		$this->assertNotSame( $key_a, $key_b );
+		$result = ec_rate_limit_login( new WP_Error( 'incorrect_password', 'No.' ), 'person@example.com' );
+		$this->assertSame( 'ec_login_blocked', $result->get_error_code() );
 	}
 
-	public function test_key_handles_missing_remote_addr(): void {
-		unset( $_SERVER['REMOTE_ADDR'] );
-		$key = ec_get_password_reset_attempt_key();
+	public function test_successful_login_clear_does_not_erase_newer_failure(): void {
+		ec_record_failed_login( 'person@example.com' );
+		$this->cache->after_incr_pattern = '_generation';
+		$this->cache->after_incr         = static function (): void {
+			ec_record_failed_login( 'person@example.com' );
+		};
 
-		// Empty IP → md5('') = d41d8cd98f00b204e9800998ecf8427e.
-		$this->assertSame( 'ec_password_reset_attempts_' . md5( '' ), $key );
+		$this->assertSame( 0, ec_clear_login_attempts( 'person@example.com' ) );
+		$this->assertSame( 1, ec_login_rate_limit_store( 'get', ec_get_login_attempt_key( 'person@example.com' ) ) );
 	}
 
-	// ---------------------------------------------------------------------
-	// ec_is_password_reset_blocked()
-	// ---------------------------------------------------------------------
+	public function test_login_counter_expires_after_original_window(): void {
+		ec_record_failed_login( 'person@example.com' );
+		$this->cache->now += EXTRACHILL_USERS_LOGIN_RATE_WINDOW + 1;
 
-	public function test_not_blocked_when_no_transient(): void {
-		$_SERVER['REMOTE_ADDR'] = self::IP_A;
-
-		$this->assertFalse( ec_is_password_reset_blocked() );
+		$this->assertFalse( ec_is_login_blocked( 'person@example.com' ) );
+		$this->assertSame( 0, ec_login_rate_limit_store( 'get', ec_get_login_attempt_key( 'person@example.com' ) ) );
 	}
 
-	/**
-	 * @dataProvider below_threshold_attempt_counts
-	 */
-	public function test_not_blocked_below_threshold( int $attempts ): void {
-		$_SERVER['REMOTE_ADDR'] = self::IP_A;
-		set_transient( ec_get_password_reset_attempt_key(), $attempts, 15 * MINUTE_IN_SECONDS );
+	public function test_login_storage_failure_fails_closed(): void {
+		$this->cache->fail = true;
 
-		$this->assertFalse( ec_is_password_reset_blocked(), "Expected not blocked at {$attempts} attempts" );
-	}
-
-	public function below_threshold_attempt_counts(): array {
-		return array(
-			'1 attempt'  => array( 1 ),
-			'2 attempts' => array( 2 ),
-			'3 attempts' => array( 3 ),
-			'4 attempts' => array( 4 ),
+		$this->assertWPError( ec_record_failed_login( 'person@example.com' ) );
+		$this->assertTrue( ec_is_login_blocked( 'person@example.com' ) );
+		$this->assertSame(
+			'ec_login_limiter_unavailable',
+			ec_rate_limit_login( new WP_Error( 'incorrect_password', 'No.' ), 'person@example.com' )->get_error_code()
 		);
 	}
 
-	public function test_blocked_at_threshold(): void {
-		$_SERVER['REMOTE_ADDR'] = self::IP_A;
-		set_transient( ec_get_password_reset_attempt_key(), 5, 15 * MINUTE_IN_SECONDS );
+	public function test_password_reset_barrier_records_every_concurrent_attempt(): void {
+		$this->cache->after_add_pattern = 'ec_password_reset_attempts_';
+		$this->cache->after_add         = static function (): void {
+			for ( $attempt = 0; $attempt < 5; ++$attempt ) {
+				ec_record_password_reset_attempt();
+			}
+		};
 
-		$this->assertTrue( ec_is_password_reset_blocked() );
+		$this->assertSame( 1, ec_record_password_reset_attempt() );
+		$this->assertSame( 6, ec_password_reset_rate_limit_store( 'get', ec_get_password_reset_attempt_key() ) );
 	}
 
-	public function test_blocked_above_threshold(): void {
-		$_SERVER['REMOTE_ADDR'] = self::IP_A;
-		set_transient( ec_get_password_reset_attempt_key(), 42, 15 * MINUTE_IN_SECONDS );
-
-		$this->assertTrue( ec_is_password_reset_blocked() );
-	}
-
-	// ---------------------------------------------------------------------
-	// ec_record_password_reset_attempt()
-	// ---------------------------------------------------------------------
-
-	public function test_record_first_attempt_sets_counter_to_one(): void {
-		$_SERVER['REMOTE_ADDR'] = self::IP_A;
-		ec_record_password_reset_attempt();
-
-		$this->assertSame( 1, get_transient( ec_get_password_reset_attempt_key() ) );
-	}
-
-	public function test_record_subsequent_attempts_increment(): void {
-		$_SERVER['REMOTE_ADDR'] = self::IP_A;
-		ec_record_password_reset_attempt();
-		ec_record_password_reset_attempt();
-		ec_record_password_reset_attempt();
-
-		$this->assertSame( 3, get_transient( ec_get_password_reset_attempt_key() ) );
-	}
-
-	public function test_record_isolates_counters_per_ip(): void {
-		$_SERVER['REMOTE_ADDR'] = self::IP_A;
-		ec_record_password_reset_attempt();
-		ec_record_password_reset_attempt();
-		$key_a = ec_get_password_reset_attempt_key();
-
-		$_SERVER['REMOTE_ADDR'] = self::IP_B;
-		ec_record_password_reset_attempt();
-		$key_b = ec_get_password_reset_attempt_key();
-
-		$this->assertSame( 2, get_transient( $key_a ), 'IP A counter should be 2 after two records' );
-		$this->assertSame( 1, get_transient( $key_b ), 'IP B counter should be 1 after one record' );
-	}
-
-	// ---------------------------------------------------------------------
-	// End-to-end: record → check
-	// ---------------------------------------------------------------------
-
-	public function test_four_records_does_not_block(): void {
-		$_SERVER['REMOTE_ADDR'] = self::IP_A;
-
-		for ( $i = 0; $i < 4; $i++ ) {
-			ec_record_password_reset_attempt();
+	public function test_password_reset_fifth_and_sixth_boundary_is_exact(): void {
+		for ( $attempt = 1; $attempt <= EXTRACHILL_USERS_PASSWORD_RESET_RATE_LIMIT; ++$attempt ) {
+			$this->assertSame( $attempt, ec_record_password_reset_attempt() );
 		}
+
+		$this->assertTrue( ec_is_password_reset_blocked() );
+		$this->assertSame( 6, ec_record_password_reset_attempt() );
+	}
+
+	public function test_password_reset_counter_expires_after_original_window(): void {
+		ec_record_password_reset_attempt();
+		$this->cache->now += EXTRACHILL_USERS_PASSWORD_RESET_RATE_WINDOW + 1;
 
 		$this->assertFalse( ec_is_password_reset_blocked() );
 	}
 
-	public function test_five_records_blocks(): void {
-		$_SERVER['REMOTE_ADDR'] = self::IP_A;
+	public function test_password_reset_storage_failure_fails_closed(): void {
+		$this->cache->fail = true;
 
-		for ( $i = 0; $i < 5; $i++ ) {
-			ec_record_password_reset_attempt();
-		}
-
+		$this->assertWPError( ec_record_password_reset_attempt() );
 		$this->assertTrue( ec_is_password_reset_blocked() );
 	}
 
-	public function test_block_does_not_affect_other_ip(): void {
-		$_SERVER['REMOTE_ADDR'] = self::IP_A;
-		for ( $i = 0; $i < 5; $i++ ) {
-			ec_record_password_reset_attempt();
-		}
-		$this->assertTrue( ec_is_password_reset_blocked(), 'IP A should be blocked' );
+	public function test_missing_request_ip_fails_closed_without_raw_key_data(): void {
+		unset( $_SERVER['REMOTE_ADDR'] );
 
-		// Switch to IP B — should be unaffected.
-		$_SERVER['REMOTE_ADDR'] = self::IP_B;
-		$this->assertFalse( ec_is_password_reset_blocked(), 'IP B should NOT be blocked by IP A activity' );
+		$this->assertSame( '', ec_get_login_attempt_key( 'person@example.com' ) );
+		$this->assertSame( '', ec_get_password_reset_attempt_key() );
+		$this->assertTrue( ec_is_login_blocked( 'person@example.com' ) );
+		$this->assertTrue( ec_is_password_reset_blocked() );
+	}
+
+	public function test_rate_limit_groups_remain_site_scoped_on_multisite(): void {
+		ec_record_failed_login( 'person@example.com' );
+		ec_record_password_reset_attempt();
+		$this->cache->switch_to_blog( 2 );
+
+		$this->assertSame( 0, ec_login_rate_limit_store( 'get', ec_get_login_attempt_key( 'person@example.com' ) ) );
+		$this->assertSame( 0, ec_password_reset_rate_limit_store( 'get', ec_get_password_reset_attempt_key() ) );
 	}
 }

--- a/tests/unit/PasswordResetRateLimitTest.php
+++ b/tests/unit/PasswordResetRateLimitTest.php
@@ -25,10 +25,10 @@ class Auth_Rate_Limit_Test_Cache {
 	public $after_add_pattern = '';
 
 	/** @var callable|null */
-	public $after_incr;
+	public $after_set;
 
 	/** @var string */
-	public $after_incr_pattern = '';
+	public $after_set_pattern = '';
 
 	public function add( $key, $value, $group = 'default', $expiration = 0 ): bool {
 		if ( $this->fail ) {
@@ -60,6 +60,12 @@ class Auth_Rate_Limit_Test_Cache {
 			'value'      => $value,
 			'expires_at' => $expiration ? $this->now + (int) $expiration : 0,
 		);
+		if ( is_callable( $this->after_set ) && false !== strpos( (string) $key, $this->after_set_pattern ) ) {
+			$callback        = $this->after_set;
+			$this->after_set = null;
+			$callback();
+		}
+
 		return true;
 	}
 
@@ -99,12 +105,6 @@ class Auth_Rate_Limit_Test_Cache {
 
 		$id                         = $this->id( $key, $group );
 		$this->data[ $id ]['value'] = (int) $value + (int) $offset;
-		if ( is_callable( $this->after_incr ) && false !== strpos( (string) $key, $this->after_incr_pattern ) ) {
-			$callback         = $this->after_incr;
-			$this->after_incr = null;
-			$callback();
-		}
-
 		return $this->data[ $id ]['value'];
 	}
 
@@ -165,7 +165,7 @@ class Test_Authentication_Rate_Limits extends WP_UnitTestCase {
 
 	public function test_login_barrier_records_every_concurrent_failure(): void {
 		$key                           = ec_get_login_attempt_key( 'person@example.com' );
-		$this->cache->after_add_pattern = '_generation_0';
+		$this->cache->after_add_pattern = '_generation_';
 		$this->cache->after_add         = static function (): void {
 			for ( $attempt = 0; $attempt < 5; ++$attempt ) {
 				ec_record_failed_login( 'person@example.com' );
@@ -206,12 +206,23 @@ class Test_Authentication_Rate_Limits extends WP_UnitTestCase {
 
 	public function test_successful_login_clear_does_not_erase_newer_failure(): void {
 		ec_record_failed_login( 'person@example.com' );
-		$this->cache->after_incr_pattern = '_generation';
-		$this->cache->after_incr         = static function (): void {
+		$this->cache->after_set_pattern = '_generation';
+		$this->cache->after_set         = static function (): void {
 			ec_record_failed_login( 'person@example.com' );
 		};
 
 		$this->assertSame( 0, ec_clear_login_attempts( 'person@example.com' ) );
+		$this->assertSame( 1, ec_login_rate_limit_store( 'get', ec_get_login_attempt_key( 'person@example.com' ) ) );
+	}
+
+	public function test_clear_near_generation_expiry_keeps_new_failures_visible(): void {
+		ec_record_failed_login( 'person@example.com' );
+		$this->cache->now += ( 2 * EXTRACHILL_USERS_LOGIN_RATE_WINDOW ) - 1;
+
+		$this->assertSame( 0, ec_clear_login_attempts( 'person@example.com' ) );
+		ec_record_failed_login( 'person@example.com' );
+		$this->cache->now += 2;
+
 		$this->assertSame( 1, ec_login_rate_limit_store( 'get', ec_get_login_attempt_key( 'person@example.com' ) ) );
 	}
 


### PR DESCRIPTION
## Summary
- replace login and password-reset transient read/write counters with blog-scoped persistent-cache atomic counters
- use bounded 15-minute fixed-window keys with 30-minute storage TTLs, preventing addressed keys from expiring during their window
- count failed credentials inside the authentication filter and password-reset attempts before admission so the fifth/sixth boundary cannot race
- clear successful login failures with a cumulative cleared-through marker rather than deleting active counters
- fail closed when requester identity or atomic storage is unavailable

## Primitive choice and race proof
WordPress core exposes `wp_cache_add()` for atomic first-writer creation, `wp_cache_incr()` for atomic cross-worker increments, and `wp_cache_set()` for marker writes. Production uses Redis Object Cache with PhpRedis and no igbinary serialization, so increments reach Redis `INCRBY`.

Each key includes `intdiv(time(), 15 minutes)`. Totals and login clear markers receive a 30-minute TTL. A key created at any point in window N therefore remains alive throughout window N and all of N+1. Requests stop addressing it at the N/N+1 boundary, so an `add` loser cannot encounter natural key expiry before `incr`; `INCRBY` cannot create a TTL-less replacement through the former boundary race. Old keys expire without deletion.

Concurrent recorders race on `wp_cache_add()`: one creates total 1 and every loser atomically increments it. N requests therefore produce N attempts. The new window addresses a distinct key, resetting accounting without reading stale totals or markers.

## Successful-login clear ordering
Login stores a cumulative failure total and a cleared-through marker in the same fixed window. Effective attempts are `max(0, total - cleared_through)`.

A clear reads the total and writes that value to the marker. A failure linearized before the read is included and cleared; an increment after the read remains above the marker and survives. Concurrent clear writes may regress the marker, but that can only overcount failures, never hide one or bypass the threshold. No active counter key is deleted.

## Scope, identity, and failures
The cache groups are intentionally blog-scoped, preserving prior multisite transient behavior. Known login/email aliases canonicalize to the same user ID; password reset remains IP-only. Keys contain only hashed requester/identity material plus non-sensitive window numbers and suffixes.

Missing IPs, absent external object cache support, unavailable primitives, malformed values, and failed operations return explicit limiter-unavailable errors. Login and password reset fail closed rather than proceeding without reliable accounting.

## Tests
- focused WP Codebox suite: 16 tests, 46 assertions passed
- deterministic barriers cover N-way increments and exact fifth/sixth boundaries
- fixed-window regressions prove totals/markers have bounded matching lifetimes, login and reset `add` losers retain TTL across rollover, pre-clear failures clear while post-read failures survive, and stale markers do not affect the next window
- PHP syntax and `git diff --check` passed
- PR audit passed with no introduced findings
- PHPCS passed with only existing unused-parameter warnings

## Baseline failures
Changed-file lint remains red because the repository PHPStan configuration does not load WordPress symbols. The broader WP Codebox SQLite suite also has existing unrelated failures from missing cross-plugin tables and dependencies; both baselines were documented in the initial PR revision.

Closes #256
Closes #263