### PR TITLE
fix: persist artist email consent identity

### DIFF
--- a/inc/core/abilities/subscriptions.php
+++ b/inc/core/abilities/subscriptions.php
@@ -100,6 +100,7 @@ function extrachill_users_ability_get_subscriptions() {
 	// artist the user has subscribed to with email consent granted.
 	$artist_email_consents = array();
 	$artist_blog_id        = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+	$artist_blog_id        = (int) apply_filters( 'extrachill_users_artist_consent_blog_id', $artist_blog_id );
 
 	if ( $artist_blog_id ) {
 		switch_to_blog( $artist_blog_id );
@@ -152,14 +153,34 @@ function extrachill_users_ability_update_subscriptions( $input ) {
 	}
 
 	$consented_artists = isset( $input['consented_artists'] ) ? array_map( 'intval', (array) $input['consented_artists'] ) : array();
+	$consented_artists = array_values(
+		array_unique(
+			array_filter(
+				$consented_artists,
+				static function ( $artist_id ) {
+					return $artist_id > 0;
+				}
+			)
+		)
+	);
 
 	$user = get_user_by( 'ID', $user_id );
 	if ( ! $user ) {
 		return new WP_Error( 'user_not_found', 'User not found.' );
 	}
 
+	$subscriber_email = sanitize_email( $user->user_email );
+	if ( empty( $subscriber_email ) ) {
+		return new WP_Error(
+			'user_email_missing',
+			'An account email is required to share email access with artists.',
+			array( 'status' => 400 )
+		);
+	}
+
 	// The artist_subscribers table lives on the artist site (blog 4).
 	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+	$artist_blog_id = (int) apply_filters( 'extrachill_users_artist_consent_blog_id', $artist_blog_id );
 
 	if ( ! $artist_blog_id ) {
 		return new WP_Error( 'service_unavailable', 'Artist platform not configured.' );
@@ -167,61 +188,90 @@ function extrachill_users_ability_update_subscriptions( $input ) {
 
 	switch_to_blog( $artist_blog_id );
 
-	global $wpdb;
-	$table_name = $wpdb->prefix . 'artist_subscribers';
+	try {
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'artist_subscribers';
 
-	// Existing consent rows for this user define the current scope. We add
-	// consent for any newly-supplied artist and remove consent rows the user
-	// no longer includes in the consented set.
-	$existing_ids = $wpdb->get_col(
-		$wpdb->prepare(
-			"SELECT artist_profile_id FROM {$table_name} WHERE user_id = %d AND source = 'platform_follow_consent'", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted prefix.
-			$user_id
-		)
-	);
-	$existing_ids = array_map( 'intval', (array) $existing_ids );
+		// Existing consent rows for this user define the current scope. We add
+		// consent for any newly-supplied artist and remove consent rows the user
+		// no longer includes in the consented set.
+		$existing_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT artist_profile_id FROM {$table_name} WHERE user_id = %d AND source = 'platform_follow_consent'", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted prefix.
+				$user_id
+			)
+		);
+		if ( null === $existing_ids && '' !== $wpdb->last_error ) {
+			return new WP_Error(
+				'artist_email_consent_read_failed',
+				'Artist email preferences could not be loaded.',
+				array( 'status' => 500 )
+			);
+		}
+		$existing_ids = array_map( 'intval', (array) $existing_ids );
 
-	// Add consent for newly-supplied artists.
-	foreach ( $consented_artists as $artist_id ) {
-		$artist_id = (int) $artist_id;
-		if ( in_array( $artist_id, $existing_ids, true ) ) {
-			continue;
+		// Add consent for newly-supplied artists with the identity required by
+		// the artist-platform export contract and unique email/artist index.
+		foreach ( $consented_artists as $artist_id ) {
+			if ( in_array( $artist_id, $existing_ids, true ) ) {
+				continue;
+			}
+
+			$inserted = $wpdb->insert(
+				$table_name,
+				array(
+					'user_id'           => $user_id,
+					'artist_profile_id' => $artist_id,
+					'subscriber_email'  => $subscriber_email,
+					'username'          => $user->user_login,
+					'source'            => 'platform_follow_consent',
+					'subscribed_at'     => current_time( 'mysql' ),
+				),
+				array( '%d', '%d', '%s', '%s', '%s', '%s' )
+			);
+			if ( false === $inserted ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Operational context for a failed consent write.
+				error_log( 'Artist email consent insert failed: ' . $wpdb->last_error );
+				return new WP_Error(
+					'artist_email_consent_insert_failed',
+					'Artist email preferences could not be updated.',
+					array( 'status' => 500 )
+				);
+			}
 		}
 
-		$wpdb->insert(
-			$table_name,
-			array(
-				'user_id'           => $user_id,
-				'artist_profile_id' => $artist_id,
-				'source'            => 'platform_follow_consent',
-				'subscribed_at'     => current_time( 'mysql' ),
-			),
-			array( '%d', '%d', '%s', '%s' )
-		);
-	}
+		// Remove consent rows no longer in the consented set.
+		foreach ( $existing_ids as $artist_id ) {
+			if ( in_array( $artist_id, $consented_artists, true ) ) {
+				continue;
+			}
 
-	// Remove consent rows no longer in the consented set.
-	foreach ( $existing_ids as $artist_id ) {
-		if ( in_array( $artist_id, $consented_artists, true ) ) {
-			continue;
+			$deleted = $wpdb->delete(
+				$table_name,
+				array(
+					'user_id'           => $user_id,
+					'artist_profile_id' => $artist_id,
+					'source'            => 'platform_follow_consent',
+				),
+				array( '%d', '%d', '%s' )
+			);
+			if ( false === $deleted ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Operational context for a failed consent write.
+				error_log( 'Artist email consent delete failed: ' . $wpdb->last_error );
+				return new WP_Error(
+					'artist_email_consent_delete_failed',
+					'Artist email preferences could not be updated.',
+					array( 'status' => 500 )
+				);
+			}
 		}
 
-		$wpdb->delete(
-			$table_name,
-			array(
-				'user_id'           => $user_id,
-				'artist_profile_id' => $artist_id,
-				'source'            => 'platform_follow_consent',
-			),
-			array( '%d', '%d', '%s' )
+		return array(
+			'success' => true,
+			'message' => 'Subscription preferences updated.',
+			'user_id' => $user_id,
 		);
+	} finally {
+		restore_current_blog();
 	}
-
-	restore_current_blog();
-
-	return array(
-		'success' => true,
-		'message' => 'Subscription preferences updated.',
-		'user_id' => $user_id,
-	);
 }

--- a/tests/unit/ArtistEmailConsentAbilitiesTest.php
+++ b/tests/unit/ArtistEmailConsentAbilitiesTest.php
@@ -6,6 +6,34 @@
  */
 
 class Test_Artist_Email_Consent_Abilities extends WP_UnitTestCase {
+	/**
+	 * Artist-site subscriber table used by the fixture.
+	 *
+	 * @var string
+	 */
+	private $table_name;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		global $wpdb;
+		$this->table_name = $wpdb->prefix . 'artist_subscribers';
+		add_filter( 'extrachill_users_artist_consent_blog_id', array( $this, 'use_current_blog' ) );
+		$this->create_consent_table();
+	}
+
+	protected function tearDown(): void {
+		global $wpdb;
+		$wpdb->query( "DROP TABLE IF EXISTS {$this->table_name}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test fixture table uses the trusted WordPress prefix.
+		remove_filter( 'extrachill_users_artist_consent_blog_id', array( $this, 'use_current_blog' ) );
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	public function use_current_blog(): int {
+		return get_current_blog_id();
+	}
 
 	public function test_abilities_use_email_consent_language_and_stable_contracts(): void {
 		$get    = wp_get_ability( 'extrachill/get-subscriptions' );
@@ -30,5 +58,144 @@ class Test_Artist_Email_Consent_Abilities extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'followed_artists', $result );
 		$this->assertSame( $result['artist_email_consents'], $result['followed_artists'] );
 		$this->assertArrayNotHasKey( 'subscriber_count', $result );
+	}
+
+	public function test_multiple_users_can_share_email_with_the_same_artist(): void {
+		$first_user_id = self::factory()->user->create(
+			array(
+				'user_login' => 'first-consent-user',
+				'user_email' => 'first-consent@example.com',
+			)
+		);
+		$second_user_id = self::factory()->user->create(
+			array(
+				'user_login' => 'second-consent-user',
+				'user_email' => 'second-consent@example.com',
+			)
+		);
+
+		wp_set_current_user( $first_user_id );
+		$first_result = extrachill_users_ability_update_subscriptions(
+			array( 'consented_artists' => array( 42, 42 ) )
+		);
+
+		wp_set_current_user( $second_user_id );
+		$second_result = extrachill_users_ability_update_subscriptions(
+			array( 'consented_artists' => array( 42 ) )
+		);
+
+		$this->assertIsArray( $first_result );
+		$this->assertIsArray( $second_result );
+
+		global $wpdb;
+		$rows = $wpdb->get_results(
+			"SELECT user_id, artist_profile_id, subscriber_email, username, source FROM {$this->table_name} ORDER BY user_id ASC", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test fixture table uses the trusted WordPress prefix.
+			ARRAY_A
+		);
+
+		$this->assertCount( 2, $rows );
+		$this->assertSame( array( 42, 42 ), array_map( 'intval', array_column( $rows, 'artist_profile_id' ) ) );
+		$this->assertSame( array( 'first-consent@example.com', 'second-consent@example.com' ), array_column( $rows, 'subscriber_email' ) );
+		$this->assertSame( array( 'first-consent-user', 'second-consent-user' ), array_column( $rows, 'username' ) );
+		$this->assertSame( array( 'platform_follow_consent', 'platform_follow_consent' ), array_column( $rows, 'source' ) );
+
+		wp_set_current_user( $first_user_id );
+		$preferences = extrachill_users_ability_get_subscriptions();
+		$this->assertCount( 1, $preferences['artist_email_consents'] );
+		$this->assertSame( 42, $preferences['artist_email_consents'][0]['artist_id'] );
+	}
+
+	public function test_unrelated_artist_subscription_rows_are_preserved(): void {
+		$user_id = self::factory()->user->create(
+			array(
+				'user_login' => 'mixed-subscription-user',
+				'user_email' => 'mixed-subscription@example.com',
+			)
+		);
+
+		global $wpdb;
+		$wpdb->insert(
+			$this->table_name,
+			array(
+				'user_id'           => $user_id,
+				'artist_profile_id' => 42,
+				'subscriber_email'  => 'mixed-subscription@example.com',
+				'username'          => 'mixed-subscription-user',
+				'source'            => 'artist_subscribe_form',
+				'subscribed_at'     => current_time( 'mysql' ),
+			),
+			array( '%d', '%d', '%s', '%s', '%s', '%s' )
+		);
+
+		wp_set_current_user( $user_id );
+		$result = extrachill_users_ability_update_subscriptions( array( 'consented_artists' => array() ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 1, (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$this->table_name} WHERE source = 'artist_subscribe_form'" ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test fixture table uses the trusted WordPress prefix.
+	}
+
+	public function test_insert_failure_is_returned_instead_of_reporting_success(): void {
+		$user_id = self::factory()->user->create(
+			array(
+				'user_email' => 'failed-consent@example.com',
+			)
+		);
+
+		global $wpdb;
+		$wpdb->insert(
+			$this->table_name,
+			array(
+				'user_id'           => $user_id,
+				'artist_profile_id' => 42,
+				'subscriber_email'  => 'failed-consent@example.com',
+				'username'          => 'existing-form-subscriber',
+				'source'            => 'artist_subscribe_form',
+				'subscribed_at'     => current_time( 'mysql' ),
+			),
+			array( '%d', '%d', '%s', '%s', '%s', '%s' )
+		);
+		wp_set_current_user( $user_id );
+
+		$result = extrachill_users_ability_update_subscriptions( array( 'consented_artists' => array( 42 ) ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'artist_email_consent_insert_failed', $result->get_error_code() );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+	}
+
+	public function test_account_without_email_cannot_grant_artist_email_access(): void {
+		$user_id = self::factory()->user->create(
+			array(
+				'user_email' => '',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$result = extrachill_users_ability_update_subscriptions( array( 'consented_artists' => array( 42 ) ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'user_email_missing', $result->get_error_code() );
+	}
+
+	private function create_consent_table(): void {
+		global $wpdb;
+		$wpdb->query( "DROP TABLE IF EXISTS {$this->table_name}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test fixture table uses the trusted WordPress prefix.
+		$created = $wpdb->query(
+			"CREATE TABLE {$this->table_name} (
+				subscriber_id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+				user_id BIGINT(20) UNSIGNED NULL,
+				artist_profile_id BIGINT(20) UNSIGNED NOT NULL,
+				subscriber_email VARCHAR(255) NOT NULL,
+				username VARCHAR(60) NULL DEFAULT NULL,
+				source VARCHAR(50) NOT NULL DEFAULT 'artist_subscribe_form',
+				subscribed_at DATETIME NOT NULL,
+				exported TINYINT(1) NOT NULL DEFAULT 0,
+				PRIMARY KEY (subscriber_id),
+				UNIQUE KEY email_artist (subscriber_email, artist_profile_id),
+				KEY user_artist_source (user_id, artist_profile_id, source)
+			)"
+		); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test fixture schema uses the trusted WordPress prefix.
+
+		$this->assertNotFalse( $created, $wpdb->last_error );
 	}
 }


### PR DESCRIPTION
## Summary
- persist the authenticated user's email and login in artist email-consent rows so the artist export contract receives complete identity
- reject missing account email, normalize duplicate/invalid artist IDs, and surface database read/write failures instead of reporting false success
- preserve the shipped `platform_follow_consent` source and unrelated artist subscription rows
- guarantee artist-site context restoration when a database operation fails

## Tests
- `homeboy --placement local review test --path=/var/lib/datamachine/workspace/extrachill-users@fix-279-consent-row-identity --skip-lint --json-summary -- --filter=Test_Artist_Email_Consent_Abilities` (6 tests, 33 assertions)
- `homeboy --placement local review lint --changed-only --path=/var/lib/datamachine/workspace/extrachill-users@fix-279-consent-row-identity` (PHPCS and PHPStan passed)
- `git diff --check`

Closes #279