### PR TITLE
refactor: canonicalize entity email consent

### DIFF
--- a/inc/core/abilities/entity-subscriptions.php
+++ b/inc/core/abilities/entity-subscriptions.php
@@ -54,6 +54,32 @@ function extrachill_users_register_entity_subscription_abilities(): void {
 		);
 	}
 
+	wp_register_ability(
+		'extrachill/list-entity-subscriptions',
+		array(
+			'label'               => __( 'List Entity Subscriptions', 'extrachill-users' ),
+			'description'         => __( 'List the authenticated user’s private canonical entity subscription identities.', 'extrachill-users' ),
+			'category'            => 'extrachill-users',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'page'     => array( 'type' => 'integer' ),
+					'per_page' => array( 'type' => 'integer' ),
+				),
+			),
+			'output_schema'       => array( 'type' => 'object' ),
+			'execute_callback'    => 'extrachill_users_ability_list_entity_subscriptions',
+			'permission_callback' => 'is_user_logged_in',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'   => true,
+					'idempotent' => true,
+				),
+			),
+		)
+	);
+
 	// Producer recipient enumeration is never exposed through REST. Producers
 	// use the private service directly, and privileged tooling may use this
 	// ability only when it has a network administrator's authorization.
@@ -151,6 +177,21 @@ function extrachill_users_ability_entity_unsubscribe( array $input ) {
  */
 function extrachill_users_ability_entity_subscription_status( array $input ) {
 	return extrachill_users_entity_subscription_ability( $input, 'status' );
+}
+
+/**
+ * List the authenticated user's canonical subscription identities.
+ *
+ * @param array $input Pagination input.
+ * @return array|WP_Error
+ */
+function extrachill_users_ability_list_entity_subscriptions( array $input ) {
+	$user_id = extrachill_users_resolve_self_user_id();
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
+
+	return extrachill_users_list_entity_subscriptions( $user_id, $input['page'] ?? 1, $input['per_page'] ?? 50 );
 }
 
 /**

--- a/inc/core/abilities/subscriptions.php
+++ b/inc/core/abilities/subscriptions.php
@@ -14,6 +14,22 @@ defined( 'ABSPATH' ) || exit;
 add_action( 'wp_abilities_api_init', 'extrachill_users_register_subscription_abilities' );
 
 /**
+ * Register the Artist feature's email-sharing purpose identity.
+ *
+ * @param array $entities Entity identity definitions.
+ * @return array
+ */
+function extrachill_users_register_artist_email_sharing_identity( array $entities ): array {
+	$entities['artist-email-sharing'] = array(
+		'taxonomy'                           => 'artist',
+		'uses_notification_email_preference' => false,
+	);
+
+	return $entities;
+}
+add_filter( 'extrachill_users_entity_subscription_entities', 'extrachill_users_register_artist_email_sharing_identity' );
+
+/**
  * Register subscription abilities.
  */
 function extrachill_users_register_subscription_abilities() {
@@ -89,47 +105,15 @@ function extrachill_users_ability_get_subscriptions() {
 		return $user_id;
 	}
 
-	$user = get_user_by( 'ID', $user_id );
-	if ( ! $user ) {
-		return new WP_Error( 'user_not_found', 'User not found.' );
+	$subscriptions = extrachill_users_get_artist_email_sharing_subscriptions( $user_id );
+	if ( is_wp_error( $subscriptions ) ) {
+		return $subscriptions;
 	}
-
-	// Resolve artist email consent directly from artist_subscribers rows.
-	// The artist_subscribers table lives on the artist site (blog 4), so we
-	// switch_to_blog to get the correct table prefix. Each consent row is an
-	// artist the user has subscribed to with email consent granted.
-	$artist_email_consents = array();
-	$artist_blog_id        = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
-	$artist_blog_id        = (int) apply_filters( 'extrachill_users_artist_consent_blog_id', $artist_blog_id );
-
-	if ( $artist_blog_id ) {
-		switch_to_blog( $artist_blog_id );
-
-		global $wpdb;
-		$table_name = $wpdb->prefix . 'artist_subscribers';
-
-		$results = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT artist_profile_id FROM {$table_name} WHERE user_id = %d AND source = 'platform_follow_consent'", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted prefix.
-				$user_id
-			),
-			ARRAY_A
-		);
-
-		if ( ! empty( $results ) ) {
-			foreach ( $results as $row ) {
-				$artist_id               = (int) $row['artist_profile_id'];
-				$artist_email_consents[] = array(
-					'artist_id'     => $artist_id,
-					'name'          => get_the_title( $artist_id ),
-					'url'           => get_permalink( $artist_id ),
-					'email_consent' => true,
-				);
-			}
-		}
-
-		restore_current_blog();
-	}
+	$artist_email_consents = array_values(
+		array_filter(
+			array_map( 'extrachill_users_artist_email_sharing_presentation', $subscriptions )
+		)
+	);
 
 	return array(
 		'user_id'               => $user_id,
@@ -169,8 +153,7 @@ function extrachill_users_ability_update_subscriptions( $input ) {
 		return new WP_Error( 'user_not_found', 'User not found.' );
 	}
 
-	$subscriber_email = sanitize_email( $user->user_email );
-	if ( empty( $subscriber_email ) ) {
+	if ( ! empty( $consented_artists ) && empty( sanitize_email( $user->user_email ) ) ) {
 		return new WP_Error(
 			'user_email_missing',
 			'An account email is required to share email access with artists.',
@@ -178,100 +161,263 @@ function extrachill_users_ability_update_subscriptions( $input ) {
 		);
 	}
 
-	// The artist_subscribers table lives on the artist site (blog 4).
-	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
-	$artist_blog_id = (int) apply_filters( 'extrachill_users_artist_consent_blog_id', $artist_blog_id );
+	$desired = array();
+	foreach ( $consented_artists as $artist_id ) {
+		$identity = extrachill_users_artist_email_sharing_identity( $artist_id );
+		if ( is_wp_error( $identity ) ) {
+			return $identity;
+		}
+		$desired[ $identity['slug'] ] = $identity;
+	}
 
-	if ( ! $artist_blog_id ) {
-		return new WP_Error( 'service_unavailable', 'Artist platform not configured.' );
+	$existing = extrachill_users_get_artist_email_sharing_subscriptions( $user_id );
+	if ( is_wp_error( $existing ) ) {
+		return $existing;
+	}
+	foreach ( $desired as $slug => $identity ) {
+		if ( isset( $existing[ $slug ] ) ) {
+			continue;
+		}
+		$result = extrachill_users_subscribe_to_entity( $user_id, $identity['entity_type'], $identity['taxonomy'], $slug );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+	}
+	foreach ( $existing as $slug => $identity ) {
+		if ( isset( $desired[ $slug ] ) ) {
+			continue;
+		}
+		$result = extrachill_users_unsubscribe_from_entity( $user_id, $identity['entity_type'], $identity['taxonomy'], $slug );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+	}
+
+	return array(
+		'success' => true,
+		'message' => 'Subscription preferences updated.',
+		'user_id' => $user_id,
+	);
+}
+
+/**
+ * Resolve an artist profile to its canonical email-sharing identity.
+ *
+ * @param int  $artist_id Artist profile ID.
+ * @param bool $allow_binding_fallback Whether the feature resolver may self-heal a missing stored binding.
+ * @return array|WP_Error
+ */
+function extrachill_users_artist_email_sharing_identity( $artist_id, $allow_binding_fallback = true ) {
+	$artist_id      = absint( $artist_id );
+	$artist_blog_id = (int) apply_filters( 'extrachill_users_artist_consent_blog_id', function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : 0 );
+	$main_blog_id   = (int) apply_filters( 'extrachill_users_artist_consent_main_blog_id', function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : 0 );
+	if ( ! $artist_id || ! $artist_blog_id || ! $main_blog_id ) {
+		return new WP_Error( 'artist_email_consent_identity_unavailable', __( 'The canonical artist identity is unavailable.', 'extrachill-users' ), array( 'status' => 503 ) );
 	}
 
 	switch_to_blog( $artist_blog_id );
-
 	try {
-		global $wpdb;
-		$table_name = $wpdb->prefix . 'artist_subscribers';
-
-		// Existing consent rows for this user define the current scope. We add
-		// consent for any newly-supplied artist and remove consent rows the user
-		// no longer includes in the consented set.
-		$existing_ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT artist_profile_id FROM {$table_name} WHERE user_id = %d AND source = 'platform_follow_consent'", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted prefix.
-				$user_id
-			)
-		);
-		if ( null === $existing_ids && '' !== $wpdb->last_error ) {
-			return new WP_Error(
-				'artist_email_consent_read_failed',
-				'Artist email preferences could not be loaded.',
-				array( 'status' => 500 )
-			);
+		$term_id = absint( get_post_meta( $artist_id, '_artist_term_id', true ) );
+		if ( ! $term_id && $allow_binding_fallback && function_exists( 'ec_get_artist_term_id' ) ) {
+			$term_id = absint( ec_get_artist_term_id( $artist_id ) );
 		}
-		$existing_ids = array_map( 'intval', (array) $existing_ids );
+	} finally {
+		restore_current_blog();
+	}
+	if ( ! $term_id ) {
+		return new WP_Error( 'artist_email_consent_binding_missing', __( 'The artist profile has no canonical artist term binding.', 'extrachill-users' ), array( 'status' => 409 ) );
+	}
 
-		// Add consent for newly-supplied artists with the identity required by
-		// the artist-platform export contract and unique email/artist index.
-		foreach ( $consented_artists as $artist_id ) {
-			if ( in_array( $artist_id, $existing_ids, true ) ) {
-				continue;
-			}
+	switch_to_blog( $main_blog_id );
+	try {
+		$term = get_term( $term_id, 'artist' );
+	} finally {
+		restore_current_blog();
+	}
+	if ( ! $term instanceof WP_Term ) {
+		return new WP_Error( 'artist_email_consent_term_missing', __( 'The bound canonical artist term is unavailable.', 'extrachill-users' ), array( 'status' => 409 ) );
+	}
 
-			$inserted = $wpdb->insert(
-				$table_name,
-				array(
-					'user_id'           => $user_id,
-					'artist_profile_id' => $artist_id,
-					'subscriber_email'  => $subscriber_email,
-					'username'          => $user->user_login,
-					'source'            => 'platform_follow_consent',
-					'subscribed_at'     => current_time( 'mysql' ),
-				),
-				array( '%d', '%d', '%s', '%s', '%s', '%s' )
-			);
-			if ( false === $inserted ) {
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Operational context for a failed consent write.
-				error_log( 'Artist email consent insert failed: ' . $wpdb->last_error );
-				return new WP_Error(
-					'artist_email_consent_insert_failed',
-					'Artist email preferences could not be updated.',
-					array( 'status' => 500 )
-				);
+	return array(
+		'entity_type' => 'artist-email-sharing',
+		'taxonomy'    => 'artist',
+		'slug'        => $term->slug,
+	);
+}
+
+/**
+ * Return all artist email-sharing identities for one user, keyed by slug.
+ *
+ * @param int $user_id User ID.
+ * @return array|WP_Error
+ */
+function extrachill_users_get_artist_email_sharing_subscriptions( $user_id ) {
+	$subscriptions = array();
+	$page          = 1;
+	do {
+		$result = extrachill_users_list_entity_subscriptions( $user_id, $page, 100 );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		foreach ( $result['subscriptions'] as $identity ) {
+			if ( 'artist-email-sharing' === $identity['entity_type'] ) {
+				$subscriptions[ $identity['slug'] ] = $identity;
 			}
 		}
+		++$page;
+	} while ( $page <= $result['total_pages'] );
 
-		// Remove consent rows no longer in the consented set.
-		foreach ( $existing_ids as $artist_id ) {
-			if ( in_array( $artist_id, $consented_artists, true ) ) {
-				continue;
-			}
+	return $subscriptions;
+}
 
-			$deleted = $wpdb->delete(
-				$table_name,
-				array(
-					'user_id'           => $user_id,
-					'artist_profile_id' => $artist_id,
-					'source'            => 'platform_follow_consent',
-				),
-				array( '%d', '%d', '%s' )
-			);
-			if ( false === $deleted ) {
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Operational context for a failed consent write.
-				error_log( 'Artist email consent delete failed: ' . $wpdb->last_error );
-				return new WP_Error(
-					'artist_email_consent_delete_failed',
-					'Artist email preferences could not be updated.',
-					array( 'status' => 500 )
-				);
-			}
-		}
+/**
+ * Resolve legacy artist presentation fields outside the generic service.
+ *
+ * @param array $identity Canonical artist email-sharing identity.
+ * @return array|null
+ */
+function extrachill_users_artist_email_sharing_presentation( array $identity ) {
+	$main_blog_id   = (int) apply_filters( 'extrachill_users_artist_consent_main_blog_id', function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : 0 );
+	$artist_blog_id = (int) apply_filters( 'extrachill_users_artist_consent_blog_id', function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : 0 );
+	if ( ! $main_blog_id || ! $artist_blog_id ) {
+		return null;
+	}
 
+	switch_to_blog( $main_blog_id );
+	try {
+		$term      = get_term_by( 'slug', $identity['slug'], 'artist' );
+		$artist_id = $term instanceof WP_Term ? absint( get_term_meta( $term->term_id, '_artist_profile_id', true ) ) : 0;
+	} finally {
+		restore_current_blog();
+	}
+	if ( ! $artist_id ) {
+		return null;
+	}
+
+	switch_to_blog( $artist_blog_id );
+	try {
 		return array(
-			'success' => true,
-			'message' => 'Subscription preferences updated.',
-			'user_id' => $user_id,
+			'artist_id'     => $artist_id,
+			'name'          => get_the_title( $artist_id ),
+			'url'           => get_permalink( $artist_id ),
+			'email_consent' => true,
 		);
 	} finally {
 		restore_current_blog();
 	}
+}
+
+/**
+ * Dry-run or migrate authenticated legacy artist consent rows.
+ *
+ * @param bool $apply Whether to write canonical rows and remove verified legacy rows.
+ * @return array|WP_Error
+ */
+function extrachill_users_migrate_artist_email_sharing_consent( bool $apply = false ) {
+	$artist_blog_id = (int) apply_filters( 'extrachill_users_artist_consent_blog_id', function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : 0 );
+	if ( ! $artist_blog_id ) {
+		return new WP_Error( 'artist_email_consent_migration_unavailable', __( 'The artist site is unavailable.', 'extrachill-users' ) );
+	}
+
+	switch_to_blog( $artist_blog_id );
+	try {
+		global $wpdb;
+		$table = $wpdb->prefix . 'artist_subscribers';
+		$rows  = $wpdb->get_results( "SELECT subscriber_id, user_id, artist_profile_id FROM {$table} WHERE user_id > 0 AND source = 'platform_follow_consent' ORDER BY subscriber_id ASC", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- trusted current-site prefix and fixed legacy source.
+	} finally {
+		restore_current_blog();
+	}
+	if ( ! is_array( $rows ) ) {
+		return new WP_Error( 'artist_email_consent_migration_read_failed', __( 'Legacy artist consent rows could not be loaded.', 'extrachill-users' ) );
+	}
+
+	$report = array();
+	$totals = array_fill_keys( array( 'candidates', 'ready', 'migrated', 'already_canonical', 'unresolved', 'failed' ), 0 );
+	foreach ( $rows as $row ) {
+		++$totals['candidates'];
+		$user_id       = absint( $row['user_id'] );
+		$subscriber_id = absint( $row['subscriber_id'] );
+		$artist_id     = absint( $row['artist_profile_id'] );
+		$identity      = extrachill_users_artist_email_sharing_identity( $artist_id, false );
+		$status        = 'ready';
+		if ( ! get_userdata( $user_id ) || is_wp_error( $identity ) ) {
+			$status = 'unresolved';
+			++$totals['unresolved'];
+		} else {
+			$canonical = extrachill_users_entity_subscription_status( $user_id, $identity['entity_type'], $identity['taxonomy'], $identity['slug'] );
+			if ( is_wp_error( $canonical ) ) {
+				$status = 'failed';
+				++$totals['failed'];
+			} elseif ( ! $apply ) {
+				$status = $canonical['subscribed'] ? 'already-canonical' : 'ready';
+				++$totals[ $canonical['subscribed'] ? 'already_canonical' : 'ready' ];
+			} else {
+				if ( ! $canonical['subscribed'] ) {
+					$canonical = extrachill_users_subscribe_to_entity( $user_id, $identity['entity_type'], $identity['taxonomy'], $identity['slug'] );
+				}
+				$verification = is_wp_error( $canonical ) ? $canonical : extrachill_users_entity_subscription_status( $user_id, $identity['entity_type'], $identity['taxonomy'], $identity['slug'] );
+				$verified     = ! is_wp_error( $verification ) && $verification['subscribed'];
+				if ( $verified ) {
+					switch_to_blog( $artist_blog_id );
+					try {
+						global $wpdb;
+						$deleted = $wpdb->delete(
+							$wpdb->prefix . 'artist_subscribers',
+							array(
+								'subscriber_id' => $subscriber_id,
+								'user_id'       => $user_id,
+								'source'        => 'platform_follow_consent',
+							),
+							array( '%d', '%d', '%s' )
+						);
+					} finally {
+						restore_current_blog();
+					}
+					$status = 1 === $deleted ? 'migrated' : 'failed';
+				} else {
+					$status = 'failed';
+				}
+				++$totals[ 'migrated' === $status ? 'migrated' : 'failed' ];
+			}
+		}
+
+		$report[] = array(
+			'subscriber_id'     => $subscriber_id,
+			'user_id'           => $user_id,
+			'artist_profile_id' => $artist_id,
+			'status'            => $status,
+			'canonical_slug'    => is_wp_error( $identity ) ? '' : $identity['slug'],
+		);
+	}
+
+	return array(
+		'applied' => $apply,
+		'rows'    => $report,
+		'totals'  => $totals,
+	);
+}
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	WP_CLI::add_command(
+		'extrachill-users migrate-artist-email-consent',
+		static function ( $args, $assoc_args ) {
+			$result = extrachill_users_migrate_artist_email_sharing_consent( isset( $assoc_args['apply'] ) );
+			if ( is_wp_error( $result ) ) {
+				WP_CLI::error( $result->get_error_message() );
+			}
+			WP_CLI\Utils\format_items( 'table', $result['rows'], array( 'subscriber_id', 'user_id', 'artist_profile_id', 'status', 'canonical_slug' ) );
+			WP_CLI::success( wp_json_encode( $result['totals'] ) );
+		},
+		array(
+			'shortdesc' => 'Dry-run or apply authenticated artist email-consent migration.',
+			'synopsis'  => array(
+				array(
+					'type'        => 'flag',
+					'name'        => 'apply',
+					'description' => 'Write and verify canonical consent, then remove each legacy row.',
+					'optional'    => true,
+				),
+			),
+		)
+	);
 }

--- a/inc/entity-subscriptions/service.php
+++ b/inc/entity-subscriptions/service.php
@@ -38,9 +38,43 @@ add_action( 'init', 'extrachill_users_maybe_install_entity_subscriptions_table' 
  */
 function extrachill_users_normalize_entity_subscription( $entity_type, $taxonomy, $slug ) {
 
+	$entity_type       = sanitize_key( $entity_type );
+	$taxonomy          = sanitize_key( $taxonomy );
+	$slug              = sanitize_title( $slug );
+	$entities          = apply_filters(
+		'extrachill_users_entity_subscription_entities',
+		array(
+			'festival' => 'festival',
+			'artist'   => 'artist',
+			'venue'    => 'venue',
+			'location' => 'location',
+		)
+	);
+	$definition        = $entities[ $entity_type ] ?? null;
+	$expected_taxonomy = is_array( $definition ) ? sanitize_key( $definition['taxonomy'] ?? '' ) : sanitize_key( $definition );
+
+	if ( '' === $entity_type || '' === $taxonomy || '' === $slug || '' === $expected_taxonomy || $taxonomy !== $expected_taxonomy ) {
+		return new WP_Error( 'invalid_entity_subscription', __( 'A supported entity type, taxonomy, and slug are required.', 'extrachill-users' ), array( 'status' => 400 ) );
+	}
+
+	return array(
+		'entity_type' => $entity_type,
+		'taxonomy'    => $taxonomy,
+		'slug'        => $slug,
+	);
+}
+
+/**
+ * Determine whether an identity uses the account notification-email preference.
+ *
+ * Feature-owned purpose identities may opt out without the generic layer
+ * knowing which product registered them.
+ *
+ * @param string $entity_type Entity type.
+ * @return bool
+ */
+function extrachill_users_entity_subscription_uses_notification_email_preference( $entity_type ): bool {
 	$entity_type = sanitize_key( $entity_type );
-	$taxonomy    = sanitize_key( $taxonomy );
-	$slug        = sanitize_title( $slug );
 	$entities    = apply_filters(
 		'extrachill_users_entity_subscription_entities',
 		array(
@@ -50,16 +84,9 @@ function extrachill_users_normalize_entity_subscription( $entity_type, $taxonomy
 			'location' => 'location',
 		)
 	);
+	$definition  = $entities[ $entity_type ] ?? null;
 
-	if ( '' === $entity_type || '' === $taxonomy || '' === $slug || ! isset( $entities[ $entity_type ] ) || $taxonomy !== $entities[ $entity_type ] ) {
-		return new WP_Error( 'invalid_entity_subscription', __( 'A supported entity type, taxonomy, and slug are required.', 'extrachill-users' ), array( 'status' => 400 ) );
-	}
-
-	return array(
-		'entity_type' => $entity_type,
-		'taxonomy'    => $taxonomy,
-		'slug'        => $slug,
-	);
+	return ! is_array( $definition ) || ! array_key_exists( 'uses_notification_email_preference', $definition ) || (bool) $definition['uses_notification_email_preference'];
 }
 
 /**
@@ -84,8 +111,8 @@ function extrachill_users_subscribe_to_entity( $user_id, $entity_type, $taxonomy
 		return new WP_Error( 'user_not_found', __( 'User not found.', 'extrachill-users' ), array( 'status' => 404 ) );
 	}
 
-	$table = extrachill_users_entity_subscriptions_table_name();
-	$wpdb->query(
+	$table    = extrachill_users_entity_subscriptions_table_name();
+	$inserted = $wpdb->query(
 		$wpdb->prepare(
 			"INSERT IGNORE INTO {$table} (user_id, entity_type, taxonomy, entity_slug, created_at) VALUES (%d, %s, %s, %s, %s)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- trusted table helper.
 			$user_id,
@@ -95,6 +122,9 @@ function extrachill_users_subscribe_to_entity( $user_id, $entity_type, $taxonomy
 			current_time( 'mysql', true )
 		)
 	);
+	if ( false === $inserted ) {
+		return new WP_Error( 'entity_subscription_insert_failed', __( 'The subscription could not be saved.', 'extrachill-users' ), array( 'status' => 500 ) );
+	}
 
 	return array_merge( $entity, array( 'subscribed' => true ) );
 }
@@ -172,6 +202,63 @@ function extrachill_users_entity_subscription_status( $user_id, $entity_type, $t
 }
 
 /**
+ * List one user's canonical entity subscription identities.
+ *
+ * @param int $user_id User ID.
+ * @param int $page Page number.
+ * @param int $per_page Results per page, capped at 100.
+ * @return array|WP_Error
+ */
+function extrachill_users_list_entity_subscriptions( $user_id, $page = 1, $per_page = 50 ) {
+	global $wpdb;
+
+	$user_id  = absint( $user_id );
+	$page     = max( 1, absint( $page ) );
+	$per_page = max( 1, min( 100, absint( $per_page ) ) );
+	if ( ! $user_id || ! get_userdata( $user_id ) ) {
+		return new WP_Error( 'user_not_found', __( 'User not found.', 'extrachill-users' ), array( 'status' => 404 ) );
+	}
+
+	$table  = extrachill_users_entity_subscriptions_table_name();
+	$offset = ( $page - 1 ) * $per_page;
+	$rows   = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT entity_type, taxonomy, entity_slug FROM {$table} WHERE user_id = %d ORDER BY id ASC LIMIT %d OFFSET %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- trusted table helper.
+			$user_id,
+			$per_page,
+			$offset
+		),
+		ARRAY_A
+	);
+	if ( ! is_array( $rows ) ) {
+		return new WP_Error( 'entity_subscriptions_read_failed', __( 'The subscriptions could not be loaded.', 'extrachill-users' ), array( 'status' => 500 ) );
+	}
+	$total = (int) $wpdb->get_var(
+		$wpdb->prepare(
+			"SELECT COUNT(*) FROM {$table} WHERE user_id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- trusted table helper.
+			$user_id
+		)
+	);
+
+	return array(
+		'subscriptions' => array_map(
+			static function ( array $row ): array {
+				return array(
+					'entity_type' => $row['entity_type'],
+					'taxonomy'    => $row['taxonomy'],
+					'slug'        => $row['entity_slug'],
+				);
+			},
+			$rows
+		),
+		'page'          => $page,
+		'per_page'      => $per_page,
+		'total'         => $total,
+		'total_pages'   => (int) ceil( $total / $per_page ),
+	);
+}
+
+/**
  * Resolve recipients for an authorized producer without exposing an audience.
  *
  * Producers must opt in through the authorization filter with their own stable
@@ -212,7 +299,7 @@ function extrachill_users_entity_subscription_recipients( $producer, $entity_typ
 	);
 	$ids   = array_values( array_unique( array_map( 'absint', $ids ) ) );
 
-	if ( 'email' === $delivery && function_exists( 'ec_users_notification_emails_enabled' ) ) {
+	if ( 'email' === $delivery && extrachill_users_entity_subscription_uses_notification_email_preference( $entity['entity_type'] ) && function_exists( 'ec_users_notification_emails_enabled' ) ) {
 		$ids = array_values( array_filter( $ids, 'ec_users_notification_emails_enabled' ) );
 	}
 

--- a/tests/unit/ArtistEmailConsentAbilitiesTest.php
+++ b/tests/unit/ArtistEmailConsentAbilitiesTest.php
@@ -6,11 +6,7 @@
  */
 
 class Test_Artist_Email_Consent_Abilities extends WP_UnitTestCase {
-	/**
-	 * Artist-site subscriber table used by the fixture.
-	 *
-	 * @var string
-	 */
+	/** @var string */
 	private $table_name;
 
 	protected function setUp(): void {
@@ -19,6 +15,10 @@ class Test_Artist_Email_Consent_Abilities extends WP_UnitTestCase {
 		global $wpdb;
 		$this->table_name = $wpdb->prefix . 'artist_subscribers';
 		add_filter( 'extrachill_users_artist_consent_blog_id', array( $this, 'use_current_blog' ) );
+		add_filter( 'extrachill_users_artist_consent_main_blog_id', array( $this, 'use_current_blog' ) );
+		register_post_type( 'artist_profile', array( 'public' => true ) );
+		register_taxonomy( 'artist', 'post' );
+		extrachill_users_install_entity_subscriptions_table();
 		$this->create_consent_table();
 	}
 
@@ -26,6 +26,9 @@ class Test_Artist_Email_Consent_Abilities extends WP_UnitTestCase {
 		global $wpdb;
 		$wpdb->query( "DROP TABLE IF EXISTS {$this->table_name}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test fixture table uses the trusted WordPress prefix.
 		remove_filter( 'extrachill_users_artist_consent_blog_id', array( $this, 'use_current_blog' ) );
+		remove_filter( 'extrachill_users_artist_consent_main_blog_id', array( $this, 'use_current_blog' ) );
+		unregister_post_type( 'artist_profile' );
+		unregister_taxonomy( 'artist' );
 		wp_set_current_user( 0 );
 
 		parent::tearDown();
@@ -46,135 +49,118 @@ class Test_Artist_Email_Consent_Abilities extends WP_UnitTestCase {
 		$this->assertContains( 'consented_artists', $update->get_input_schema()['required'] );
 	}
 
-	public function test_get_exposes_canonical_consent_field_with_legacy_alias(): void {
-		$user_id = self::factory()->user->create();
+	public function test_update_uses_distinct_canonical_purpose_identity(): void {
+		$artist  = $this->create_bound_artist( 'phish' );
+		$user_id = self::factory()->user->create( array( 'user_email' => 'listener@example.com' ) );
+		wp_set_current_user( $user_id );
+
+		$result = extrachill_users_ability_update_subscriptions( array( 'consented_artists' => array( $artist['profile_id'] ) ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertTrue( extrachill_users_entity_subscription_status( $user_id, 'artist-email-sharing', 'artist', 'phish' )['subscribed'] );
+		$this->assertFalse( extrachill_users_entity_subscription_status( $user_id, 'artist', 'artist', 'phish' )['subscribed'] );
+		$this->assertSame( 0, (int) $GLOBALS['wpdb']->get_var( "SELECT COUNT(*) FROM {$this->table_name}" ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test fixture table uses the trusted WordPress prefix.
+	}
+
+	public function test_get_enriches_canonical_rows_with_legacy_response_alias(): void {
+		$artist  = $this->create_bound_artist( 'susto' );
+		$user_id = self::factory()->user->create( array( 'user_email' => 'listener@example.com' ) );
+		extrachill_users_subscribe_to_entity( $user_id, 'artist-email-sharing', 'artist', 'susto' );
 		wp_set_current_user( $user_id );
 
 		$result = extrachill_users_ability_get_subscriptions();
 
-		$this->assertIsArray( $result );
 		$this->assertSame( $user_id, $result['user_id'] );
-		$this->assertArrayHasKey( 'artist_email_consents', $result );
-		$this->assertArrayHasKey( 'followed_artists', $result );
+		$this->assertSame( $artist['profile_id'], $result['artist_email_consents'][0]['artist_id'] );
 		$this->assertSame( $result['artist_email_consents'], $result['followed_artists'] );
-		$this->assertArrayNotHasKey( 'subscriber_count', $result );
 	}
 
-	public function test_multiple_users_can_share_email_with_the_same_artist(): void {
-		$first_user_id = self::factory()->user->create(
-			array(
-				'user_login' => 'first-consent-user',
-				'user_email' => 'first-consent@example.com',
-			)
-		);
-		$second_user_id = self::factory()->user->create(
-			array(
-				'user_login' => 'second-consent-user',
-				'user_email' => 'second-consent@example.com',
-			)
-		);
+	public function test_notification_email_preference_does_not_change_email_sharing_consent(): void {
+		$user_id = self::factory()->user->create( array( 'user_email' => 'current@example.com' ) );
+		extrachill_users_subscribe_to_entity( $user_id, 'artist-email-sharing', 'artist', 'futurebirds' );
+		ec_users_set_notification_emails_disabled( $user_id, true );
 
-		wp_set_current_user( $first_user_id );
-		$first_result = extrachill_users_ability_update_subscriptions(
-			array( 'consented_artists' => array( 42, 42 ) )
-		);
+		add_filter( 'extrachill_users_entity_subscription_producer_authorized', '__return_true' );
+		try {
+			$recipient_ids = extrachill_users_entity_subscription_recipients( 'artist-export', 'artist-email-sharing', 'artist', 'futurebirds', 'email' );
+		} finally {
+			remove_filter( 'extrachill_users_entity_subscription_producer_authorized', '__return_true' );
+		}
 
-		wp_set_current_user( $second_user_id );
-		$second_result = extrachill_users_ability_update_subscriptions(
-			array( 'consented_artists' => array( 42 ) )
-		);
-
-		$this->assertIsArray( $first_result );
-		$this->assertIsArray( $second_result );
-
-		global $wpdb;
-		$rows = $wpdb->get_results(
-			"SELECT user_id, artist_profile_id, subscriber_email, username, source FROM {$this->table_name} ORDER BY user_id ASC", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test fixture table uses the trusted WordPress prefix.
-			ARRAY_A
-		);
-
-		$this->assertCount( 2, $rows );
-		$this->assertSame( array( 42, 42 ), array_map( 'intval', array_column( $rows, 'artist_profile_id' ) ) );
-		$this->assertSame( array( 'first-consent@example.com', 'second-consent@example.com' ), array_column( $rows, 'subscriber_email' ) );
-		$this->assertSame( array( 'first-consent-user', 'second-consent-user' ), array_column( $rows, 'username' ) );
-		$this->assertSame( array( 'platform_follow_consent', 'platform_follow_consent' ), array_column( $rows, 'source' ) );
-
-		wp_set_current_user( $first_user_id );
-		$preferences = extrachill_users_ability_get_subscriptions();
-		$this->assertCount( 1, $preferences['artist_email_consents'] );
-		$this->assertSame( 42, $preferences['artist_email_consents'][0]['artist_id'] );
+		$this->assertSame( array( $user_id ), $recipient_ids );
+		$this->assertSame( 'current@example.com', get_userdata( $recipient_ids[0] )->user_email );
+		$this->assertTrue( extrachill_users_entity_subscription_status( $user_id, 'artist-email-sharing', 'artist', 'futurebirds' )['subscribed'] );
 	}
 
-	public function test_unrelated_artist_subscription_rows_are_preserved(): void {
+	public function test_migration_is_dry_run_safe_idempotent_and_preserves_direct_rows(): void {
+		$artist  = $this->create_bound_artist( 'kid-lake' );
 		$user_id = self::factory()->user->create(
 			array(
-				'user_login' => 'mixed-subscription-user',
-				'user_email' => 'mixed-subscription@example.com',
+				'user_login' => 'legacy-listener',
+				'user_email' => 'legacy@example.com',
 			)
 		);
+		$this->insert_legacy_row( $user_id, $artist['profile_id'], 'platform_follow_consent', 'legacy@example.com' );
+		$this->insert_legacy_row( 0, $artist['profile_id'], 'artist_subscribe_form', 'direct@example.com' );
 
-		global $wpdb;
-		$wpdb->insert(
-			$this->table_name,
-			array(
-				'user_id'           => $user_id,
-				'artist_profile_id' => 42,
-				'subscriber_email'  => 'mixed-subscription@example.com',
-				'username'          => 'mixed-subscription-user',
-				'source'            => 'artist_subscribe_form',
-				'subscribed_at'     => current_time( 'mysql' ),
-			),
-			array( '%d', '%d', '%s', '%s', '%s', '%s' )
-		);
+		$dry_run = extrachill_users_migrate_artist_email_sharing_consent();
+		$this->assertSame( 1, $dry_run['totals']['ready'] );
+		$this->assertSame( 2, (int) $GLOBALS['wpdb']->get_var( "SELECT COUNT(*) FROM {$this->table_name}" ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test fixture table uses the trusted WordPress prefix.
+		$this->assertFalse( extrachill_users_entity_subscription_status( $user_id, 'artist-email-sharing', 'artist', 'kid-lake' )['subscribed'] );
 
-		wp_set_current_user( $user_id );
-		$result = extrachill_users_ability_update_subscriptions( array( 'consented_artists' => array() ) );
+		$applied = extrachill_users_migrate_artist_email_sharing_consent( true );
+		$this->assertSame( 1, $applied['totals']['migrated'] );
+		$this->assertTrue( extrachill_users_entity_subscription_status( $user_id, 'artist-email-sharing', 'artist', 'kid-lake' )['subscribed'] );
+		$this->assertSame( 1, (int) $GLOBALS['wpdb']->get_var( "SELECT COUNT(*) FROM {$this->table_name} WHERE source = 'artist_subscribe_form'" ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test fixture table uses the trusted WordPress prefix.
 
-		$this->assertIsArray( $result );
-		$this->assertSame( 1, (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$this->table_name} WHERE source = 'artist_subscribe_form'" ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test fixture table uses the trusted WordPress prefix.
-	}
-
-	public function test_insert_failure_is_returned_instead_of_reporting_success(): void {
-		$user_id = self::factory()->user->create(
-			array(
-				'user_email' => 'failed-consent@example.com',
-			)
-		);
-
-		global $wpdb;
-		$wpdb->insert(
-			$this->table_name,
-			array(
-				'user_id'           => $user_id,
-				'artist_profile_id' => 42,
-				'subscriber_email'  => 'failed-consent@example.com',
-				'username'          => 'existing-form-subscriber',
-				'source'            => 'artist_subscribe_form',
-				'subscribed_at'     => current_time( 'mysql' ),
-			),
-			array( '%d', '%d', '%s', '%s', '%s', '%s' )
-		);
-		wp_set_current_user( $user_id );
-
-		$result = extrachill_users_ability_update_subscriptions( array( 'consented_artists' => array( 42 ) ) );
-
-		$this->assertWPError( $result );
-		$this->assertSame( 'artist_email_consent_insert_failed', $result->get_error_code() );
-		$this->assertSame( 500, $result->get_error_data()['status'] );
+		$rerun = extrachill_users_migrate_artist_email_sharing_consent( true );
+		$this->assertSame( 0, $rerun['totals']['candidates'] );
 	}
 
 	public function test_account_without_email_cannot_grant_artist_email_access(): void {
-		$user_id = self::factory()->user->create(
-			array(
-				'user_email' => '',
-			)
-		);
+		$artist  = $this->create_bound_artist( 'empty-email-artist' );
+		$user_id = self::factory()->user->create( array( 'user_email' => '' ) );
 		wp_set_current_user( $user_id );
 
-		$result = extrachill_users_ability_update_subscriptions( array( 'consented_artists' => array( 42 ) ) );
+		$result = extrachill_users_ability_update_subscriptions( array( 'consented_artists' => array( $artist['profile_id'] ) ) );
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'user_email_missing', $result->get_error_code() );
+	}
+
+	private function create_bound_artist( string $slug ): array {
+		$term       = wp_insert_term( ucwords( str_replace( '-', ' ', $slug ) ), 'artist', array( 'slug' => $slug ) );
+		$profile_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'artist_profile',
+				'post_status' => 'publish',
+				'post_name'   => $slug,
+				'post_title'  => ucwords( str_replace( '-', ' ', $slug ) ),
+			)
+		);
+		update_post_meta( $profile_id, '_artist_term_id', $term['term_id'] );
+		update_term_meta( $term['term_id'], '_artist_profile_id', $profile_id );
+
+		return array(
+			'profile_id' => $profile_id,
+			'term_id'    => $term['term_id'],
+		);
+	}
+
+	private function insert_legacy_row( int $user_id, int $artist_id, string $source, string $email ): void {
+		global $wpdb;
+		$wpdb->insert(
+			$this->table_name,
+			array(
+				'user_id'           => $user_id > 0 ? $user_id : null,
+				'artist_profile_id' => $artist_id,
+				'subscriber_email'  => $email,
+				'username'          => $user_id ? 'legacy-listener' : null,
+				'source'            => $source,
+				'subscribed_at'     => current_time( 'mysql' ),
+			),
+			array( '%d', '%d', '%s', '%s', '%s', '%s' )
+		);
 	}
 
 	private function create_consent_table(): void {

--- a/tests/unit/EntitySubscriptionsTest.php
+++ b/tests/unit/EntitySubscriptionsTest.php
@@ -11,15 +11,26 @@ class Test_Entity_Subscriptions extends WP_UnitTestCase {
 		parent::setUp();
 		extrachill_users_install_entity_subscriptions_table();
 		add_filter( 'extrachill_users_entity_subscription_producer_authorized', array( $this, 'authorize_test_producer' ), 10, 4 );
+		add_filter( 'extrachill_users_entity_subscription_entities', array( $this, 'register_scoped_test_identities' ) );
 	}
 
 	protected function tearDown(): void {
 		remove_filter( 'extrachill_users_entity_subscription_producer_authorized', array( $this, 'authorize_test_producer' ), 10 );
+		remove_filter( 'extrachill_users_entity_subscription_entities', array( $this, 'register_scoped_test_identities' ) );
 		parent::tearDown();
 	}
 
 	public function authorize_test_producer( $authorized, $producer ): bool {
 		return 'test-producer' === $producer;
+	}
+
+	public function register_scoped_test_identities( array $entities ): array {
+		$entities['venue-email-sharing'] = array(
+			'taxonomy'                           => 'venue',
+			'uses_notification_email_preference' => false,
+		);
+
+		return $entities;
 	}
 
 	public function test_subscribe_normalizes_and_deduplicates(): void {
@@ -41,6 +52,7 @@ class Test_Entity_Subscriptions extends WP_UnitTestCase {
 		$this->assertNotNull( $subscribe );
 		$this->assertNotNull( $unsubscribe );
 		$this->assertNotNull( wp_get_ability( 'extrachill/entity-subscription-status' ) );
+		$this->assertNotNull( wp_get_ability( 'extrachill/list-entity-subscriptions' ) );
 		$this->assertNotNull( wp_get_ability( 'extrachill/resolve-entity-subscription-recipients' ) );
 
 		$user_id = self::factory()->user->create();
@@ -55,6 +67,27 @@ class Test_Entity_Subscriptions extends WP_UnitTestCase {
 
 		$this->assertSame( 'bonnaroo', $result['slug'] );
 		$this->assertTrue( $result['subscribed'] );
+	}
+
+	public function test_list_is_self_only_bounded_and_preserves_purpose_identity(): void {
+		$user_id       = self::factory()->user->create();
+		$other_user_id = self::factory()->user->create();
+		extrachill_users_subscribe_to_entity( $user_id, 'venue', 'venue', 'the-royal-american' );
+		extrachill_users_subscribe_to_entity( $user_id, 'venue-email-sharing', 'venue', 'the-royal-american' );
+		extrachill_users_subscribe_to_entity( $other_user_id, 'artist', 'artist', 'phish' );
+		wp_set_current_user( $user_id );
+
+		$result = extrachill_users_ability_list_entity_subscriptions(
+			array(
+				'page'     => 1,
+				'per_page' => 1,
+			)
+		);
+
+		$this->assertSame( 2, $result['total'] );
+		$this->assertSame( 1, $result['per_page'] );
+		$this->assertSame( 2, $result['total_pages'] );
+		$this->assertContains( $result['subscriptions'][0]['entity_type'], array( 'venue', 'venue-email-sharing' ) );
 	}
 
 	public function test_status_and_unsubscribe_are_self_contained(): void {


### PR DESCRIPTION
## Summary
- move authenticated artist email-sharing consent from `artist_subscribers` into the canonical `ec_entity_subscriptions` reverse index
- extend feature-registered entity definitions with purpose-specific notification-email behavior and add bounded self-only subscription listing
- add a dry-run/apply migration that verifies canonical consent before deleting exact authenticated legacy rows

## Canonical identities and purpose separation
- Artist email sharing uses `entity_type=artist-email-sharing`, `taxonomy=artist`, and the canonical artist term slug.
- Venue email sharing uses the parallel feature-owned contract `entity_type=venue-email-sharing`, `taxonomy=venue`, and the canonical venue term slug. Venue features register that mapping when they ship a consumer.
- Existing `artist`, `venue`, `festival`, and `location` identities remain update-subscription purposes. Neither purpose creates, revokes, or implies the other.
- The bounded `extrachill/list-entity-subscriptions` ability returns the exact identity tuple so centralized settings can distinguish these purposes without presentation data.

## Generic-layer purity
- The generic service accepts string mappings as before and optional feature-owned descriptors through `extrachill_users_entity_subscription_entities`.
- Descriptor metadata controls whether the master notification-email preference applies without hard-coding artist, venue, or product names in the generic service.
- Artist profile/term presentation and legacy adaptation remain in the existing artist-specific subscriptions ability, outside the generic persistence/listing service.
- No schema or parallel storage abstraction was added.

## Migration and safety
- `wp extrachill-users migrate-artist-email-consent` is a dry run by default; `--apply` is required to mutate data.
- Only rows with an authenticated `user_id` and exact `source = 'platform_follow_consent'` are candidates.
- Migration requires the stored canonical `_artist_term_id` binding, writes or confirms the canonical purpose row, re-reads it, and only then deletes the exact legacy `subscriber_id`/user/source row.
- Missing users, missing bindings, failed writes, and failed verification retain the legacy row and are reported as unresolved/failed.
- Reruns are idempotent. Rollback before legacy deletion is a no-op; after deletion, the canonical row is the verified source of truth and can be unsubscribed through the normal self-only contract.

## Product-owned direct subscribers
Anonymous and direct artist mailing-list rows remain in `artist_subscribers` because they are email-address records without a canonical authenticated network user identity. Product exports may combine those rows with authorized canonical user IDs at read time, but Users does not copy email addresses into its generic table.

## Authorization and privacy
- Status, subscribe, unsubscribe, and listing resolve only the authenticated user.
- Recipient enumeration remains private, hidden from REST, network-admin gated through the ability, and additionally requires the exact producer authorization filter contract.
- Recipient resolution returns user IDs only. Authorized consuming products resolve each current account email at list/export time.
- Email-sharing identities opt out of the master Extra Chill notification-email filter, so that preference neither grants nor suppresses entity email-sharing consent.

## Tests and verification
- Added coverage for scoped artist/venue purpose identities, update-purpose separation, bounded self-only listing, current-email resolution, notification-email independence, migration dry-run/apply behavior, direct-row preservation, and idempotency.
- `homeboy review lint --changed-only --summary`: passed PHPCS and PHPStan. A final alignment warning was fixed afterward.
- `php -l` on all five changed PHP files: passed.
- `git diff --check`: passed.
- `homeboy review test --skip-lint -- --filter='Test_(Entity_Subscriptions|Artist_Email_Consent_Abilities)'`: runner exited before reporting PHPUnit counts or artifacts due the tracked Homeboy evidence regression Extra-Chill/homeboy#10427; no product-test result was available locally. PR CI should provide the authoritative runtime result.
- `homeboy review audit --changed-since=origin/main --json-summary`: reported one heuristic skeleton-duplication warning comparing the migration to an unrelated avatar helper; no concrete architecture violation was identified.

Closes #300