### PR TITLE
test: restore managed WordPress release harness

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -6,7 +6,19 @@
       "database_type": "mysql",
       "settings": {
         "validation_dependencies": ["data-machine-events"],
+        "wp_codebox_database_service": {
+          "provider": "external",
+          "engine": "mysql",
+          "allowed_hosts": ["127.0.0.1:3306"],
+          "secret_env": {
+            "host": "WP_CODEBOX_DB_HOST",
+            "port": "WP_CODEBOX_DB_PORT",
+            "username": "WP_CODEBOX_DB_USER",
+            "password": "WP_CODEBOX_DB_PASSWORD"
+          }
+        },
         "wp_codebox_multisite": true,
+        "wp_codebox_phpunit_bootstrap_mode": "managed",
         "wordpress_runtime_php_version": "8.4"
       }
     }


### PR DESCRIPTION
## Summary
- select WP Codebox's managed WordPress PHPUnit bootstrap after the legacy project bootstrap was removed
- route the required multisite MySQL suite through the existing external test-database provider contract used by Extra Chill Events
- keep database credentials out of repository configuration by declaring environment-variable references only

## Root Cause
Users declared `database_type=mysql` and multisite mode, but omitted both a managed bootstrap mode and an executable database-service provider. The default provider attempted Docker on a host without Docker, so PHPUnit never started. Bare `composer test` also has no project bootstrap/config because the canonical runtime is WP Codebox-managed.

## Verification
- `npm run test:unit:js -- --runInBand`: 1 suite, 4 tests passed
- managed WP Codebox recipe generation verified with the Users worktree as test root, multisite enabled, managed bootstrap selected, and all validation dependencies mounted
- default Docker failure was retained as evidence: `Managed runtime service failed: wordpress-database`
- external-provider execution currently stops before PHPUnit because Homeboy does not provision `WP_CODEBOX_DB_HOST` into the adapter child; this existing upstream defect remains tracked in Extra-Chill/homeboy#10402

No secret values were printed, committed, or serialized. No release or deployment was performed by this PR.

Closes #305