### PR TITLE
feat: support producer-owned notification email

### DIFF
--- a/inc/entity-subscriptions/service.php
+++ b/inc/entity-subscriptions/service.php
@@ -121,8 +121,8 @@ function extrachill_users_unsubscribe_from_entity( $user_id, $entity_type, $taxo
 		return new WP_Error( 'user_not_found', __( 'User not found.', 'extrachill-users' ), array( 'status' => 404 ) );
 	}
 
-	$table = extrachill_users_entity_subscriptions_table_name();
-	$wpdb->query(
+	$table   = extrachill_users_entity_subscriptions_table_name();
+	$deleted = $wpdb->query(
 		$wpdb->prepare(
 			"DELETE FROM {$table} WHERE user_id = %d AND entity_type = %s AND taxonomy = %s AND entity_slug = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- trusted table helper.
 			$user_id,
@@ -131,6 +131,9 @@ function extrachill_users_unsubscribe_from_entity( $user_id, $entity_type, $taxo
 			$entity['slug']
 		)
 	);
+	if ( false === $deleted ) {
+		return new WP_Error( 'entity_subscription_delete_failed', __( 'The subscription could not be removed.', 'extrachill-users' ), array( 'status' => 500 ) );
+	}
 
 	return array_merge( $entity, array( 'subscribed' => false ) );
 }

--- a/inc/notifications/db.php
+++ b/inc/notifications/db.php
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
  * upgrade path).
  */
 if ( ! defined( 'EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION' ) ) {
-	define( 'EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION', '3' );
+	define( 'EXTRACHILL_USERS_NOTIFICATIONS_SCHEMA_VERSION', '4' );
 }
 
 /**
@@ -59,9 +59,9 @@ function extrachill_users_notifications_table_name() {
  *   - is_read    0 unread, 1 read
  *   - created_at when the notification was generated (UTC)
  *   - emailed_at when this notification was first included in a digest email
- *                (NULL == never emailed). Drives "nudge once per notification":
- *                a notification is eligible for the digest exactly once, then
- *                its emailed_at is stamped so it never re-triggers an email.
+ *                (NULL == never emailed by the generic digest).
+ *   - producer_owns_email excludes the row from generic email delivery while
+ *                leaving it visible in the notification reader.
  *   - producer / idempotency_key identify an optional producer-owned delivery
  *   - delivery_key is their SHA-256 digest, used for compact atomic uniqueness
  *
@@ -92,6 +92,7 @@ function extrachill_users_install_notifications_table() {
 		is_read tinyint(1) NOT NULL DEFAULT 0,
 		created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		emailed_at datetime DEFAULT NULL,
+		producer_owns_email tinyint(1) NOT NULL DEFAULT 0,
 		producer varchar(64) DEFAULT NULL,
 		idempotency_key varchar(191) DEFAULT NULL,
 		delivery_key char(64) DEFAULT NULL,
@@ -124,7 +125,7 @@ function extrachill_users_notifications_receipt_schema_is_healthy() {
 	$table   = extrachill_users_notifications_table_name();
 	$columns = $wpdb->get_col( "SHOW COLUMNS FROM {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
 
-	foreach ( array( 'producer', 'idempotency_key', 'delivery_key' ) as $required_column ) {
+	foreach ( array( 'producer_owns_email', 'producer', 'idempotency_key', 'delivery_key' ) as $required_column ) {
 		if ( ! in_array( $required_column, (array) $columns, true ) ) {
 			return false;
 		}

--- a/inc/notifications/email.php
+++ b/inc/notifications/email.php
@@ -237,12 +237,12 @@ add_action( EC_NOTIFICATIONS_EMAIL_CRON_HOOK, 'ec_notifications_email_run' );
 /**
  * Find users eligible for a digest email.
  *
- * Eligible == has at least one unread, NEVER-EMAILED notification whose
- * created_at is older than EC_NOTIFICATIONS_EMAIL_DELAY. The emailed_at IS NULL
- * predicate is what makes the digest "nudge once per notification": once a
- * notification has been included in a digest its emailed_at is stamped, so it
- * can never make the user eligible again. Without it the sweep re-nudged the
- * same stale unread notification every cooldown window, forever, until read.
+ * Eligible == has at least one ordinary unread, NEVER-EMAILED notification whose
+ * created_at is older than EC_NOTIFICATIONS_EMAIL_DELAY. Producer-owned email
+ * receipts are excluded by their persisted ownership marker. The emailed_at IS
+ * NULL predicate makes the digest "nudge once per notification": once an
+ * ordinary notification has been included, it can never make the user eligible
+ * again.
  *
  * Uses the idx_email_sweep index (is_read, emailed_at, created_at) — one
  * grouped scan, no per-row loading.
@@ -273,7 +273,7 @@ function ec_notifications_email_find_eligible_users( $limit = 50 ) {
 	// not eligible no matter how long it stays unread.
 	$rows = $wpdb->get_col(
 		$wpdb->prepare(
-			"SELECT user_id FROM {$table} WHERE is_read = 0 AND emailed_at IS NULL AND created_at <= %s GROUP BY user_id ORDER BY MIN(created_at) ASC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+			"SELECT user_id FROM {$table} WHERE is_read = 0 AND producer_owns_email = 0 AND emailed_at IS NULL AND created_at <= %s GROUP BY user_id ORDER BY MIN(created_at) ASC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
 			$cutoff,
 			$candidate_limit
 		)
@@ -488,9 +488,10 @@ function ec_notifications_email_send_digest( $user_id ) {
 	$result = ec_users_get_notifications(
 		$user_id,
 		array(
-			'unread'   => true,
-			'page'     => 1,
-			'per_page' => EC_NOTIFICATIONS_EMAIL_PREVIEW_COUNT,
+			'unread'                       => true,
+			'page'                         => 1,
+			'per_page'                     => EC_NOTIFICATIONS_EMAIL_PREVIEW_COUNT,
+			'exclude_producer_owned_email' => true,
 		)
 	);
 
@@ -524,9 +525,10 @@ function ec_notifications_email_send_digest( $user_id ) {
 		$wide    = ec_users_get_notifications(
 			$user_id,
 			array(
-				'unread'   => true,
-				'page'     => 1,
-				'per_page' => 100,
+				'unread'                       => true,
+				'page'                         => 1,
+				'per_page'                     => 100,
+				'exclude_producer_owned_email' => true,
 			)
 		);
 		$preview = array_slice(
@@ -590,8 +592,9 @@ function ec_notifications_email_send_digest( $user_id ) {
 /**
  * Count a user's unread notifications that have NOT yet been emailed.
  *
- * The once-per-notification eligibility signal: only notifications with
- * emailed_at IS NULL can justify a digest. Uses the idx_email_sweep index.
+ * The once-per-notification eligibility signal: only ordinary notifications
+ * with emailed_at IS NULL can justify a digest. Producer-owned email receipts
+ * are excluded independently of emailed_at. Uses the idx_email_sweep index.
  *
  * @param int $user_id User ID.
  * @return int Number of unread, never-emailed notifications.
@@ -608,7 +611,7 @@ function ec_notifications_email_count_unmailed_unread( $user_id ) {
 
 	return (int) $wpdb->get_var(
 		$wpdb->prepare(
-			"SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND is_read = 0 AND emailed_at IS NULL", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+			"SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND is_read = 0 AND producer_owns_email = 0 AND emailed_at IS NULL", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
 			$user_id
 		)
 	);
@@ -640,7 +643,7 @@ function ec_notifications_email_count_stale_unread_reminders( $user_id ) {
 
 	$rows = $wpdb->get_results(
 		$wpdb->prepare(
-			"SELECT item_id FROM {$table} WHERE user_id = %d AND is_read = 0 AND type = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+			"SELECT item_id FROM {$table} WHERE user_id = %d AND is_read = 0 AND producer_owns_email = 0 AND type = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
 			$user_id,
 			EC_USERS_SHOW_REMINDER_TYPE
 		),
@@ -717,12 +720,12 @@ function ec_notifications_email_reminder_is_stale( $event_id ) {
 }
 
 /**
- * Stamp emailed_at = now on a user's unread, not-yet-emailed notifications.
+ * Stamp emailed_at = now on a user's ordinary unread, not-yet-emailed notifications.
  *
  * After a digest is enqueued, every unread notification that was eligible to be
- * nudged is marked so it never triggers another email. Only unread + NULL
- * rows are touched: already-read rows are irrelevant and already-emailed rows
- * keep their original (earlier) stamp.
+ * nudged is marked so it never triggers another email. Only non-producer-owned,
+ * unread + NULL rows are touched: already-read rows are irrelevant and
+ * already-emailed rows keep their original (earlier) stamp.
  *
  * @param int $user_id User ID.
  * @return int Number of rows stamped.
@@ -740,7 +743,7 @@ function ec_notifications_email_mark_unread_as_emailed( $user_id ) {
 
 	return (int) $wpdb->query(
 		$wpdb->prepare(
-			"UPDATE {$table} SET emailed_at = %s WHERE user_id = %d AND is_read = 0 AND emailed_at IS NULL", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+			"UPDATE {$table} SET emailed_at = %s WHERE user_id = %d AND is_read = 0 AND producer_owns_email = 0 AND emailed_at IS NULL", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
 			$now,
 			$user_id
 		)

--- a/inc/notifications/service.php
+++ b/inc/notifications/service.php
@@ -133,6 +133,15 @@ function ec_users_notify( $user_ids, array $data ): int {
  * converge on one row per recipient while unrelated producers remain isolated.
  * Omitting both fields retains the historical non-idempotent insert behavior.
  *
+ * An idempotent producer that delivers its own email may also pass
+ * `producer_owns_email => true`. The insert atomically persists that ownership
+ * and stamps emailed_at equal to created_at, keeping the notification unread and
+ * visible while excluding it from the generic email sweep. A crash after this
+ * insert but before downstream
+ * queue admission leaves the suppressed receipt in place; producers should call
+ * ec_users_release_notification_receipt() only after an explicit admission
+ * failure, then retry the complete operation.
+ *
  * Requested IDs are normalized to a unique recipient set. Each receipt has an
  * inserted, existing, or failed status. A notification row ID is returned only
  * after an insert or an exact producer/key replay has been verified.
@@ -145,6 +154,9 @@ function ec_users_notify( $user_ids, array $data ): int {
  *                                   with idempotency_key.
  *     @type string $idempotency_key Optional producer-owned replay key. Must be
  *                                   paired with producer.
+ *     @type bool   $producer_owns_email Optional. When true, the producer owns
+ *                                       email delivery for this receipt. Requires
+ *                                       producer and idempotency_key.
  * }
  * @return array{requested:int, inserted:int, existing:int, failed:int, recipients:array<int,array{user_id:int,status:string,notification_id:?int,error:?string}>}
  */
