### PR TITLE
fix: test network plugin in multisite MySQL

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -20,6 +20,6 @@ jobs:
   lint:
     uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2
     with:
-      commands: review lint
-      expected-commands: review lint
+      commands: review lint,review test
+      expected-commands: review lint,review test
     secrets: inherit

--- a/homeboy.json
+++ b/homeboy.json
@@ -3,8 +3,10 @@
   "changelog_target": "docs/CHANGELOG.md",
   "extensions": {
     "wordpress": {
+      "database_type": "mysql",
       "settings": {
         "validation_dependencies": ["data-machine-events"],
+        "wp_codebox_multisite": true,
         "wordpress_runtime_php_version": "8.4"
       }
     }


### PR DESCRIPTION
## Summary
- run Homeboy Codebox tests in the multisite topology required by Extra Chill Users
- match production's MySQL database instead of SQLite
- add `review test` to required PR CI so the release gate is proven on a Docker-capable runner

Closes #295.

## Verification
- `jq empty homeboy.json`
- local multisite Codebox boots and executes PHPUnit; local MySQL provisioning is unavailable because this host has no Docker
- GitHub CI is the authoritative MySQL test runner for this configuration