### PR TITLE
fix: restore auth fuzz rate limit seams

### DIFF
--- a/tests/e2e/auth-multisite/README.md
+++ b/tests/e2e/auth-multisite/README.md
@@ -24,8 +24,9 @@ The component manifest must point to clean Git checkouts at exact full commit
 revisions. The Users checkout must have ignored release assets generated with
 `npm run build`; mounted-byte SHA-256 provenance binds those assets to the run.
 
-Turnstile and email use documented local/test seams. Google OAuth, real email,
-mapped subdomains, TLS, and `.extrachill.com` cookie-domain behavior are outside
-this localhost path-multisite proof and require deployed smoke coverage.
+Turnstile, email, and atomic rate-limit storage use documented local/test seams.
+Google OAuth, real email, mapped subdomains, TLS, and `.extrachill.com`
+cookie-domain behavior are outside this localhost path-multisite proof and
+require deployed smoke coverage.
 Browser page fixtures use WordPress's `pagename` query because the localhost
 Playground router does not provide production-equivalent pretty-page rewrites.

--- a/tests/e2e/auth-multisite/fixture/auth-fuzz-fixture.php
+++ b/tests/e2e/auth-multisite/fixture/auth-fuzz-fixture.php
@@ -7,6 +7,50 @@
 
 add_filter( 'extrachill_bypass_turnstile_verification', '__return_true' );
 add_filter( 'pre_wp_mail', '__return_true' );
+
+function extrachill_auth_fuzz_registration_admitter() {
+	$count = (int) get_site_option( 'extrachill_auth_fuzz_registration_attempts', 0 ) + 1;
+	update_site_option( 'extrachill_auth_fuzz_registration_attempts', $count );
+
+	return $count > EXTRACHILL_USERS_REGISTRATION_RATE_LIMIT
+		? extrachill_users_registration_rate_limit_error( time() + EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW )
+		: true;
+}
+
+add_filter(
+	'extrachill_users_registration_admitter',
+	static function () {
+		return 'extrachill_auth_fuzz_registration_admitter';
+	}
+);
+
+function extrachill_auth_fuzz_login_rate_limit_store( $operation, $key ) {
+	$state = get_site_option( 'extrachill_auth_fuzz_login_attempts', array() );
+	$count = (int) ( $state[ $key ] ?? 0 );
+
+	if ( 'get' === $operation ) {
+		return $count;
+	}
+	if ( 'increment' === $operation ) {
+		$state[ $key ] = ++$count;
+		update_site_option( 'extrachill_auth_fuzz_login_attempts', $state );
+		return $count;
+	}
+	if ( 'clear' === $operation ) {
+		unset( $state[ $key ] );
+		update_site_option( 'extrachill_auth_fuzz_login_attempts', $state );
+		return true;
+	}
+
+	return new WP_Error( 'ec_login_limiter_unavailable', 'Unsupported auth fuzz limiter operation.' );
+}
+
+add_filter(
+	'extrachill_users_login_rate_limit_store',
+	static function () {
+		return 'extrachill_auth_fuzz_login_rate_limit_store';
+	}
+);
 add_filter(
 	'ec_site_url_override',
 	static function ( $url, $key, $blog_id ) {


### PR DESCRIPTION
## Summary
- provide deterministic registration and login rate-limit storage in the disposable auth fuzz fixture
- preserve production-style requester/identity keying across browser requests
- isolate backend mutation fuzzing from browser registration so the campaign does not rate-limit itself
- improve known-good credential diagnostics and document the limiter seam

## Why
The full multisite auth campaign runs without Redis by design, but registration and login now require atomic limiter storage. The missing test seam first caused valid registration to fail with `registration_limiter_unavailable`; once supplied, a shared phase counter caused browser registration to receive an artificial `429`.

Production fail-closed behavior is unchanged. These changes are confined to the disposable test fixture and campaign assertions.

## Verification
- `php -l tests/e2e/auth-multisite/fixture/auth-fuzz-fixture.php`
- `php -l tests/e2e/auth-multisite/assert.php`
- Full campaign on WordPress `7.0.2`, PHP `8.4`, WP Codebox `0.15.0`
- Seed: `extrachill-auth-full-001`
- Homeboy run: `2819e8c0-f081-4953-be8f-e1ddcfebd89b`
- Backend: 87 assertions passed
- Anonymous browser scenario: 5/5 assertions passed, zero browser errors
- Registration/onboarding/cross-site scenario: 5/5 assertions passed, zero browser errors
- Post-assertion: browser registration, onboarding, Community membership, cookie continuity, Artist/Events session continuity, and analytics cardinality passed

Fixes #285