### PR TITLE
test: provision event dates fixture

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -4,6 +4,7 @@
   "extensions": {
     "wordpress": {
       "settings": {
+        "validation_dependencies": ["data-machine-events"],
         "wordpress_runtime_php_version": "8.4"
       }
     }

--- a/tests/unit/ConcertTrackingAbilitiesTest.php
+++ b/tests/unit/ConcertTrackingAbilitiesTest.php
@@ -5,6 +5,8 @@
  * @package ExtraChill\Users
  */
 
+use DataMachineEvents\Core\EventDatesTable;
+
 /**
  * Exercise concert attendance through registered WP_Ability contracts.
  */
@@ -25,18 +27,21 @@ class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
 		$this->user_id        = self::factory()->user->create();
 
 		add_filter( 'extrachill_users_events_blog_id', array( $this, 'filter_events_blog_id' ) );
+		add_filter( 'extrachill_users_event_timing_now', array( $this, 'filter_event_timing_now' ) );
 		if ( ! post_type_exists( 'data_machine_events' ) ) {
 			register_post_type( 'data_machine_events', array( 'public' => true ) );
 		}
 
 		switch_to_blog( $this->events_blog_id );
 		try {
+			EventDatesTable::create_table();
 			$this->event_id = self::factory()->post->create(
 				array(
 					'post_type'   => 'data_machine_events',
 					'post_status' => 'publish',
 				)
 			);
+			EventDatesTable::upsert( $this->event_id, '2026-07-25 20:00:00', null, 'publish' );
 		} finally {
 			restore_current_blog();
 		}
@@ -49,12 +54,35 @@ class Test_Concert_Tracking_Abilities extends WP_UnitTestCase {
 	protected function tearDown(): void {
 		$this->clear_tracking_table();
 		remove_filter( 'extrachill_users_events_blog_id', array( $this, 'filter_events_blog_id' ) );
+		remove_filter( 'extrachill_users_event_timing_now', array( $this, 'filter_event_timing_now' ) );
 		wp_set_current_user( 0 );
 		parent::tearDown();
 	}
 
 	public function filter_events_blog_id(): int {
 		return $this->events_blog_id;
+	}
+
+	public function filter_event_timing_now(): string {
+		return '2026-07-24 12:00:00';
+	}
+
+	public function test_event_timing_uses_owned_event_dates_fixture_for_all_states(): void {
+		$fixtures = array(
+			'upcoming' => array( '2026-07-25 20:00:00', null ),
+			'ongoing'  => array( '2026-07-24 10:00:00', '2026-07-24 14:00:00' ),
+			'past'     => array( '2026-07-23 20:00:00', '2026-07-23 23:00:00' ),
+		);
+
+		switch_to_blog( $this->events_blog_id );
+		try {
+			foreach ( $fixtures as $expected => $dates ) {
+				EventDatesTable::upsert( $this->event_id, $dates[0], $dates[1], 'publish' );
+				$this->assertSame( $expected, ec_users_get_event_timing( $this->event_id, $this->events_blog_id ) );
+			}
+		} finally {
+			restore_current_blog();
+		}
 	}
 
 	public function test_registered_set_ability_validates_input_and_declares_stable_output(): void {


### PR DESCRIPTION
## Summary

- declare Data Machine Events as a Homeboy validation dependency so the fresh Codebox runtime has the schema owner available
- provision each generated Events-site table through `DataMachineEvents\Core\EventDatesTable::create_table()` instead of duplicating its schema
- seed deterministic event dates through the owner's `upsert()` primitive and cover upcoming, ongoing, and past timing against a fixed clock

## Root cause

`Test_Concert_Tracking_Abilities` created event posts and the Users concert-tracking table, but not the authoritative per-site `datamachine_event_dates` table. Ability callbacks call `ec_users_get_event_timing()`, so fresh SQLite runtimes queried an absent table and cascaded failures. Production code is unchanged because schema ownership remains with Data Machine Events; the missing setup was entirely in the integration-style test harness.

## Verification

Passed:

```text
php -l tests/unit/ConcertTrackingAbilitiesTest.php
No syntax errors detected

jq empty homeboy.json
git diff --check

homeboy review test extrachill-users \
  --path /var/lib/datamachine/workspace/extrachill-users@test-267-event-dates-fixture \
  --placement local \
  --setting-json validation_dependencies='[\"/var/lib/datamachine/workspace/data-machine-events\"]' \
  -- --filter='test_event_timing_uses_owned_event_dates_fixture_for_all_states|test_registered_set_ability_is_idempotent_in_both_directions'

OK (2 tests, 13 assertions)
Run: d4cb95ed-ed52-40f5-8637-16dd14588155
```

Required full command executed:

```text
homeboy review test extrachill-users \
  --path /var/lib/datamachine/workspace/extrachill-users@test-267-event-dates-fixture \
  --placement local

Run: 380bf68d-5289-4d1a-a3fd-0063743a033e
```

The installed Homeboy runtime omits repository-declared `validation_dependencies` from the generated recipe even though `homeboy component show` resolves the setting. The explicit absolute override proves the fixture itself passes when the owner is mounted. This upstream settings-forwarding defect is tracked with recipe evidence in Extra-Chill/homeboy#9926; no Users-side workaround was added.

Closes #267