@@ -181,6 +193,7 @@ function ec_users_notify_with_receipts( $user_ids, array $data ): array {
 	$idempotency_key = isset( $data['idempotency_key'] ) ? trim( (string) $data['idempotency_key'] ) : '';
 	$has_producer    = '' !== $producer;
 	$has_key         = '' !== $idempotency_key;
+	$owns_email      = true === ( $data['producer_owns_email'] ?? false );
 	$payload_error   = null;
 
 	if ( ! $actor_id || '' === $type || '' === $link || '' === $title ) {
@@ -193,6 +206,8 @@ function ec_users_notify_with_receipts( $user_ids, array $data ): array {
 		$payload_error = 'invalid_producer';
 	} elseif ( $has_key && ( strlen( $idempotency_key ) > 191 || preg_match( '/[\x00-\x1F\x7F]/', $idempotency_key ) ) ) {
 		$payload_error = 'invalid_idempotency_key';
+	} elseif ( $owns_email && ( ! $has_producer || ! $has_key ) ) {
+		$payload_error = 'email_ownership_requires_idempotency';
 	}
 
 	if ( null !== $payload_error ) {
@@ -225,7 +240,7 @@ function ec_users_notify_with_receipts( $user_ids, array $data ): array {
 		if ( $has_producer ) {
 			$result = $wpdb->query(
 				$wpdb->prepare(
-					"INSERT IGNORE INTO {$table} (user_id, actor_id, type, title, link, item_id, is_read, created_at, producer, idempotency_key, delivery_key) VALUES (%d, %d, %s, %s, %s, NULLIF(%d, 0), 0, %s, %s, %s, %s)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+					"INSERT IGNORE INTO {$table} (user_id, actor_id, type, title, link, item_id, is_read, created_at, emailed_at, producer_owns_email, producer, idempotency_key, delivery_key) VALUES (%d, %d, %s, %s, %s, NULLIF(%d, 0), 0, %s, NULLIF(%s, ''), %d, %s, %s, %s)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
 					$user_id,
 					$actor_id,
 					$type,
@@ -233,6 +248,8 @@ function ec_users_notify_with_receipts( $user_ids, array $data ): array {
 					$link,
 					$item_id,
 					$created_at,
+					$owns_email ? $created_at : '',
+					(int) $owns_email,
 					$producer,
 					$idempotency_key,
 					$delivery_key
@@ -267,7 +284,7 @@ function ec_users_notify_with_receipts( $user_ids, array $data ): array {
 		if ( $has_producer && 1 !== (int) $result ) {
 			$existing = $wpdb->get_row(
 				$wpdb->prepare(
-					"SELECT id, producer, idempotency_key FROM {$table} WHERE user_id = %d AND delivery_key = %s LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+					"SELECT id, producer, idempotency_key, producer_owns_email FROM {$table} WHERE user_id = %d AND delivery_key = %s LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
 					$user_id,
 					$delivery_key
 				),
@@ -276,6 +293,11 @@ function ec_users_notify_with_receipts( $user_ids, array $data ): array {
 
 			if ( ! $existing || $producer !== $existing['producer'] || $idempotency_key !== $existing['idempotency_key'] ) {
 				$receipt['recipients'][ $user_id ] = ec_users_notification_failed_receipt( $user_id, 'insert_failed' );
+				++$receipt['failed'];
+				continue;
+			}
+			if ( (int) $owns_email !== (int) $existing['producer_owns_email'] ) {
+				$receipt['recipients'][ $user_id ] = ec_users_notification_failed_receipt( $user_id, 'idempotency_contract_mismatch' );
 				++$receipt['failed'];
 				continue;
 			}
@@ -309,6 +331,63 @@ function ec_users_notify_with_receipts( $user_ids, array $data ): array {
 	}
 
 	return $receipt;
+}
+
+/**
+ * Release one producer-owned notification receipt after queue admission fails.
+ *
+ * The delete is bounded by the receipt ID, recipient, producer, idempotency key,
+ * delivery digest, authoritative email-ownership marker, and unread state. It cannot
+ * release a normal idempotent notification or another producer's receipt.
+ * Call this only for an explicit downstream queue-admission failure. It cannot
+ * repair a process crash between notification insertion and learning the queue
+ * result, and releasing after successful admission could permit duplicate work.
+ *
+ * @param int    $notification_id Notification ID returned in the receipt.
+ * @param int    $user_id         Receipt recipient ID.
+ * @param string $producer        Exact producer namespace used for insertion.
+ * @param string $idempotency_key Exact producer replay key used for insertion.
+ * @return bool True only when the exact producer-owned receipt was deleted.
+ */
+function ec_users_release_notification_receipt( int $notification_id, int $user_id, string $producer, string $idempotency_key ): bool {
+	global $wpdb;
+
+	$producer        = strtolower( trim( $producer ) );
+	$idempotency_key = trim( $idempotency_key );
+
+	if (
+		$notification_id <= 0
+		|| $user_id <= 0
+		|| '' === $producer
+		|| '' === $idempotency_key
+		|| strlen( $producer ) > 64
+		|| ! preg_match( '/^[a-z0-9][a-z0-9._\/-]*$/', $producer )
+		|| strlen( $idempotency_key ) > 191
+		|| preg_match( '/[\x00-\x1F\x7F]/', $idempotency_key )
+	) {
+		return false;
+	}
+
+	$table        = extrachill_users_notifications_table_name();
+	$delivery_key = hash( 'sha256', $producer . "\0" . $idempotency_key );
+	$deleted      = $wpdb->query(
+		$wpdb->prepare(
+			"DELETE FROM {$table} WHERE id = %d AND user_id = %d AND producer = %s AND idempotency_key = %s AND delivery_key = %s AND producer_owns_email = 1 AND is_read = 0", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+			$notification_id,
+			$user_id,
+			$producer,
+			$idempotency_key,
+			$delivery_key
+		)
+	);
+
+	if ( 1 !== (int) $deleted ) {
+		return false;
+	}
+
+	ec_users_flush_unread_count_cache( $user_id );
+
+	return true;
 }
 
 /**
@@ -377,6 +456,9 @@ function ec_users_enrich_notification( array $row ): array {
  *     @type bool $unread   Only return unread notifications. Default false.
  *     @type int  $page     1-indexed page number. Default 1.
  *     @type int  $per_page Results per page (1-100). Default 50.
+ *     @type bool $exclude_producer_owned_email Exclude notifications whose
+ *                                               producer owns email delivery.
+ *                                               Default false.
  * }
  * @return array{ user_id:int, total:int, unread_count:int, page:int, pages:int, notifications:array }
  */
@@ -384,15 +466,17 @@ function ec_users_get_notifications( int $user_id, array $args = array() ): arra
 	global $wpdb;
 
 	$defaults = array(
-		'unread'   => false,
-		'page'     => 1,
-		'per_page' => 50,
+		'unread'                       => false,
+		'page'                         => 1,
+		'per_page'                     => 50,
+		'exclude_producer_owned_email' => false,
 	);
 	$args     = wp_parse_args( $args, $defaults );
 
-	$unread_only = ! empty( $args['unread'] );
-	$per_page    = max( 1, min( 100, (int) $args['per_page'] ) );
-	$page        = max( 1, (int) $args['page'] );
+	$unread_only   = ! empty( $args['unread'] );
+	$exclude_owned = ! empty( $args['exclude_producer_owned_email'] );
+	$per_page      = max( 1, min( 100, (int) $args['per_page'] ) );
+	$page          = max( 1, (int) $args['page'] );
 
 	$table = extrachill_users_notifications_table_name();
 
@@ -407,15 +491,31 @@ function ec_users_get_notifications( int $user_id, array $args = array() ): arra
 		);
 	}
 
-	$unread_count = (int) $wpdb->get_var(
-		$wpdb->prepare(
-			"SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND is_read = 0", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
-			$user_id
-		)
-	);
+	if ( $exclude_owned ) {
+		$unread_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND is_read = 0 AND producer_owns_email = 0", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+				$user_id
+			)
+		);
+	} else {
+		$unread_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND is_read = 0", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+				$user_id
+			)
+		);
+	}
 
 	if ( $unread_only ) {
 		$total = $unread_count;
+	} elseif ( $exclude_owned ) {
+		$total = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND producer_owns_email = 0", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+				$user_id
+			)
+		);
 	} else {
 		$total = (int) $wpdb->get_var(
 			$wpdb->prepare(
@@ -440,10 +540,30 @@ function ec_users_get_notifications( int $user_id, array $args = array() ): arra
 		);
 	}
 
-	if ( $unread_only ) {
+	if ( $unread_only && $exclude_owned ) {
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM {$table} WHERE user_id = %d AND is_read = 0 AND producer_owns_email = 0 ORDER BY created_at DESC, id DESC LIMIT %d OFFSET %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+				$user_id,
+				$per_page,
+				$offset
+			),
+			ARRAY_A
+		);
+	} elseif ( $unread_only ) {
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT * FROM {$table} WHERE user_id = %d AND is_read = 0 ORDER BY created_at DESC, id DESC LIMIT %d OFFSET %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+				$user_id,
+				$per_page,
+				$offset
+			),
+			ARRAY_A
+		);
+	} elseif ( $exclude_owned ) {
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM {$table} WHERE user_id = %d AND producer_owns_email = 0 ORDER BY created_at DESC, id DESC LIMIT %d OFFSET %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
 				$user_id,
 				$per_page,
 				$offset

--- a/tests/unit/EntitySubscriptionsTest.php
+++ b/tests/unit/EntitySubscriptionsTest.php
@@ -66,6 +66,42 @@ class Test_Entity_Subscriptions extends WP_UnitTestCase {
 		$this->assertFalse( extrachill_users_entity_subscription_status( $user_id, 'venue', 'venue', 'the-royal-american' )['subscribed'] );
 	}
 
+	public function test_unsubscribe_is_idempotent_when_no_row_exists(): void {
+		$user_id = self::factory()->user->create();
+
+		$first  = extrachill_users_unsubscribe_from_entity( $user_id, 'venue', 'venue', 'the-royal-american' );
+		$second = extrachill_users_unsubscribe_from_entity( $user_id, 'venue', 'venue', 'the-royal-american' );
+
+		$this->assertFalse( $first['subscribed'] );
+		$this->assertFalse( $second['subscribed'] );
+	}
+
+	public function test_unsubscribe_returns_error_on_database_failure(): void {
+		global $wpdb;
+
+		$user_id = self::factory()->user->create();
+		$table   = extrachill_users_entity_subscriptions_table_name();
+		$fail    = static function ( string $query ) use ( $table ): string {
+			if ( str_contains( $query, "DELETE FROM {$table}" ) ) {
+				return 'INVALID ENTITY SUBSCRIPTION DELETE';
+			}
+
+			return $query;
+		};
+
+		$previous_suppression = $wpdb->suppress_errors( true );
+		add_filter( 'query', $fail );
+		try {
+			$result = extrachill_users_unsubscribe_from_entity( $user_id, 'venue', 'venue', 'the-royal-american' );
+		} finally {
+			remove_filter( 'query', $fail );
+			$wpdb->suppress_errors( $previous_suppression );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'entity_subscription_delete_failed', $result->get_error_code() );
+	}
+
 	public function test_invalid_entity_pair_is_rejected(): void {
 		$user_id = self::factory()->user->create();
 		$result  = extrachill_users_subscribe_to_entity( $user_id, 'festival', 'artist', 'big-fest' );

--- a/tests/unit/NotificationDeliveryReceiptsTest.php
+++ b/tests/unit/NotificationDeliveryReceiptsTest.php
@@ -20,12 +20,12 @@ class Test_Notification_Delivery_Receipts extends WP_UnitTestCase {
 	private function payload( int $actor_id, array $overrides = array() ): array {
 		return array_merge(
 			array(
-				'actor_id'       => $actor_id,
-				'type'           => 'test_notice',
-				'title'          => 'A test notification',
-				'link'           => 'https://example.org/notice',
-				'item_id'        => 42,
-				'producer'       => 'tests.notifications',
+				'actor_id'        => $actor_id,
+				'type'            => 'test_notice',
+				'title'           => 'A test notification',
+				'link'            => 'https://example.org/notice',
+				'item_id'         => 42,
+				'producer'        => 'tests.notifications',
 				'idempotency_key' => 'delivery-42',
 			),
 			$overrides
@@ -143,6 +143,198 @@ class Test_Notification_Delivery_Receipts extends WP_UnitTestCase {
 
 		ec_users_notify_with_receipts( $recipient, $payload );
 		$this->assertSame( 1, ec_notifications_email_count_unmailed_unread( $recipient ) );
+	}
+
+	public function test_producer_owned_email_is_suppressed_but_remains_unread(): void {
+		$actor     = self::factory()->user->create();
+		$recipient = self::factory()->user->create();
+		$receipt   = ec_users_notify_with_receipts(
+			$recipient,
+			$this->payload( $actor, array( 'producer_owns_email' => true ) )
+		);
+
+		$this->assertSame( 1, $receipt['inserted'] );
+		$notification_id = $receipt['recipients'][ $recipient ]['notification_id'];
+		$this->assertGreaterThan( 0, $notification_id );
+		$this->assertSame( 1, ec_users_get_unread_count( $recipient ) );
+		$this->assertSame( 0, ec_notifications_email_count_unmailed_unread( $recipient ) );
+
+		global $wpdb;
+		$table = extrachill_users_notifications_table_name();
+		$row   = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT created_at, emailed_at, producer_owns_email FROM {$table} WHERE id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- test table from trusted helper.
+				$notification_id
+			),
+			ARRAY_A
+		);
+		$this->assertSame( $row['created_at'], $row['emailed_at'] );
+		$this->assertSame( '1', $row['producer_owns_email'] );
+	}
+
+	public function test_email_reader_excludes_owned_rows_without_changing_in_app_reader(): void {
+		$actor     = self::factory()->user->create();
+		$recipient = self::factory()->user->create();
+
+		$owned = ec_users_notify_with_receipts(
+			$recipient,
+			$this->payload( $actor, array( 'producer_owns_email' => true ) )
+		);
+		$ordinary = ec_users_notify_with_receipts(
+			$recipient,
+			$this->payload( $actor, array( 'idempotency_key' => 'ordinary-delivery' ) )
+		);
+
+		$in_app = ec_users_get_notifications( $recipient, array( 'unread' => true ) );
+		$email  = ec_users_get_notifications(
+			$recipient,
+			array(
+				'unread'                       => true,
+				'exclude_producer_owned_email' => true,
+			)
+		);
+
+		$this->assertSame( 2, $in_app['unread_count'] );
+		$this->assertCount( 2, $in_app['notifications'] );
+		$this->assertSame( 1, $email['unread_count'] );
+		$this->assertCount( 1, $email['notifications'] );
+		$this->assertSame( 1, ec_notifications_email_count_unmailed_unread( $recipient ) );
+		$this->assertSame( $ordinary['recipients'][ $recipient ]['notification_id'], $email['notifications'][0]['id'] );
+		$this->assertNotSame( $owned['recipients'][ $recipient ]['notification_id'], $email['notifications'][0]['id'] );
+	}
+
+	public function test_normal_idempotent_notification_remains_email_eligible(): void {
+		$actor     = self::factory()->user->create();
+		$recipient = self::factory()->user->create();
+
+		ec_users_notify_with_receipts(
+			$recipient,
+			$this->payload( $actor, array( 'producer_owns_email' => false ) )
+		);
+
+		$this->assertSame( 1, ec_notifications_email_count_unmailed_unread( $recipient ) );
+	}
+
+	public function test_producer_owned_email_requires_idempotency_fields(): void {
+		$actor     = self::factory()->user->create();
+		$recipient = self::factory()->user->create();
+		$payload   = $this->payload( $actor, array( 'producer_owns_email' => true ) );
+		unset( $payload['producer'], $payload['idempotency_key'] );
+
+		$receipt = ec_users_notify_with_receipts( $recipient, $payload );
+
+		$this->assertSame( 'email_ownership_requires_idempotency', $receipt['recipients'][ $recipient ]['error'] );
+		$this->assertSame( 0, ec_users_get_unread_count( $recipient ) );
+	}
+
+	public function test_producer_owned_replay_returns_same_suppressed_receipt(): void {
+		$actor     = self::factory()->user->create();
+		$recipient = self::factory()->user->create();
+		$payload   = $this->payload( $actor, array( 'producer_owns_email' => true ) );
+
+		$first  = ec_users_notify_with_receipts( $recipient, $payload );
+		$second = ec_users_notify_with_receipts( $recipient, $payload );
+
+		$this->assertSame( 'existing', $second['recipients'][ $recipient ]['status'] );
+		$this->assertSame( $first['recipients'][ $recipient ]['notification_id'], $second['recipients'][ $recipient ]['notification_id'] );
+		$this->assertSame( 1, ec_users_get_unread_count( $recipient ) );
+		$this->assertSame( 0, ec_notifications_email_count_unmailed_unread( $recipient ) );
+	}
+
+	public function test_replay_rejects_email_ownership_contract_mismatch(): void {
+		$actor           = self::factory()->user->create();
+		$recipient       = self::factory()->user->create();
+		$other_recipient = self::factory()->user->create();
+		$payload         = $this->payload( $actor, array( 'producer_owns_email' => true ) );
+
+		$first = ec_users_notify_with_receipts( $recipient, $payload );
+		unset( $payload['producer_owns_email'] );
+		$replay = ec_users_notify_with_receipts( $recipient, $payload );
+
+		$this->assertSame( 'inserted', $first['recipients'][ $recipient ]['status'] );
+		$this->assertSame( 'failed', $replay['recipients'][ $recipient ]['status'] );
+		$this->assertSame( 'idempotency_contract_mismatch', $replay['recipients'][ $recipient ]['error'] );
+		$this->assertSame( 1, ec_users_get_unread_count( $recipient ) );
+		$this->assertSame( 0, ec_notifications_email_count_unmailed_unread( $recipient ) );
+
+		$normal = $this->payload( $actor );
+		ec_users_notify_with_receipts( $other_recipient, $normal );
+		$normal['producer_owns_email'] = true;
+		$owned_replay                  = ec_users_notify_with_receipts( $other_recipient, $normal );
+
+		$this->assertSame( 'failed', $owned_replay['recipients'][ $other_recipient ]['status'] );
+		$this->assertSame( 'idempotency_contract_mismatch', $owned_replay['recipients'][ $other_recipient ]['error'] );
+		$this->assertSame( 1, ec_notifications_email_count_unmailed_unread( $other_recipient ) );
+	}
+
+	public function test_release_removes_exact_producer_owned_receipt(): void {
+		$actor     = self::factory()->user->create();
+		$recipient = self::factory()->user->create();
+		$payload   = $this->payload( $actor, array( 'producer_owns_email' => true ) );
+		$receipt   = ec_users_notify_with_receipts( $recipient, $payload );
+		$id        = $receipt['recipients'][ $recipient ]['notification_id'];
+
+		$this->assertTrue( ec_users_release_notification_receipt( $id, $recipient, $payload['producer'], $payload['idempotency_key'] ) );
+		$this->assertSame( 0, ec_users_get_unread_count( $recipient ) );
+		$this->assertFalse( ec_users_release_notification_receipt( $id, $recipient, $payload['producer'], $payload['idempotency_key'] ) );
+	}
+
+	public function test_release_rejects_mismatched_and_normal_receipts(): void {
+		$actor     = self::factory()->user->create();
+		$recipient = self::factory()->user->create();
+		$owned     = $this->payload( $actor, array( 'producer_owns_email' => true ) );
+		$receipt   = ec_users_notify_with_receipts( $recipient, $owned );
+		$id        = $receipt['recipients'][ $recipient ]['notification_id'];
+
+		$this->assertFalse( ec_users_release_notification_receipt( $id, $recipient, 'tests.other-producer', $owned['idempotency_key'] ) );
+		$this->assertFalse( ec_users_release_notification_receipt( $id, $recipient, $owned['producer'], 'other-key' ) );
+		$this->assertSame( 1, ec_users_get_unread_count( $recipient ) );
+
+		$normal         = $this->payload(
+			$actor,
+			array(
+				'idempotency_key' => 'normal-delivery',
+			)
+		);
+		$normal_receipt = ec_users_notify_with_receipts( $recipient, $normal );
+		$normal_id      = $normal_receipt['recipients'][ $recipient ]['notification_id'];
+
+		$this->assertFalse( ec_users_release_notification_receipt( $normal_id, $recipient, $normal['producer'], $normal['idempotency_key'] ) );
+		$this->assertSame( 2, ec_users_get_unread_count( $recipient ) );
+	}
+
+	public function test_release_rejects_read_receipt_and_replay_does_not_recreate_it_unread(): void {
+		$actor     = self::factory()->user->create();
+		$recipient = self::factory()->user->create();
+		$payload   = $this->payload( $actor, array( 'producer_owns_email' => true ) );
+		$receipt   = ec_users_notify_with_receipts( $recipient, $payload );
+		$id        = $receipt['recipients'][ $recipient ]['notification_id'];
+
+		$this->assertSame( 1, ec_users_mark_notifications_read( $recipient, $id ) );
+		$this->assertFalse( ec_users_release_notification_receipt( $id, $recipient, $payload['producer'], $payload['idempotency_key'] ) );
+
+		$replay = ec_users_notify_with_receipts( $recipient, $payload );
+
+		$this->assertSame( 'existing', $replay['recipients'][ $recipient ]['status'] );
+		$this->assertSame( $id, $replay['recipients'][ $recipient ]['notification_id'] );
+		$this->assertSame( 0, ec_users_get_unread_count( $recipient ) );
+	}
+
+	public function test_retry_inserts_again_after_release(): void {
+		$actor     = self::factory()->user->create();
+		$recipient = self::factory()->user->create();
+		$payload   = $this->payload( $actor, array( 'producer_owns_email' => true ) );
+		$first     = ec_users_notify_with_receipts( $recipient, $payload );
+		$first_id  = $first['recipients'][ $recipient ]['notification_id'];
+
+		$this->assertTrue( ec_users_release_notification_receipt( $first_id, $recipient, $payload['producer'], $payload['idempotency_key'] ) );
+
+		$retry = ec_users_notify_with_receipts( $recipient, $payload );
+
+		$this->assertSame( 'inserted', $retry['recipients'][ $recipient ]['status'] );
+		$this->assertNotSame( $first_id, $retry['recipients'][ $recipient ]['notification_id'] );
+		$this->assertSame( 1, ec_users_get_unread_count( $recipient ) );
+		$this->assertSame( 0, ec_notifications_email_count_unmailed_unread( $recipient ) );
 	}
 
 	public function test_schema_health_requires_atomic_delivery_index(): void {


### PR DESCRIPTION
## Summary
- let idempotent notification producers own rich-email delivery without entering or appearing in the generic unread-email digest
- persist and validate email ownership across replay, and allow exact unread receipts to be released after explicit queue-admission failure
- report entity-subscription deletion failures instead of falsely confirming unsubscribe

## Why
The weekly Local Scene digest needs an in-app notification as its durable delivery receipt while sending a richer producer-owned email. Without this contract, recipients can receive a second generic email and failed queue admission cannot be retried safely.

## Verification
- targeted WordPress sandbox before rebase: 27 tests, 97 assertions
- PHPStan: passed
- WordPress PHPCS on production files: 0 errors; existing direct-database warnings only
- PHP syntax and `git diff --check`: passed
- post-rebase managed WordPress rerun was blocked by Homeboy MySQL 8.4 provisioning; source/static gates remained green

Closes #294
Closes #297