### PR TITLE
feat: add idempotent notification delivery receipts

### DIFF
--- a/inc/core/activation.php
+++ b/inc/core/activation.php
@@ -38,14 +38,17 @@ function extrachill_users_run_activation() {
 	update_site_option( 'extrachill_users_concert_import_runs_table_created', 1 );
 
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/notifications/db.php';
+	$notifications_table_ready = false;
 	if ( function_exists( 'extrachill_users_install_notifications_table' ) ) {
-		extrachill_users_install_notifications_table();
+		$notifications_table_ready = extrachill_users_install_notifications_table();
 	}
 
-	update_site_option(
-		'extrachill_users_notifications_schema_version',
-		defined( 'EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION' ) ? (string) EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION : '1'
-	);
+	if ( $notifications_table_ready ) {
+		update_site_option(
+			'extrachill_users_notifications_schema_version',
+			defined( 'EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION' ) ? (string) EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION : '1'
+		);
+	}
 
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/entity-subscriptions/db.php';
 	extrachill_users_install_entity_subscriptions_table();

--- a/inc/notifications/db.php
+++ b/inc/notifications/db.php
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
  * upgrade path).
  */
 if ( ! defined( 'EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION' ) ) {
-	define( 'EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION', '2' );
+	define( 'EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION', '3' );
 }
 
 /**
@@ -62,11 +62,16 @@ function extrachill_users_notifications_table_name() {
  *                (NULL == never emailed). Drives "nudge once per notification":
  *                a notification is eligible for the digest exactly once, then
  *                its emailed_at is stamped so it never re-triggers an email.
+ *   - producer / idempotency_key identify an optional producer-owned delivery
+ *   - delivery_key is their SHA-256 digest, used for compact atomic uniqueness
  *
  * Indexes:
  *   - idx_user_unread  (user_id, is_read, created_at) — bell badge + unread list
  *   - idx_user_created (user_id, created_at)          — full paginated list
  *   - idx_email_sweep  (is_read, emailed_at, created_at) — digest eligibility scan
+ *   - uq_delivery      (user_id, delivery_key) — per-recipient replay protection
+ *
+ * @return bool True when the receipt columns and unique index are installed.
  */
 function extrachill_users_install_notifications_table() {
 	global $wpdb;
@@ -87,15 +92,53 @@ function extrachill_users_install_notifications_table() {
 		is_read tinyint(1) NOT NULL DEFAULT 0,
 		created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		emailed_at datetime DEFAULT NULL,
+		producer varchar(64) DEFAULT NULL,
+		idempotency_key varchar(191) DEFAULT NULL,
+		delivery_key char(64) DEFAULT NULL,
 		PRIMARY KEY  (id),
 		KEY idx_user_unread (user_id, is_read, created_at),
 		KEY idx_user_created (user_id, created_at),
-		KEY idx_email_sweep (is_read, emailed_at, created_at)
+		KEY idx_email_sweep (is_read, emailed_at, created_at),
+		UNIQUE KEY uq_delivery (user_id, delivery_key)
 	) {$charset_collate};";
 
 	dbDelta( $sql );
 
 	extrachill_users_backfill_notifications_emailed_at();
+
+	return extrachill_users_notifications_receipt_schema_is_healthy();
+}
+
+/**
+ * Verify the columns and unique index required for atomic delivery receipts.
+ *
+ * This is deliberately called after dbDelta rather than on every request. The
+ * schema version is advanced only after the migration is actually usable, so a
+ * failed migration is retried by the existing init guard.
+ *
+ * @return bool True when the receipt schema is ready.
+ */
+function extrachill_users_notifications_receipt_schema_is_healthy() {
+	global $wpdb;
+
+	$table   = extrachill_users_notifications_table_name();
+	$columns = $wpdb->get_col( "SHOW COLUMNS FROM {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+
+	foreach ( array( 'producer', 'idempotency_key', 'delivery_key' ) as $required_column ) {
+		if ( ! in_array( $required_column, (array) $columns, true ) ) {
+			return false;
+		}
+	}
+
+	$indexes = $wpdb->get_results( "SHOW INDEX FROM {$table} WHERE Key_name = 'uq_delivery'", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper and static index name.
+	if ( 2 !== count( (array) $indexes ) ) {
+		return false;
+	}
+
+	$indexed_columns = array_column( $indexes, 'Column_name' );
+
+	return array( 'user_id', 'delivery_key' ) === array_values( $indexed_columns )
+		&& 0 === (int) $indexes[0]['Non_unique'];
 }
 
 /**

--- a/inc/notifications/service.php
+++ b/inc/notifications/service.php
@@ -91,9 +91,9 @@ function ec_users_maybe_install_notifications_table() {
 		return;
 	}
 
-	extrachill_users_install_notifications_table();
-
-	update_site_option( 'extrachill_users_notifications_schema_version', $current_version );
+	if ( extrachill_users_install_notifications_table() ) {
+		update_site_option( 'extrachill_users_notifications_schema_version', $current_version );
+	}
 }
 add_action( 'init', 'ec_users_maybe_install_notifications_table' );
 
@@ -119,11 +119,50 @@ add_action( 'init', 'ec_users_maybe_install_notifications_table' );
  * @return int Number of notification rows inserted.
  */
 function ec_users_notify( $user_ids, array $data ): int {
+	$receipt = ec_users_notify_with_receipts( $user_ids, $data );
+
+	return (int) $receipt['inserted'];
+}
+
+/**
+ * Create notifications and return a per-recipient delivery receipt.
+ *
+ * Producers that need retry safety pass both `producer` and `idempotency_key`.
+ * Their exact pair is hashed into the compact delivery key protected by the
+ * table's unique (user_id, delivery_key) index. Concurrent calls therefore
+ * converge on one row per recipient while unrelated producers remain isolated.
+ * Omitting both fields retains the historical non-idempotent insert behavior.
+ *
+ * Requested IDs are normalized to a unique recipient set. Each receipt has an
+ * inserted, existing, or failed status. A notification row ID is returned only
+ * after an insert or an exact producer/key replay has been verified.
+ *
+ * @param int|int[] $user_ids Single recipient ID or array of recipient IDs.
+ * @param array     $data {
+ *     Notification payload. See ec_users_notify().
+ *
+ *     @type string $producer        Optional producer namespace. Must be paired
+ *                                   with idempotency_key.
+ *     @type string $idempotency_key Optional producer-owned replay key. Must be
+ *                                   paired with producer.
+ * }
+ * @return array{requested:int, inserted:int, existing:int, failed:int, recipients:array<int,array{user_id:int,status:string,notification_id:?int,error:?string}>}
+ */
+function ec_users_notify_with_receipts( $user_ids, array $data ): array {
 	global $wpdb;
 
 	if ( ! is_array( $user_ids ) ) {
 		$user_ids = array( $user_ids );
 	}
+
+	$user_ids = array_values( array_unique( array_map( 'intval', $user_ids ) ) );
+	$receipt  = array(
+		'requested'  => count( $user_ids ),
+		'inserted'   => 0,
+		'existing'   => 0,
+		'failed'     => 0,
+		'recipients' => array(),
+	);
 
 	// Validate required fields.
 	$actor_id = isset( $data['actor_id'] ) ? (int) $data['actor_id'] : 0;
@@ -138,12 +177,31 @@ function ec_users_notify( $user_ids, array $data ): int {
 
 	$title = sanitize_text_field( $title );
 
+	$producer        = isset( $data['producer'] ) ? strtolower( trim( (string) $data['producer'] ) ) : '';
+	$idempotency_key = isset( $data['idempotency_key'] ) ? trim( (string) $data['idempotency_key'] ) : '';
+	$has_producer    = '' !== $producer;
+	$has_key         = '' !== $idempotency_key;
+	$payload_error   = null;
+
 	if ( ! $actor_id || '' === $type || '' === $link || '' === $title ) {
-		return 0;
+		$payload_error = 'invalid_payload';
+	} elseif ( ! get_userdata( $actor_id ) ) {
+		$payload_error = 'invalid_actor';
+	} elseif ( $has_producer !== $has_key ) {
+		$payload_error = 'incomplete_idempotency';
+	} elseif ( $has_producer && ( strlen( $producer ) > 64 || ! preg_match( '/^[a-z0-9][a-z0-9._\/-]*$/', $producer ) ) ) {
+		$payload_error = 'invalid_producer';
+	} elseif ( $has_key && ( strlen( $idempotency_key ) > 191 || preg_match( '/[\x00-\x1F\x7F]/', $idempotency_key ) ) ) {
+		$payload_error = 'invalid_idempotency_key';
 	}
 
-	if ( ! get_userdata( $actor_id ) ) {
-		return 0;
+	if ( null !== $payload_error ) {
+		foreach ( $user_ids as $user_id ) {
+			$receipt['recipients'][ $user_id ] = ec_users_notification_failed_receipt( $user_id, $payload_error );
+			++$receipt['failed'];
+		}
+
+		return $receipt;
 	}
 
 	$item_id = isset( $data['item_id'] ) ? (int) $data['item_id'] : 0;
@@ -154,33 +212,93 @@ function ec_users_notify( $user_ids, array $data ): int {
 
 	$table        = extrachill_users_notifications_table_name();
 	$created_at   = current_time( 'mysql', true );
-	$inserted     = 0;
 	$notified_ids = array();
+	$delivery_key = $has_producer ? hash( 'sha256', $producer . "\0" . $idempotency_key ) : null;
 
 	foreach ( $user_ids as $user_id ) {
-		$user_id = (int) $user_id;
-
 		if ( $user_id <= 0 || ! get_userdata( $user_id ) ) {
+			$receipt['recipients'][ $user_id ] = ec_users_notification_failed_receipt( $user_id, 'invalid_user' );
+			++$receipt['failed'];
 			continue;
 		}
 
-		$result = $wpdb->insert(
-			$table,
-			array(
-				'user_id'    => $user_id,
-				'actor_id'   => $actor_id,
-				'type'       => $type,
-				'title'      => $title,
-				'link'       => $link,
-				'item_id'    => $item_id > 0 ? $item_id : null,
-				'is_read'    => 0,
-				'created_at' => $created_at,
-			),
-			array( '%d', '%d', '%s', '%s', '%s', $item_id > 0 ? '%d' : null, '%d', '%s' )
-		);
+		if ( $has_producer ) {
+			$result = $wpdb->query(
+				$wpdb->prepare(
+					"INSERT IGNORE INTO {$table} (user_id, actor_id, type, title, link, item_id, is_read, created_at, producer, idempotency_key, delivery_key) VALUES (%d, %d, %s, %s, %s, NULLIF(%d, 0), 0, %s, %s, %s, %s)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+					$user_id,
+					$actor_id,
+					$type,
+					$title,
+					$link,
+					$item_id,
+					$created_at,
+					$producer,
+					$idempotency_key,
+					$delivery_key
+				)
+			);
+		} else {
+			$result = $wpdb->insert(
+				$table,
+				array(
+					'user_id'    => $user_id,
+					'actor_id'   => $actor_id,
+					'type'       => $type,
+					'title'      => $title,
+					'link'       => $link,
+					'item_id'    => $item_id > 0 ? $item_id : null,
+					'is_read'    => 0,
+					'created_at' => $created_at,
+				),
+				array( '%d', '%d', '%s', '%s', '%s', $item_id > 0 ? '%d' : null, '%d', '%s' )
+			);
+		}
 
-		if ( $result ) {
-			++$inserted;
+		if ( false === $result ) {
+			$receipt['recipients'][ $user_id ] = ec_users_notification_failed_receipt( $user_id, 'insert_failed' );
+			++$receipt['failed'];
+			continue;
+		}
+
+		$notification_id = (int) $wpdb->insert_id;
+		$status          = 'inserted';
+
+		if ( $has_producer && 1 !== (int) $result ) {
+			$existing = $wpdb->get_row(
+				$wpdb->prepare(
+					"SELECT id, producer, idempotency_key FROM {$table} WHERE user_id = %d AND delivery_key = %s LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+					$user_id,
+					$delivery_key
+				),
+				ARRAY_A
+			);
+
+			if ( ! $existing || $producer !== $existing['producer'] || $idempotency_key !== $existing['idempotency_key'] ) {
+				$receipt['recipients'][ $user_id ] = ec_users_notification_failed_receipt( $user_id, 'insert_failed' );
+				++$receipt['failed'];
+				continue;
+			}
+
+			$status          = 'existing';
+			$notification_id = (int) $existing['id'];
+		}
+
+		if ( $notification_id <= 0 ) {
+			$receipt['recipients'][ $user_id ] = ec_users_notification_failed_receipt( $user_id, 'row_id_unavailable' );
+			++$receipt['failed'];
+			continue;
+		}
+
+		$receipt['recipients'][ $user_id ] = array(
+			'user_id'         => $user_id,
+			'status'          => $status,
+			'notification_id' => $notification_id,
+			'error'           => null,
+		);
+		++$receipt[ $status ];
+
+		if ( 'inserted' === $status ) {
 			$notified_ids[] = $user_id;
 		}
 	}
@@ -190,7 +308,23 @@ function ec_users_notify( $user_ids, array $data ): int {
 		ec_users_flush_unread_count_cache( $notified_ids );
 	}
 
-	return $inserted;
+	return $receipt;
+}
+
+/**
+ * Build a failed per-recipient delivery receipt.
+ *
+ * @param int    $user_id Recipient ID as requested.
+ * @param string $error   Stable failure code.
+ * @return array{user_id:int,status:string,notification_id:null,error:string}
+ */
+function ec_users_notification_failed_receipt( int $user_id, string $error ): array {
+	return array(
+		'user_id'         => $user_id,
+		'status'          => 'failed',
+		'notification_id' => null,
+		'error'           => $error,
+	);
 }
 
 // ─── Read / CRUD ─────────────────────────────────────────────────────────────

--- a/tests/unit/NotificationDeliveryReceiptsTest.php
+++ b/tests/unit/NotificationDeliveryReceiptsTest.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Tests for idempotent notification delivery receipts.
+ *
+ * @package ExtraChill\Users
+ */
+
+class Test_Notification_Delivery_Receipts extends WP_UnitTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		extrachill_users_install_notifications_table();
+
+		global $wpdb;
+		$table = extrachill_users_notifications_table_name();
+		$wpdb->query( "DELETE FROM {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- test table from trusted helper.
+	}
+
+	private function payload( int $actor_id, array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'actor_id'       => $actor_id,
+				'type'           => 'test_notice',
+				'title'          => 'A test notification',
+				'link'           => 'https://example.org/notice',
+				'item_id'        => 42,
+				'producer'       => 'tests.notifications',
+				'idempotency_key' => 'delivery-42',
+			),
+			$overrides
+		);
+	}
+
+	public function test_replay_returns_existing_row_receipt(): void {
+		$actor     = self::factory()->user->create();
+		$recipient = self::factory()->user->create();
+
+		$this->assertSame( 0, ec_users_get_unread_count( $recipient ) );
+
+		$first  = ec_users_notify_with_receipts( $recipient, $this->payload( $actor ) );
+		$second = ec_users_notify_with_receipts( $recipient, $this->payload( $actor ) );
+
+		$this->assertSame( 1, $first['inserted'] );
+		$this->assertSame( 'inserted', $first['recipients'][ $recipient ]['status'] );
+		$this->assertSame( 1, $second['existing'] );
+		$this->assertSame( 'existing', $second['recipients'][ $recipient ]['status'] );
+		$this->assertSame( $first['recipients'][ $recipient ]['notification_id'], $second['recipients'][ $recipient ]['notification_id'] );
+		$this->assertSame( 1, ec_users_get_unread_count( $recipient ) );
+	}
+
+	public function test_same_key_is_isolated_by_producer_and_recipient(): void {
+		$actor      = self::factory()->user->create();
+		$recipient1 = self::factory()->user->create();
+		$recipient2 = self::factory()->user->create();
+
+		$first = ec_users_notify_with_receipts( array( $recipient1, $recipient2 ), $this->payload( $actor ) );
+		$other = ec_users_notify_with_receipts(
+			$recipient1,
+			$this->payload( $actor, array( 'producer' => 'tests.other-producer' ) )
+		);
+
+		$this->assertSame( 2, $first['inserted'] );
+		$this->assertSame( 1, $other['inserted'] );
+		$this->assertSame( 2, ec_users_get_unread_count( $recipient1 ) );
+		$this->assertSame( 1, ec_users_get_unread_count( $recipient2 ) );
+	}
+
+	public function test_partial_failure_identifies_retryable_recipient(): void {
+		$actor     = self::factory()->user->create();
+		$recipient = self::factory()->user->create();
+		$missing   = 999999999;
+
+		$receipt = ec_users_notify_with_receipts( array( $recipient, $missing ), $this->payload( $actor ) );
+		$retry   = ec_users_notify_with_receipts( $recipient, $this->payload( $actor ) );
+
+		$this->assertSame( 1, $receipt['inserted'] );
+		$this->assertSame( 1, $receipt['failed'] );
+		$this->assertSame( 'invalid_user', $receipt['recipients'][ $missing ]['error'] );
+		$this->assertSame( 'existing', $retry['recipients'][ $recipient ]['status'] );
+	}
+
+	public function test_invalid_actor_and_incomplete_idempotency_fail_each_recipient(): void {
+		$recipient = self::factory()->user->create();
+
+		$invalid_actor = ec_users_notify_with_receipts( $recipient, $this->payload( 999999999 ) );
+		$incomplete    = ec_users_notify_with_receipts(
+			$recipient,
+			$this->payload( self::factory()->user->create(), array( 'idempotency_key' => '' ) )
+		);
+
+		$this->assertSame( 'invalid_actor', $invalid_actor['recipients'][ $recipient ]['error'] );
+		$this->assertSame( 'incomplete_idempotency', $incomplete['recipients'][ $recipient ]['error'] );
+		$this->assertSame( 0, ec_users_get_unread_count( $recipient ) );
+	}
+
+	public function test_legacy_api_remains_non_idempotent_and_returns_count(): void {
+		$actor     = self::factory()->user->create();
+		$recipient = self::factory()->user->create();
+		$payload   = $this->payload( $actor );
+		unset( $payload['producer'], $payload['idempotency_key'] );
+
+		$this->assertSame( 1, ec_users_notify( $recipient, $payload ) );
+		$this->assertSame( 1, ec_users_notify( $recipient, $payload ) );
+		$this->assertSame( 2, ec_users_get_unread_count( $recipient ) );
+	}
+
+	public function test_legacy_count_wrapper_supports_idempotent_payloads(): void {
+		$actor     = self::factory()->user->create();
+		$recipient = self::factory()->user->create();
+		$payload   = $this->payload( $actor );
+
+		$this->assertSame( 1, ec_users_notify( $recipient, $payload ) );
+		$this->assertSame( 0, ec_users_notify( $recipient, $payload ) );
+	}
+
+	public function test_replay_is_network_wide_across_blog_contexts(): void {
+		$actor       = self::factory()->user->create();
+		$recipient   = self::factory()->user->create();
+		$second_blog = self::factory()->blog->create();
+		$payload     = $this->payload( $actor );
+
+		$first = ec_users_notify_with_receipts( $recipient, $payload );
+
+		switch_to_blog( $second_blog );
+		try {
+			$second = ec_users_notify_with_receipts( $recipient, $payload );
+		} finally {
+			restore_current_blog();
+		}
+
+		$this->assertSame( 'existing', $second['recipients'][ $recipient ]['status'] );
+		$this->assertSame( $first['recipients'][ $recipient ]['notification_id'], $second['recipients'][ $recipient ]['notification_id'] );
+	}
+
+	public function test_replay_does_not_create_new_digest_eligible_row(): void {
+		$actor     = self::factory()->user->create();
+		$recipient = self::factory()->user->create();
+		$payload   = $this->payload( $actor );
+
+		ec_users_notify_with_receipts( $recipient, $payload );
+		$this->assertSame( 1, ec_notifications_email_count_unmailed_unread( $recipient ) );
+
+		ec_users_notify_with_receipts( $recipient, $payload );
+		$this->assertSame( 1, ec_notifications_email_count_unmailed_unread( $recipient ) );
+	}
+
+	public function test_schema_health_requires_atomic_delivery_index(): void {
+		$this->assertTrue( extrachill_users_notifications_receipt_schema_is_healthy() );
+	}
+}


### PR DESCRIPTION
## Summary
- add `ec_users_notify_with_receipts()` with per-recipient `inserted`, `existing`, and `failed` outcomes plus verified notification row IDs
- atomically isolate retries by recipient and producer/key using a SHA-256 delivery key and a unique base-prefix table index
- preserve `ec_users_notify()` as the shipped integer count API, including non-idempotent behavior when no producer/key is supplied

## Migration
- bump the notification schema from v2 to v3 and add nullable `producer`, `idempotency_key`, and `delivery_key` columns
- add unique `(user_id, delivery_key)` replay protection; existing rows remain unaffected because their delivery keys are NULL
- verify required columns and index after `dbDelta()`, and only advance the network schema option when the migration is healthy

## Compatibility
- existing callers across Users, Events, Community, News Wire, Blog, and Studio continue to receive or ignore the same inserted count
- cache invalidation runs only for newly inserted rows
- replayed rows retain their original read and `emailed_at` state, so digest eligibility is unchanged
- the shared table continues to use `$wpdb->base_prefix`, with switched-blog replay covered by tests

## Verification
- focused Homeboy WordPress tests: 9 passed, 28 assertions
- changed-file PHPCS: passed
- changed-file PHPStan: passed
- PHP syntax and `git diff --check`: passed
- Homeboy audit: no introduced findings
- full PHP suite executed: 222 passed, 10 skipped, 131 existing harness failures caused by unavailable abilities/dependencies and canonical site-map fixtures
- full PHPCS and PHPStan passed; full ESLint reports 4 existing unresolved imports in login-register sources outside this change

Closes #280