### PR TITLE
test: finish auth fuzz rate-limit isolation

### DIFF
--- a/tests/e2e/auth-multisite/assert.php
+++ b/tests/e2e/auth-multisite/assert.php
@@ -4,6 +4,7 @@ $plan = get_site_option( 'extrachill_auth_fuzz_plan', array() );
 $fixture = get_site_option( 'extrachill_auth_fuzz_fixture', array() );
 $sites = get_site_option( 'extrachill_auth_fuzz_sites', array() );
 $passes = 0;
+$_SERVER['REMOTE_ADDR'] = '127.0.0.249';
 
 function auth_fuzz_assert( $condition, string $message ): void {
 	global $passes;

--- a/tests/e2e/auth-multisite/assert.php
+++ b/tests/e2e/auth-multisite/assert.php
@@ -61,6 +61,9 @@ auth_fuzz_assert( 400 === $duplicate->get_status(), 'Duplicate registration did 
 auth_fuzz_assert( auth_fuzz_network_user_count() === $initial_count + 1, 'Duplicate registration created another user.' );
 
 $existing = get_user_by( 'id', (int) $fixture['existing_user_id'] );
+auth_fuzz_assert( wp_check_password( 'existing-pass-248', $existing->user_pass, $existing->ID ), 'Stored password verification failed for the existing auth persona.' );
+$direct_auth = wp_authenticate( $existing->user_login, 'existing-pass-248' );
+auth_fuzz_assert( $direct_auth instanceof WP_User, 'Direct authentication failed for the existing auth persona: ' . ( is_wp_error( $direct_auth ) ? implode( ',', $direct_auth->get_error_codes() ) : gettype( $direct_auth ) ) );
 foreach ( array( $existing->user_login, $existing->user_email ) as $identifier ) {
 	$login = auth_fuzz_rest( '/extrachill/v1/auth/login', array( 'identifier' => $identifier, 'password' => 'existing-pass-248', 'device_id' => '00000000-0000-4000-8000-000000000249', 'set_cookie' => false ) );
 	auth_fuzz_assert( 200 === $login->get_status(), 'Login failed for ' . ( is_email( $identifier ) ? 'email: ' : 'username: ' ) . wp_json_encode( $login->get_data() ) );

--- a/tests/e2e/auth-multisite/assert.php
+++ b/tests/e2e/auth-multisite/assert.php
@@ -63,7 +63,7 @@ auth_fuzz_assert( auth_fuzz_network_user_count() === $initial_count + 1, 'Duplic
 $existing = get_user_by( 'id', (int) $fixture['existing_user_id'] );
 foreach ( array( $existing->user_login, $existing->user_email ) as $identifier ) {
 	$login = auth_fuzz_rest( '/extrachill/v1/auth/login', array( 'identifier' => $identifier, 'password' => 'existing-pass-248', 'device_id' => '00000000-0000-4000-8000-000000000249', 'set_cookie' => false ) );
-	auth_fuzz_assert( 200 === $login->get_status(), 'Login failed for ' . ( is_email( $identifier ) ? 'email.' : 'username.' ) );
+	auth_fuzz_assert( 200 === $login->get_status(), 'Login failed for ' . ( is_email( $identifier ) ? 'email: ' : 'username: ' ) . wp_json_encode( $login->get_data() ) );
 	auth_fuzz_assert( (int) ( $login->get_data()['user']['id'] ?? 0 ) === (int) $existing->ID, 'Login resolved the wrong network identity.' );
 }
 $unknown_login = auth_fuzz_rest( '/extrachill/v1/auth/login', array( 'identifier' => 'missing-auth-fuzz', 'password' => 'wrong-pass', 'device_id' => '00000000-0000-4000-8000-000000000252' ) );

--- a/tests/e2e/auth-multisite/fixture/auth-fuzz-fixture.php
+++ b/tests/e2e/auth-multisite/fixture/auth-fuzz-fixture.php
@@ -39,7 +39,7 @@ function extrachill_auth_fuzz_login_rate_limit_store( $operation, $key ) {
 	if ( 'clear' === $operation ) {
 		unset( $state[ $key ] );
 		update_site_option( 'extrachill_auth_fuzz_login_attempts', $state );
-		return true;
+		return 0;
 	}
 
 	return new WP_Error( 'ec_login_limiter_unavailable', 'Unsupported auth fuzz limiter operation.' );

--- a/tests/e2e/auth-multisite/fixture/auth-fuzz-fixture.php
+++ b/tests/e2e/auth-multisite/fixture/auth-fuzz-fixture.php
@@ -13,8 +13,11 @@ if ( empty( $_SERVER['REMOTE_ADDR'] ) ) {
 }
 
 function extrachill_auth_fuzz_registration_admitter() {
-	$count = (int) get_site_option( 'extrachill_auth_fuzz_registration_attempts', 0 ) + 1;
-	update_site_option( 'extrachill_auth_fuzz_registration_attempts', $count );
+	$key   = extrachill_users_registration_attempt_key();
+	$state = get_site_option( 'extrachill_auth_fuzz_registration_attempts', array() );
+	$count = (int) ( $state[ $key ] ?? 0 ) + 1;
+	$state[ $key ] = $count;
+	update_site_option( 'extrachill_auth_fuzz_registration_attempts', $state );
 
 	return $count > EXTRACHILL_USERS_REGISTRATION_RATE_LIMIT
 		? extrachill_users_registration_rate_limit_error( time() + EXTRACHILL_USERS_REGISTRATION_RATE_WINDOW )

--- a/tests/e2e/auth-multisite/fixture/auth-fuzz-fixture.php
+++ b/tests/e2e/auth-multisite/fixture/auth-fuzz-fixture.php
@@ -8,6 +8,10 @@
 add_filter( 'extrachill_bypass_turnstile_verification', '__return_true' );
 add_filter( 'pre_wp_mail', '__return_true' );
 
+if ( empty( $_SERVER['REMOTE_ADDR'] ) ) {
+	$_SERVER['REMOTE_ADDR'] = '127.0.0.248';
+}
+
 function extrachill_auth_fuzz_registration_admitter() {
 	$count = (int) get_site_option( 'extrachill_auth_fuzz_registration_attempts', 0 ) + 1;
 	update_site_option( 'extrachill_auth_fuzz_registration_attempts', $count );


### PR DESCRIPTION
## Summary
- return the numeric clear result required by the login limiter contract
- persist a deterministic requester IP through each isolated runtime request
- key registration counters by the production requester/window identity
- isolate backend mutation fuzzing from browser registration requester budgets
- retain actionable credential failure diagnostics and direct authentication invariants

## Why
PR #286 supplied the missing rate-limit stores and was merged while the campaign was still running. Subsequent deterministic replays exposed two additional fixture defects:

1. `REMOTE_ADDR` set in topology/seed PHP commands did not survive into later isolated requests, so login failed before invoking the fixture store.
2. Backend mutation cases and the browser registration journey shared one unkeyed counter, causing the browser request to receive an artificial `429`.

These follow-up commits make the fixture follow production keying while keeping phase budgets isolated. Production auth code is unchanged.

## Verification
- PHP lint passed for the fixture and assertion files.
- WordPress `7.0.2`, PHP `8.4`, WP Codebox `0.15.0`.
- Seed: `extrachill-auth-full-001`.
- Homeboy run: `2819e8c0-f081-4953-be8f-e1ddcfebd89b`.
- Backend: 87 assertions passed.
- Anonymous browser scenario: 5/5 assertions, zero browser errors.
- Registration/onboarding/cross-site scenario: 5/5 assertions, zero browser errors.
- Browser mutation post-assertion passed for registration, onboarding, Community membership, cookie continuity, Artist/Events continuity, and analytics cardinality.

Fixes #285