### PR TITLE
Fix native session revocation during moderation

### DIFF
--- a/inc/core/moderation/actions.php
+++ b/inc/core/moderation/actions.php
@@ -46,6 +46,13 @@ function extrachill_users_apply_moderation_action( int $user_id, array $args = a
 	if ( ! empty( $policy['effects']['revoke_sessions'] ) && class_exists( 'WP_Session_Tokens' ) ) {
 		$manager = WP_Session_Tokens::get_instance( $user_id );
 		$manager->destroy_all();
+
+		if ( function_exists( 'wp_native_auth_revoke_user_refresh_tokens' ) ) {
+			$native_result = wp_native_auth_revoke_user_refresh_tokens( $user_id );
+			if ( is_wp_error( $native_result ) ) {
+				return $native_result;
+			}
+		}
 	}
 
 	// Explicit, opt-in hard delete. DESTRUCTIVE AND IRREVERSIBLE — only fires

--- a/tests/unit/ModerationSessionRevocationTest.php
+++ b/tests/unit/ModerationSessionRevocationTest.php
@@ -11,6 +11,17 @@
 class Test_Moderation_Session_Revocation extends WP_UnitTestCase {
 
 	/**
+	 * Ensure the optional native-auth integration can be exercised safely.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		if ( function_exists( 'wp_native_auth_install_refresh_tokens_table' ) ) {
+			wp_native_auth_install_refresh_tokens_table();
+		}
+	}
+
+	/**
 	 * A ban destroys every existing WordPress session for the user.
 	 */
 	public function test_ban_revokes_existing_sessions(): void {
@@ -31,5 +42,112 @@ class Test_Moderation_Session_Revocation extends WP_UnitTestCase {
 		$this->assertNotWPError( $result );
 		$this->assertSame( 'banned', $result['state'] );
 		$this->assertSame( array(), WP_Session_Tokens::get_instance( $user_id )->get_all() );
+	}
+
+	/**
+	 * Native refresh tokens issued before moderation stay invalid after unban.
+	 */
+	public function test_ban_revokes_native_refresh_sessions_for_only_the_moderated_user(): void {
+		if ( ! function_exists( 'wp_native_auth_revoke_user_refresh_tokens' ) ) {
+			$this->markTestSkipped( 'wp-native-auth is unavailable.' );
+		}
+
+		$user_id       = self::factory()->user->create();
+		$other_user_id = self::factory()->user->create();
+		$device_id     = '11111111-1111-4111-8111-111111111111';
+		$other_device  = '22222222-2222-4222-8222-222222222222';
+		$token         = wp_native_auth_issue_refresh_token( $user_id, $device_id, 'Moderated Device' );
+		$other_token   = wp_native_auth_issue_refresh_token( $other_user_id, $other_device, 'Other Device' );
+
+		$result = extrachill_users_apply_moderation_action(
+			$user_id,
+			array(
+				'reason_key' => 'other',
+				'source'     => 'phpunit',
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertNotWPError( extrachill_users_clear_moderation_action( $user_id ) );
+		$this->assert_refresh_rejected( $token['token'], $device_id );
+		$this->assertNotWPError( wp_native_auth_refresh_tokens( $other_token['token'], $other_device ) );
+	}
+
+	/**
+	 * Reapplying moderation safely repeats native revocation.
+	 */
+	public function test_repeated_native_session_revocation_is_safe(): void {
+		if ( ! function_exists( 'wp_native_auth_revoke_user_refresh_tokens' ) ) {
+			$this->markTestSkipped( 'wp-native-auth is unavailable.' );
+		}
+
+		$user_id = self::factory()->user->create();
+		wp_native_auth_issue_refresh_token( $user_id, '33333333-3333-4333-8333-333333333333', 'Test Device' );
+
+		$this->assertNotWPError( extrachill_users_apply_moderation_action( $user_id, array( 'reason_key' => 'other' ) ) );
+		$this->assertNotWPError( extrachill_users_apply_moderation_action( $user_id, array( 'reason_key' => 'other' ) ) );
+	}
+
+	/**
+	 * Native storage failures are returned instead of reporting success.
+	 */
+	public function test_native_session_revocation_failure_is_returned(): void {
+		global $wpdb;
+
+		if ( ! function_exists( 'wp_native_auth_revoke_user_refresh_tokens' ) ) {
+			$this->markTestSkipped( 'wp-native-auth is unavailable.' );
+		}
+
+		$user_id    = self::factory()->user->create();
+		$table_name = wp_native_auth_refresh_tokens_table_name();
+		$fail_query = static function ( string $query ) use ( $table_name ): string {
+			if ( str_contains( $query, "UPDATE {$table_name} SET revoked_at" ) ) {
+				return 'INVALID MODERATION REVOCATION QUERY';
+			}
+
+			return $query;
+		};
+
+		wp_native_auth_issue_refresh_token( $user_id, '44444444-4444-4444-8444-444444444444', 'Test Device' );
+		add_filter( 'query', $fail_query );
+		$previous_suppression = $wpdb->suppress_errors( true );
+
+		$result = extrachill_users_apply_moderation_action( $user_id, array( 'reason_key' => 'other' ) );
+
+		$wpdb->suppress_errors( $previous_suppression );
+		remove_filter( 'query', $fail_query );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'refresh_session_revocation_failed', $result->get_error_code() );
+		$this->assertTrue( extrachill_users_is_blocked( $user_id ) );
+	}
+
+	/**
+	 * Moderation remains available when the optional native plugin is absent.
+	 */
+	public function test_moderation_without_native_auth_remains_supported(): void {
+		if ( function_exists( 'wp_native_auth_revoke_user_refresh_tokens' ) ) {
+			$this->markTestSkipped( 'wp-native-auth is available.' );
+		}
+
+		$user_id = self::factory()->user->create();
+		$result  = extrachill_users_apply_moderation_action( $user_id, array( 'reason_key' => 'other' ) );
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( 'banned', $result['state'] );
+	}
+
+	/**
+	 * Assert that a refresh token can no longer rotate.
+	 *
+	 * @param string $token     Refresh token.
+	 * @param string $device_id Device UUID.
+	 */
+	private function assert_refresh_rejected( string $token, string $device_id ): void {
+		delete_transient( 'wp_native_auth_refresh_' . md5( $device_id ) );
+		$result = wp_native_auth_refresh_tokens( $token, $device_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_refresh_token', $result->get_error_code() );
 	}
 }


### PR DESCRIPTION
## Summary
- revoke wp-native refresh sessions whenever a moderation policy revokes WordPress cookie sessions
- preserve optional-plugin behavior when wp-native is unavailable and propagate native storage failures
- add focused coverage for post-unban token rejection, unrelated-user isolation, idempotency, failure handling, and optional availability

## Root cause and security impact
Moderation policies with `revoke_sessions: true` only called `WP_Session_Tokens::destroy_all()`. That invalidated WordPress cookie sessions but left wp-native refresh credentials active. Native login policy blocked refresh while moderation remained active, but clearing moderation allowed a pre-moderation refresh token to mint credentials again, violating durable session revocation.

## wp-native contract
This consumes the public generic primitive added by chubes4/wp-native#66: `wp_native_auth_revoke_user_refresh_tokens( int $user_id )`.

The primitive atomically revokes every active refresh session for the user across devices and token families. It returns the number of newly revoked rows, including `0` for a successful idempotent no-op, or `WP_Error('refresh_session_revocation_failed')` when storage fails. Extra Chill Users treats any integer as success and returns the `WP_Error` instead of silently reporting moderation success. When wp-native is not active, the guarded optional integration is skipped and WordPress cookie-session revocation continues normally.

## Tests
- `php -l inc/core/moderation/actions.php` passed
- `php -l tests/unit/ModerationSessionRevocationTest.php` passed
- `git diff --check origin/main...HEAD` passed
- `homeboy review --changed-since origin/main --summary` reported no introduced audit findings

The Homeboy lint/test parity stage did not execute because its existing `extrachill-api` validation dependency checkout is one commit behind `origin/main`; Homeboy rejected the stale dependency before running validation. This is baseline validation-environment state, not a test regression. The repository worktree also has no local Composer binaries or PHPUnit configuration, so the added WordPress integration tests await CI execution.

Fixes #259