### PR TITLE
fix: preserve registration counter ttl at rollover

### DIFF
--- a/inc/auth/register.php
+++ b/inc/auth/register.php
@@ -61,7 +61,9 @@ function extrachill_users_registration_rate_limit_error( int $expires_at ): WP_E
  *
  * `wp_cache_add()` admits the first request and `wp_cache_incr()` atomically
  * admits every concurrent follower without a separate read/write race. Redis
- * preserves the original TTL on increment, keeping the fixed expiry stable.
+ * preserves the original TTL on increment. Retaining each addressed key for
+ * two windows prevents it from expiring between a failed add and increment,
+ * while the window in the key keeps admission accounting fixed and bounded.
  *
  * @param string $key        Network-global cache key.
  * @param int    $expires_at Fixed-window expiry timestamp.
@@ -70,7 +72,7 @@ function extrachill_users_registration_rate_limit_error( int $expires_at ): WP_E
 function extrachill_users_increment_registration_attempt( string $key, int $expires_at ) {
 	wp_cache_add_global_groups( EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP );
 
-	$ttl = max( 1, $expires_at - time() );
+	$ttl = 2 * EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW;
 	if ( wp_cache_add( $key, 1, EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP, $ttl ) ) {
 		$count = 1;
 	} else {

--- a/tests/unit/RegistrationAntiAutomationTest.php
+++ b/tests/unit/RegistrationAntiAutomationTest.php
@@ -5,6 +5,99 @@
  * @package ExtraChill\Users
  */
 
+class Registration_Rate_Limit_Test_Cache {
+	/** @var array<string,array{value:int,expires_at:int}> */
+	private $data = array();
+
+	/** @var int */
+	public $now;
+
+	/** @var callable|null */
+	public $after_failed_add;
+
+	public function __construct( int $now ) {
+		$this->now = $now;
+	}
+
+	public function add( $key, $value, $group = 'default', $expiration = 0 ): bool {
+		$found = false;
+		$this->get( $key, $group, false, $found );
+		if ( $found ) {
+			if ( is_callable( $this->after_failed_add ) ) {
+				$callback               = $this->after_failed_add;
+				$this->after_failed_add = null;
+				$callback();
+			}
+			return false;
+		}
+
+		$this->data[ $this->id( $key, $group ) ] = array(
+			'value'      => (int) $value,
+			'expires_at' => $expiration ? $this->now + (int) $expiration : 0,
+		);
+		return true;
+	}
+
+	public function get( $key, $group = 'default', $force = false, &$found = null ) {
+		$id    = $this->id( $key, $group );
+		$entry = $this->data[ $id ] ?? null;
+		if ( is_array( $entry ) && ( 0 === $entry['expires_at'] || $entry['expires_at'] > $this->now ) ) {
+			$found = true;
+			return $entry['value'];
+		}
+
+		unset( $this->data[ $id ] );
+		$found = false;
+		return false;
+	}
+
+	public function incr( $key, $offset = 1, $group = 'default' ): int {
+		$found = false;
+		$value = $this->get( $key, $group, false, $found );
+		$id    = $this->id( $key, $group );
+		if ( ! $found ) {
+			// Redis INCRBY creates a non-expiring key when the key is absent.
+			$this->data[ $id ] = array(
+				'value'      => (int) $offset,
+				'expires_at' => 0,
+			);
+			return (int) $offset;
+		}
+
+		$this->data[ $id ]['value'] = (int) $value + (int) $offset;
+		return $this->data[ $id ]['value'];
+	}
+
+	public function delete( $key, $group = 'default' ): bool {
+		$id = $this->id( $key, $group );
+		if ( ! isset( $this->data[ $id ] ) ) {
+			return false;
+		}
+
+		unset( $this->data[ $id ] );
+		return true;
+	}
+
+	public function add_global_groups( $groups ): void {
+		// Registration counters are always global in this deterministic cache.
+	}
+
+	public function ttl( $key, $group ): int {
+		$found = false;
+		$this->get( $key, $group, false, $found );
+		if ( ! $found ) {
+			return -2;
+		}
+
+		$expires_at = $this->data[ $this->id( $key, $group ) ]['expires_at'];
+		return 0 === $expires_at ? -1 : $expires_at - $this->now;
+	}
+
+	private function id( $key, $group ): string {
+		return $group . ':' . $key;
+	}
+}
+
 class Test_Registration_Anti_Automation extends WP_UnitTestCase {
 	private const IP = '203.0.113.30';
 
@@ -139,6 +232,39 @@ class Test_Registration_Anti_Automation extends WP_UnitTestCase {
 		);
 
 		wp_cache_delete( $next_key, EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP );
+	}
+
+	public function test_add_loser_retains_bounded_ttl_across_window_rollover(): void {
+		$original_cache = $GLOBALS['wp_object_cache'];
+		$window_end     = ( intdiv( time(), EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW ) + 1 ) * EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW;
+		$cache          = new Registration_Rate_Limit_Test_Cache( $window_end - 1 );
+		$old_key        = extrachill_users_registration_attempt_key( $cache->now );
+		$next_key       = extrachill_users_registration_attempt_key( $window_end );
+
+		$GLOBALS['wp_object_cache'] = $cache;
+		try {
+			$this->assertTrue( extrachill_users_increment_registration_attempt( $old_key, $window_end ) );
+			$cache->after_failed_add = static function () use ( $cache ): void {
+				$cache->now += 2;
+			};
+
+			$this->assertTrue( extrachill_users_increment_registration_attempt( $old_key, $window_end ) );
+			$this->assertSame( 2, wp_cache_get( $old_key, EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP ) );
+			$this->assertSame(
+				( 2 * EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW ) - 2,
+				$cache->ttl( $old_key, EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP )
+			);
+			$this->assertGreaterThan( 0, $cache->ttl( $old_key, EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP ) );
+			$this->assertLessThanOrEqual( 2 * EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW, $cache->ttl( $old_key, EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP ) );
+
+			$this->assertTrue( extrachill_users_increment_registration_attempt( $next_key, $window_end + EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW ) );
+			$this->assertSame( 1, wp_cache_get( $next_key, EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP ) );
+
+			$cache->now = ( $window_end - 1 ) + ( 2 * EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW );
+			$this->assertSame( -2, $cache->ttl( $old_key, EXTRACHILL_USERS_REGISTRATION_CACHE_GROUP ) );
+		} finally {
+			$GLOBALS['wp_object_cache'] = $original_cache;
+		}
 	}
 
 	public function test_missing_remote_addr_fails_closed_after_turnstile(): void {


### PR DESCRIPTION
## Summary
- retain registration fixed-window counter keys for two windows, matching the bounded lifetime established for login and password-reset counters in #261
- preserve the existing network-global key identity, atomic five-attempt admission, fail-closed errors, and fixed-window response boundary
- add a deterministic Redis-faithful rollover interleaving regression

## Race and Redis consequence
A request can compute window N's key immediately before rollover and lose `wp_cache_add()` because the counter already exists. With the previous TTL ending exactly at the N/N+1 boundary, that key could expire before the request reached `wp_cache_incr()`. Redis Object Cache maps that increment to `INCRBY`; when the key is absent, Redis creates a replacement integer with no TTL, leaving immortal attacker-controlled registration accounting.

## TTL and window semantics
New registration counters receive a storage TTL of `2 * EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW`. A key created while window N is addressable therefore remains present through the old rollover race and into N+1, so an `add` loser cannot increment an expired key. Requests in N+1 use a distinct key because the window number remains part of the key. Old keys are still bounded and expire naturally after two windows.

The public limiter boundary is unchanged: `expires_at` remains the end of the addressed 15-minute window, and `retry_after` remains derived from that boundary. The longer TTL is storage cleanup safety only; it does not extend blocking into the next fixed window.

## Compatibility
- preserves network-global registration scope and network/IP/window key identity
- preserves the five-attempt threshold and atomic N-way admission through `wp_cache_add()` plus `wp_cache_incr()`
- preserves 429 rate-limit and 503 unavailable responses
- preserves `expires_at` and `retry_after` semantics
- preserves fail-closed behavior when atomic persistent-cache primitives are unavailable

## Tests
- exact rollover regression: **1 test, 10 assertions passed**
- registration anti-automation class: **12 passed, 1 unrelated baseline failure, 47 assertions total**
- broader Codebox suite: **214 passed, 120 unrelated baseline failures, 10 skipped, 344 total**
- Homeboy PR audit: **0 introduced findings**
- changed-file PHPCS: **passed with 0 findings**
- PHP syntax and `git diff --check`: **passed**

## Unrelated baseline failures
- The registration class's existing Google registration test triggers a WordPress 6.9 incorrect-usage notice because `extrachill/track-analytics-event` is not registered in the isolated runtime.
- The broader Codebox suite has existing missing cross-plugin dependency/table failures, including `wp_datamachine_event_dates`.
- Changed-file PHPStan reports 54 existing unresolved WordPress symbols/signatures because the repository configuration does not load complete WordPress definitions; PHPCS reports no findings.

Fixes #264