### PR TITLE
feat: welcome new users into the clubhouse

### DIFF
--- a/inc/core/registration-emails.php
+++ b/inc/core/registration-emails.php
@@ -188,8 +188,8 @@ function extrachill_send_welcome_email_complete( $user_data ) {
 
 	$subject = 'Welcome to the Extra Chill Community!';
 
-	$body_html  = "<p>Welcome to <strong>Extra Chill</strong>! Now that you're here, this place is a lot more chill!</p>";
-	$body_html .= '<p>With your account, you can now participate in community discussions, comment on posts, and follow your favorite artists.</p>';
+	$body_html  = "<p>Welcome to <strong>Extra Chill</strong>! Now that you're here, this place is a lot more chill.</p>";
+	$body_html .= '<p>Make yourself at home. You can join discussions, comment on stories, track concerts, and keep up with replies and activity through notifications.</p>';
 	$body_html .= '<p><strong>Account Details:</strong><br>';
 	$body_html .= 'Username: <strong>' . esc_html( $username ) . '</strong><br>';
 	$body_html .= 'If you forget your password, you can reset it <a href="' . esc_url( $reset_pass_link ) . '">here</a>.</p>';
@@ -205,8 +205,8 @@ function extrachill_send_welcome_email_complete( $user_data ) {
 				'subject_html'   => esc_html( $subject ),
 				'body_html'      => $body_html,
 				'recipient_name' => $username,
-				'cta_url'        => $community_url . '/t/introductions-thread',
-				'cta_label'      => 'Introduce Yourself',
+				'cta_url'        => $community_url,
+				'cta_label'      => 'See What’s Happening',
 				'preheader'      => 'Welcome to Extra Chill — your account is ready.',
 			),
 		)
