### PR TITLE
chore: reduce build dependency vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@extrachill/components": "^0.5.2"
   },
   "devDependencies": {
-    "@wordpress/scripts": "^31.1.0",
+    "@wordpress/scripts": "^33.0.0",
     "ajv": "^8.20.0"
   }
 }


### PR DESCRIPTION
## Summary

- upgrade the direct dev dependency `@wordpress/scripts` from the 31.x line to the current supported 33.x line
- remove the critical advisory and reduce high-severity findings without forced audit fixes or incompatible transitive overrides
- preserve byte-identical browser assets and isolate residual upstream-only development advisories

## Audit results

| Audit | Low | Moderate | High | Critical | Total |
|---|---:|---:|---:|---:|---:|
| Release report in #268 | 3 | 23 | 20 | 1 | 47 |
| Fresh current baseline (`@wordpress/scripts` 31.8.0) | 1 | 22 | 12 | 0 | 35 |
| Fresh upgraded install (`@wordpress/scripts` 33.0.0) | 0 | 22 | 7 | 0 | 29 |
| Production-only (`npm audit --omit=dev`) | 0 | 0 | 0 | 0 | 0 |

The difference between the issue snapshot and reproduced baseline comes from this repository's intentional no-lockfile policy: a fresh install resolves newer packages within existing ranges.

## Dependency analysis

`@wordpress/scripts` is the only direct dependency implicated by `npm audit`. All residual findings are transitive development/build/test dependencies below it. `@extrachill/components`, the only production dependency, has no vulnerable audit path.

Residual groups:

- `@wordpress/scripts > adm-zip@0.5.18`: high, ZIP processing used by build tooling; patched 0.6.0 is outside the upstream constraint.
- `@wordpress/scripts > copy-webpack-plugin@10.2.4 > serialize-javascript@6.0.2`: high/moderate build-time serialization advisories.
- `@wordpress/scripts > markdownlint-cli@0.31.1 > markdownlint/markdown-it/linkify-it/minimatch`: high/moderate lint-time complexity advisories.
- `@wordpress/scripts > webpack-dev-server@4.15.2 > sockjs > uuid`: moderate development-server advisories; the repository's production build does not start this server.
- `@wordpress/scripts > @wordpress/e2e-test-utils-playwright > lighthouse > @sentry/node > OpenTelemetry`: moderate e2e/Lighthouse instrumentation advisories; this repository does not invoke the e2e runner.

The published `@wordpress/scripts@33.0.0` dependency metadata is also inconsistent with its changelog, which says webpack-dev-server was upgraded to v5 while npm still declares `^4.15.1`. This and the residual paths are tracked upstream in WordPress/gutenberg#80682. Root overrides were intentionally rejected because they would bypass upstream constraints and can cross major-version compatibility boundaries.

## Shipped-code reachability

- `npm audit --omit=dev --json` reports zero findings.
- `node_modules`, package lockfiles, source blocks, and tests are excluded from production artifacts by `.buildignore`.
- The vulnerable package names do not occur in generated JS/CSS/PHP/JSON assets.
- Before/after SHA-256 checksums for every generated asset are identical.

The residual advisories can affect local build, lint, dev-server, or e2e operations if those tools process attacker-controlled inputs. They cannot execute in shipped browser or PHP runtime code.

## Verification

- clean policy-compliant install: `rm -rf node_modules package-lock.json && npm install`
- full audit: `npm audit --json` (29 dev-only findings: 22 moderate, 7 high)
- production audit: `npm audit --omit=dev --json` (0 findings)
- frontend build: `npm run build` (pass)
- JavaScript tests: `npm run test:unit:js -- --runInBand` (3/3 pass)
- bundle reachability scan for all vulnerable module names (no matches)
- generated asset SHA-256 comparison (byte-identical)
- scoped JavaScript lint executed; it remains blocked by the existing ESLint/config/format debt in #266. Version 33 warns that the repository's legacy `.eslintrc` and `.eslintignore` need flat-config migration and reports that existing debt; no source or lint configuration is changed here.

The build also confirmed an unrelated pre-existing multi-entry cleanup bug that can remove login editor assets; tracked separately in #269 and intentionally excluded from this PR.

Closes #268