@@ -233,19 +233,23 @@ function extrachill_send_welcome_email_complete( $user_data ) {
  */
 function extrachill_send_welcome_email_incomplete( $user_data ) {
 	$email         = $user_data->user_email;
-	$profile_url   = ec_get_site_url( 'community' ) . '/settings/';
 	$community_url = ec_get_site_url( 'community' );
+	$profile_url   = $community_url . '/settings/';
+	$events_url    = ec_get_site_url( 'events' );
+	$artist_url    = ec_get_site_url( 'artist' );
 
-	$subject = 'Your Extra Chill account is ready';
+	$subject = 'Make yourself at home at Extra Chill';
 
-	$body_html  = '<p>Welcome to <strong>Extra Chill</strong>! Your account is ready, and you can jump in whenever you want.</p>';
-	$body_html .= '<p><strong>Make your profile yours</strong> by adding a photo, bio, links, username, and local scene. You can do that now or come back to it later.</p>';
-	$body_html .= '<p>Your account lets you:</p>';
-	$body_html .= '<ul><li>Join community discussions and comment on stories</li>';
-	$body_html .= '<li>Track concerts and see who else is going</li>';
-	$body_html .= '<li>Follow artists and keep up with notifications</li>';
-	$body_html .= '<li>Explore artist and music-industry tools</li></ul>';
-	$body_html .= '<p><a href="' . esc_url( $community_url ) . '">Visit the Extra Chill Community</a> anytime.</p>';
+	$body_html  = '<p>You’re in. <strong>Extra Chill</strong> is an online music scene: a place to keep up with the music around you, talk with people who care, and take part in what’s happening.</p>';
+	$body_html .= '<p>There’s no setup checklist. Make yourself at home:</p>';
+	$body_html .= '<ul><li><a href="' . esc_url( $community_url ) . '">See what people are talking about</a></li>';
+	$body_html .= '<li><a href="' . esc_url( $events_url ) . '">Find shows and track concerts</a></li>';
+	$body_html .= '<li><a href="' . esc_url( $profile_url ) . '">Make your profile yours</a> whenever you’re ready</li></ul>';
+	$body_html .= '<p><strong>A few quick answers</strong></p>';
+	$body_html .= '<p><strong>Do I need to finish my profile?</strong><br>Nope. Add a photo, bio, links, username, and local scene now or come back later.</p>';
+	$body_html .= '<p><strong>Is Extra Chill just a music blog?</strong><br>No. Stories are one part of an interconnected publication, community, event calendar, and set of artist tools.</p>';
+	$body_html .= '<p><strong>Where should I start?</strong><br>See what’s happening and jump in whenever something grabs you.</p>';
+	$body_html .= '<p>If you make music, you can also explore the <a href="' . esc_url( $artist_url ) . '">artist platform</a> whenever you’re ready.</p>';
 	$body_html .= '<p>Much love,<br>Extra Chill</p>';
 
 	$result = extrachill_send_registration_email(
@@ -256,9 +260,9 @@ function extrachill_send_welcome_email_incomplete( $user_data ) {
 			'context'  => array(
 				'subject_html' => esc_html( $subject ),
 				'body_html'    => $body_html,
-				'cta_url'      => $profile_url,
-				'cta_label'    => 'Customize Your Profile',
-				'preheader'    => 'Your account is ready. Make your profile yours whenever you have time.',
+				'cta_url'      => $community_url,
+				'cta_label'    => 'See What’s Happening',
+				'preheader'    => 'You’re in. See what’s happening and make yourself at home.',
 			),
 		)
 	);

--- a/tests/unit/RegistrationEmailFailureTest.php
+++ b/tests/unit/RegistrationEmailFailureTest.php
@@ -205,6 +205,20 @@ class Test_Registration_Email_Failure extends WP_UnitTestCase {
 		$this->assertSame( '', $this->read_error_log() );
 	}
 
+	public function test_welcome_complete_uses_participation_language_without_followers(): void {
+		$GLOBALS['test_ec_send_email_result'] = array( 'success' => true );
+
+		$user_id   = $this->make_user();
+		$user_data = get_userdata( $user_id );
+
+		$this->assertTrue( extrachill_send_welcome_email_complete( $user_data ) );
+
+		$args = $GLOBALS['test_ec_send_email_last_args'];
+		$this->assertSame( 'See What’s Happening', $args['context']['cta_label'] );
+		$this->assertStringContainsString( 'Make yourself at home', $args['context']['body_html'] );
+		$this->assertDoesNotMatchRegularExpression( '/\bfollow(?:er|ers|ing|s|ed)?\b/i', $args['context']['body_html'] );
+	}
+
 	// ---------------------------------------------------------------------
 	// extrachill_send_welcome_email_incomplete() — onboarding-incomplete path
 	// ---------------------------------------------------------------------
@@ -238,7 +252,7 @@ class Test_Registration_Email_Failure extends WP_UnitTestCase {
 		$this->assertSame( '', $this->read_error_log() );
 	}
 
-	public function test_welcome_incomplete_promotes_optional_profile_setup_and_features(): void {
+	public function test_welcome_incomplete_invites_users_into_the_clubhouse(): void {
 		$GLOBALS['test_ec_send_email_result'] = array( 'success' => true );
 
 		$user_id   = $this->make_user();
@@ -247,11 +261,16 @@ class Test_Registration_Email_Failure extends WP_UnitTestCase {
 		$this->assertTrue( extrachill_send_welcome_email_incomplete( $user_data ) );
 
 		$args = $GLOBALS['test_ec_send_email_last_args'];
-		$this->assertSame( 'Your Extra Chill account is ready', $args['subject'] );
-		$this->assertSame( 'https://community.extrachill.com/settings/', $args['context']['cta_url'] );
-		$this->assertSame( 'Customize Your Profile', $args['context']['cta_label'] );
-		$this->assertStringContainsString( 'you can jump in', $args['context']['body_html'] );
-		$this->assertStringContainsString( 'Track concerts', $args['context']['body_html'] );
+		$this->assertSame( 'Make yourself at home at Extra Chill', $args['subject'] );
+		$this->assertSame( 'https://community.extrachill.com', $args['context']['cta_url'] );
+		$this->assertSame( 'See What’s Happening', $args['context']['cta_label'] );
+		$this->assertStringContainsString( 'online music scene', $args['context']['body_html'] );
+		$this->assertStringContainsString( 'There’s no setup checklist', $args['context']['body_html'] );
+		$this->assertStringContainsString( 'A few quick answers', $args['context']['body_html'] );
+		$this->assertStringContainsString( 'Do I need to finish my profile?', $args['context']['body_html'] );
+		$this->assertStringContainsString( 'Is Extra Chill just a music blog?', $args['context']['body_html'] );
+		$this->assertStringContainsString( 'Find shows and track concerts', $args['context']['body_html'] );
+		$this->assertDoesNotMatchRegularExpression( '/\bfollow(?:er|ers|ing|s|ed)?\b/i', $args['context']['body_html'] );
 	}
 
 	// ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- reshape the fast-signup follow-up around “Make yourself at home” and Extra Chill as an online music scene
- make “See What’s Happening” the primary action while keeping profile setup optional and secondary
- add a compact FAQ plus direct paths into discussions, events, profiles, and artist tools
- remove follower language from both account welcome variants and guard against its return in regression assertions

## Verification

- `homeboy --placement local review lint --changed-only` (PHPCS and PHPStan passed with no findings)
- PHP syntax checks passed
- source contract confirms required clubhouse/FAQ copy and no follower language
- focused PHPUnit could not execute because `Test_Registration_Email_Failure` requires child processes, which WP Codebox Playground does not support; all 12 tests stopped before assertions

## Follow-up

- #277 tracks the separate follower terminology violation in private artist email-consent abilities.

Closes #276
