### PR TITLE
refactor: require idempotent notification receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Extra Chill Users handles everything about user identity across the network:
 - **Profiles** — Avatars, badges, ranks, artist relationships
 - **Onboarding** — Guided first-time user experience
 - **Membership** — Lifetime membership validation (ad-free benefit)
+- **Notifications** — Network-wide idempotent delivery receipts and digest preferences
 
 ## How It Works
 
@@ -33,6 +34,7 @@ Users sign up once and get access to all Extra Chill network sites with a unifie
 | **Avatar System** | Upload and display with bbPress integration |
 | **Badge & Ranks** | Tier system based on community participation |
 | **Membership** | Lifetime membership with ad-free benefit |
+| **Notifications** | Explicit producer/key contracts with per-recipient delivery receipts |
 
 ## Auth Flow
 
@@ -77,3 +79,4 @@ homeboy review build extrachill-users
 
 - [AGENTS.md](AGENTS.md) — Technical reference for contributors
 - [docs/CHANGELOG.md](docs/CHANGELOG.md) — Version history
+- [docs/notifications.md](docs/notifications.md) — Notification producer and receipt contracts

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ The plugin is network-activated across all sites in the Extra Chill Platform net
 - [User Badges](badges.md) - Achievement system and badge management
 - [Online Users](online-users.md) - Real-time presence tracking and statistics
 - [Onboarding System](onboarding.md) - New user setup and welcome flow
+- [Notification Delivery](notifications.md) - Idempotent producer, key, and receipt contracts
 
 ### Administration & Security
 - [Admin Access Control](admin-access.md) - Team members, permissions, and overrides

--- a/docs/entity-subscriptions.md
+++ b/docs/entity-subscriptions.md
@@ -16,6 +16,6 @@ Every input includes `entity_type`, `taxonomy`, and `slug`. The default canonica
 
 ## Producer contract
 
-Main, Wire, Events, and Community producers must register their own stable producer identifier through `extrachill_users_entity_subscription_producer_authorized`. They then call `extrachill_users_entity_subscription_recipients( $producer, $entity_type, $taxonomy, $slug )` and pass the returned IDs to `ec_users_notify()`.
+Main, Wire, Events, and Community producers must register their own stable producer identifier through `extrachill_users_entity_subscription_producer_authorized`. They then call `extrachill_users_entity_subscription_recipients( $producer, $entity_type, $taxonomy, $slug )` and pass the returned IDs to `ec_users_notify_with_receipts()` with that producer identifier and a producer-owned stable idempotency key. Producers must treat `inserted` and `existing` as successful delivery and retry only `failed` recipients with the same key.
 
 Recipient resolution is a private PHP contract, not a REST ability, and only returns unique user IDs. It is denied until the producer authorizes itself through the filter. Producers must not log, render, or count recipients. For normal bell notifications, use the default `notification` delivery; the notification substrate applies the user's digest-email preference when it sends email. Producers that directly deliver email must pass `email`, which excludes users who disabled notification emails.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,22 @@
+# Notification Delivery
+
+`ec_users_notify_with_receipts()` is the only notification insertion API. Every production producer supplies a stable `producer` namespace and a producer-owned `idempotency_key`. The network-wide unique receipt is scoped by producer, key, and recipient.
+
+The result contains one recipient status:
+
+- `inserted`: this call created the notification.
+- `existing`: the same producer/key contract already created it; treat this as successful delivery.
+- `failed`: no verified notification exists for this recipient; apply the producer's retry policy with the same key.
+
+Required payload fields are `actor_id`, `type`, `title`, and `link`; `item_id` is optional. Producers that own email delivery must also set `producer_owns_email` and follow the receipt release contract documented on `ec_users_release_notification_receipt()`.
+
+## Users Producers
+
+| Producer | Idempotency key | Outcome policy |
+|----------|-----------------|----------------|
+| `extrachill-users.concert.show-reminder` | `user:{user}:event:{event}:blog:{blog}` | The scheduled callback accepts inserted/existing and preserves its prior no-retry behavior on failure. |
+| `extrachill-users.concert.milestone` | `user:{user}:count:{count}` | Repeated milestone evaluation converges on one row; the mark operation is not failed by notification failure. |
+| `extrachill-users.artist-dispatch` | `request:{request}:event:{event}` | Inserted/existing finalizes the transition delivery ledger. Failed clears the reservation for retry; ambiguous ledger state still requires reconciliation. |
+| `extrachill-users.publish-notify` | `context:{context}:blog:{blog}:post:{post}` | The post guard records every attempted valid recipient, including failed, preserving the observer's attempt-once/no-storm policy. |
+
+Registered publish-notify contexts and blog IDs are part of the key because post IDs are only unique within a site and independent sources may watch the same post.

--- a/extrachill-users.php
+++ b/extrachill-users.php
@@ -169,7 +169,7 @@ function extrachill_users_init() {
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/import/bootstrap.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/concert-tracking/notifications.php';
 
-	// Network notification substrate: entry point + read/CRUD + back-compat shim.
+	// Network notification substrate: idempotent entry point + read/CRUD.
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/notifications/service.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/notifications/email.php';
 	require_once EXTRACHILL_USERS_PLUGIN_DIR . 'inc/notifications/unsubscribe.php';

--- a/inc/artist-dispatch.php
+++ b/inc/artist-dispatch.php
@@ -428,6 +428,7 @@ function ec_users_has_artist_dispatch_delivery_receipt( $user_id, $channel, $eve
 /**
  * Build the unique user-meta key for one external delivery.
  *
+ * @param int    $user_id    User ID.
  * @param string $channel    Delivery channel.
  * @param string $event_type Lifecycle transition.
  * @param string $request_id Request UUID.
@@ -639,6 +640,11 @@ function ec_users_resolve_artist_dispatch_notification_actor( $actor_id ) {
 }
 
 /**
+ * Stable notification producer for Artist Dispatch lifecycle transitions.
+ */
+const EC_USERS_ARTIST_DISPATCH_NOTIFICATION_PRODUCER = 'extrachill-users.artist-dispatch';
+
+/**
  * Send one transition notification and mark only successful delivery.
  *
  * Must run while holding the user's transition lock.
@@ -675,7 +681,7 @@ function ec_users_maybe_notify_artist_dispatch_transition( $user_id, $event_type
 			: new WP_Error( 'artist_dispatch_notification_marker_failed', __( 'The Artist Dispatch notification delivery marker could not be repaired.', 'extrachill-users' ) );
 	}
 	$notification_actor = ec_users_resolve_artist_dispatch_notification_actor( $actor_id );
-	if ( ! $notification_actor || ! function_exists( 'ec_users_notify' ) ) {
+	if ( ! $notification_actor || ! function_exists( 'ec_users_notify_with_receipts' ) ) {
 		return new WP_Error( 'artist_dispatch_notification_actor_missing', __( 'A valid Artist Dispatch notification actor is unavailable.', 'extrachill-users' ) );
 	}
 
@@ -690,17 +696,20 @@ function ec_users_maybe_notify_artist_dispatch_transition( $user_id, $event_type
 		return new WP_Error( 'artist_dispatch_notification_receipt_failed', __( 'The Artist Dispatch notification delivery receipt could not be reserved.', 'extrachill-users' ) );
 	}
 
-	$inserted = ec_users_notify(
+	$delivery           = ec_users_notify_with_receipts(
 		$user_id,
 		array(
-			'actor_id' => $notification_actor,
-			'type'     => 'artist_dispatch_' . $event_type,
-			'link'     => $link,
-			'title'    => $titles[ $event_type ],
-			'item_id'  => isset( $state['artist_id'] ) ? absint( $state['artist_id'] ) : 0,
+			'actor_id'        => $notification_actor,
+			'type'            => 'artist_dispatch_' . $event_type,
+			'link'            => $link,
+			'title'           => $titles[ $event_type ],
+			'item_id'         => isset( $state['artist_id'] ) ? absint( $state['artist_id'] ) : 0,
+			'producer'        => EC_USERS_ARTIST_DISPATCH_NOTIFICATION_PRODUCER,
+			'idempotency_key' => sprintf( 'request:%s:event:%s', $request_id, $event_type ),
 		)
 	);
-	if ( 1 > $inserted ) {
+	$recipient_delivery = $delivery['recipients'][ $user_id ] ?? array();
+	if ( ! in_array( $recipient_delivery['status'] ?? 'failed', array( 'inserted', 'existing' ), true ) ) {
 		if ( ! ec_users_remove_artist_dispatch_delivery_receipt( $user_id, 'notification', $event_type, $request_id ) ) {
 			return new WP_Error( 'artist_dispatch_notification_reconciliation_required', __( 'Notification delivery failed and its reservation could not be cleared.', 'extrachill-users' ) );
 		}

--- a/inc/concert-tracking/notifications.php
+++ b/inc/concert-tracking/notifications.php
@@ -3,12 +3,12 @@
  * Concert tracking engagement notifications.
  *
  * The first engagement consumers of the network notification substrate
- * (ec_users_notify(), inc/notifications/service.php). Two features, both
+ * (ec_users_notify_with_receipts(), inc/notifications/service.php). Two features, both
  * reacting to the concert-tracking domain hooks fired from service.php:
  *
  *   1. SHOW REMINDERS (scheduled) — when a user marks an UPCOMING show, an
  *      Action Scheduler single action is queued for ~2 days before the event
- *      start. The callback fires ec_users_notify() with a "show_reminder"
+ *      start. The callback creates an idempotent "show_reminder"
  *      in-app notification. Unmarking cancels the pending action. Past/ongoing
  *      marks (including the bulk historical importer) get no reminder, so a
  *      large past-event import never schedules a flood of actions.
@@ -18,7 +18,7 @@
  *      100), fire a "milestone" in-app notification linking to My Shows.
  *
  * This file is the consumer only: it never writes notification storage
- * directly, it always calls ec_users_notify(). It also never touches the
+ * directly, it always calls the notification service. It also never touches the
  * substrate in inc/notifications/* nor the email channel.
  *
  * Parent epic: Extra-Chill/extrachill-community#82.
@@ -45,6 +45,16 @@ const EC_USERS_SHOW_REMINDER_ACTION = 'ec_users_send_show_reminder';
  * the literal, so the staleness logic and the producer can never drift.
  */
 const EC_USERS_SHOW_REMINDER_TYPE = 'show_reminder';
+
+/**
+ * Stable notification producer for scheduled show reminders.
+ */
+const EC_USERS_SHOW_REMINDER_PRODUCER = 'extrachill-users.concert.show-reminder';
+
+/**
+ * Stable notification producer for tracked-show milestones.
+ */
+const EC_USERS_CONCERT_MILESTONE_PRODUCER = 'extrachill-users.concert.milestone';
 
 /**
  * Action Scheduler group for concert reminders (eases bulk inspection/cancel).
@@ -232,7 +242,7 @@ function ec_users_cancel_show_reminder( int $user_id, int $event_id, int $blog_i
  * Action Scheduler callback. Re-validates that the user still has the event
  * marked (they may have unmarked after the action was queued but before a
  * cancellation propagated) and that the event is still upcoming, then enqueues
- * an in-app "show_reminder" notification through ec_users_notify().
+ * an idempotent in-app "show_reminder" notification.
  *
  * @param int $user_id  User ID.
  * @param int $event_id Event post ID.
@@ -247,7 +257,7 @@ function ec_users_deliver_show_reminder( $user_id, $event_id, $blog_id ) {
 		return;
 	}
 
-	if ( ! function_exists( 'ec_users_notify' ) ) {
+	if ( ! function_exists( 'ec_users_notify_with_receipts' ) ) {
 		return;
 	}
 
@@ -269,14 +279,16 @@ function ec_users_deliver_show_reminder( $user_id, $event_id, $blog_id ) {
 
 	$title = ec_users_build_reminder_title( $details );
 
-	ec_users_notify(
+	ec_users_notify_with_receipts(
 		$user_id,
 		array(
-			'actor_id' => $user_id, // System reminder: attribute to the recipient (substrate requires a valid actor).
-			'type'     => EC_USERS_SHOW_REMINDER_TYPE,
-			'title'    => $title,
-			'link'     => $details['permalink'],
-			'item_id'  => $event_id,
+			'actor_id'        => $user_id, // System reminder: attribute to the recipient (substrate requires a valid actor).
+			'type'            => EC_USERS_SHOW_REMINDER_TYPE,
+			'title'           => $title,
+			'link'            => $details['permalink'],
+			'item_id'         => $event_id,
+			'producer'        => EC_USERS_SHOW_REMINDER_PRODUCER,
+			'idempotency_key' => sprintf( 'user:%d:event:%d:blog:%d', $user_id, $event_id, $blog_id ),
 		)
 	);
 }
@@ -345,7 +357,7 @@ function ec_users_maybe_notify_milestone( int $user_id, int $event_id ) {
 		return;
 	}
 
-	if ( ! function_exists( 'ec_users_notify' ) || ! function_exists( 'ec_users_get_user_event_count' ) ) {
+	if ( ! function_exists( 'ec_users_notify_with_receipts' ) || ! function_exists( 'ec_users_get_user_event_count' ) ) {
 		return;
 	}
 
@@ -358,14 +370,16 @@ function ec_users_maybe_notify_milestone( int $user_id, int $event_id ) {
 
 	$link = ec_users_my_shows_url( $user_id );
 
-	ec_users_notify(
+	ec_users_notify_with_receipts(
 		$user_id,
 		array(
-			'actor_id' => $user_id, // Self-milestone: attribute to the recipient.
-			'type'     => 'milestone',
-			'title'    => ec_users_build_milestone_title( $count ),
-			'link'     => $link,
-			'item_id'  => $event_id,
+			'actor_id'        => $user_id, // Self-milestone: attribute to the recipient.
+			'type'            => 'milestone',
+			'title'           => ec_users_build_milestone_title( $count ),
+			'link'            => $link,
+			'item_id'         => $event_id,
+			'producer'        => EC_USERS_CONCERT_MILESTONE_PRODUCER,
+			'idempotency_key' => sprintf( 'user:%d:count:%d', $user_id, $count ),
 		)
 	);
 }

--- a/inc/notifications/publish-notify.php
+++ b/inc/notifications/publish-notify.php
@@ -7,7 +7,7 @@
  * post is published never hears about it. This observer fires the moment a post
  * transitions to `publish` and — if the post was registered as a "notifiable
  * submission" by some feature — enqueues a bell + email notification to the
- * recorded submitter via ec_users_notify().
+ * recorded submitter via an idempotent notification receipt.
  *
  * WHY THIS LIVES IN extrachill-users (and why it is feature-agnostic)
  * ------------------------------------------------------------------
@@ -47,7 +47,7 @@
  *
  * The observer resolves the recipient id, builds the title from the template +
  * the post title, links to the post permalink, sets item_id = post id, and
- * fires ec_users_notify() ONCE per post (a per-post meta guard prevents
+ * requests one notification per post (a per-post meta guard prevents
  * re-fire on later edits or re-publish). The batched email digest
  * (inc/notifications/email.php) then delivers the email arm for free.
  *
@@ -76,6 +76,11 @@ const EC_USERS_PUBLISH_NOTIFY_SOURCES_OPTION = 'ec_users_publish_notify_sources'
  * later re-publish/edit transition for that context.
  */
 const EC_USERS_PUBLISH_NOTIFIED_META_PREFIX = '_ec_users_publish_notified_';
+
+/**
+ * Stable notification producer for every registered publish-notify source.
+ */
+const EC_USERS_PUBLISH_NOTIFY_PRODUCER = 'extrachill-users.publish-notify';
 
 /**
  * Register (or refresh) a publish-notify source descriptor.
@@ -200,7 +205,7 @@ add_action( 'transition_post_status', 'ec_users_publish_notify_on_transition', 1
  *
  * Reads the source's marker meta off the post; if present, resolves the
  * submitter id, builds the notification payload from the descriptor, and fires
- * ec_users_notify() once (guarded by a per-context meta marker).
+ * one idempotent notification (guarded by a per-context meta marker).
  *
  * @since 0.24.0
  *
@@ -249,26 +254,28 @@ function ec_users_publish_notify_apply_source( string $context, array $descripto
 	$title      = sprintf( $title_template, $post_title );
 	$link       = (string) get_permalink( $post );
 
-	$inserted = ec_users_notify(
+	$delivery = ec_users_notify_with_receipts(
 		$user_id,
 		array(
 			// The submitter is both the subject and, for a system-authored
-			// "you're live" notice, the actor — ec_users_notify requires a
+			// "you're live" notice, the actor — the substrate requires a
 			// valid actor_id that resolves to a real user.
-			'actor_id' => $user_id,
-			'type'     => $type,
-			'title'    => $title,
-			'link'     => $link,
-			'item_id'  => (int) $post->ID,
+			'actor_id'        => $user_id,
+			'type'            => $type,
+			'title'           => $title,
+			'link'            => $link,
+			'item_id'         => (int) $post->ID,
+			'producer'        => EC_USERS_PUBLISH_NOTIFY_PRODUCER,
+			'idempotency_key' => sprintf( 'context:%s:blog:%d:post:%d', $context, get_current_blog_id(), $post->ID ),
 		)
 	);
 
-	// Set the guard whenever we attempted a real recipient, so a transient
-	// insert failure does not turn into a notification storm on later edits.
-	// (A single missed notice is preferable to repeated ones.)
+	// All receipt outcomes preserve this observer's attempt-once contract. A
+	// failed insert must not become a notification storm on later edits, while an
+	// existing receipt means a prior attempt already delivered the notification.
 	update_post_meta( $post->ID, $guard_key, current_time( 'mysql', true ) );
 
-	unset( $inserted );
+	unset( $delivery );
 }
 
 /**

--- a/inc/notifications/service.php
+++ b/inc/notifications/service.php
@@ -3,10 +3,9 @@
  * Network notification service.
  *
  * The network-callable SUBSTRATE for notifications. Because extrachill-users is
- * a Network:true plugin, ec_users_notify() is loaded on every site and ANY site
- * (community, events, artist, shop) can call it to enqueue a notification. The
- * back-compat shim keeps the legacy do_action( 'extrachill_notify' ) producers
- * working and now routes them into the table from every site.
+ * a Network:true plugin, ec_users_notify_with_receipts() is loaded on every site
+ * and any site can use an explicit producer and idempotency key to enqueue a
+ * notification safely.
  *
  * All reads/writes target the base_prefix table from inc/notifications/db.php,
  * so no switch_to_blog is needed — it is the same physical table everywhere.
@@ -48,8 +47,8 @@ function ec_users_unread_count_cache_key( int $user_id ): string {
  * Invalidate the cached unread count for one or more users.
  *
  * Called by every writer (insert / mark-read / clear) so the bell badge is
- * never stale. Accepts an array because ec_users_notify() can target multiple
- * recipients in a single call — each recipient's key must be busted.
+ * never stale. Accepts an array because notification producers can target
+ * multiple recipients in a single call — each recipient's key must be busted.
  *
  * @param int|int[] $user_ids Single user ID or array of user IDs.
  */
@@ -100,38 +99,13 @@ add_action( 'init', 'ec_users_maybe_install_notifications_table' );
 // ─── Entry Point ───────────────────────────────────────────────────────────────
 
 /**
- * Create one or more notifications.
- *
- * The single network-wide entry point. Callable from any site. Validates and
- * enriches the payload, then inserts one row per recipient into the base_prefix
- * notification table.
- *
- * @param int|int[] $user_ids Single recipient ID or array of recipient IDs.
- * @param array     $data {
- *     Notification payload.
- *
- *     @type int    $actor_id Required. User ID who triggered the notification.
- *     @type string $type     Required. Type identifier (e.g. 'reply', 'mention').
- *     @type string $link     Required. URL to the notification target.
- *     @type string $title    Required. Human-readable title/subject.
- *     @type int    $item_id  Optional. Related object ID (post/topic/reply/event).
- * }
- * @return int Number of notification rows inserted.
- */
-function ec_users_notify( $user_ids, array $data ): int {
-	$receipt = ec_users_notify_with_receipts( $user_ids, $data );
-
-	return (int) $receipt['inserted'];
-}
-
-/**
  * Create notifications and return a per-recipient delivery receipt.
  *
  * Producers that need retry safety pass both `producer` and `idempotency_key`.
  * Their exact pair is hashed into the compact delivery key protected by the
  * table's unique (user_id, delivery_key) index. Concurrent calls therefore
  * converge on one row per recipient while unrelated producers remain isolated.
- * Omitting both fields retains the historical non-idempotent insert behavior.
+ * Internal and external producers must pass both fields.
  *
  * An idempotent producer that delivers its own email may also pass
  * `producer_owns_email => true`. The insert atomically persists that ownership
@@ -148,11 +122,16 @@ function ec_users_notify( $user_ids, array $data ): int {
  *
  * @param int|int[] $user_ids Single recipient ID or array of recipient IDs.
  * @param array     $data {
- *     Notification payload. See ec_users_notify().
+ *     Notification payload.
  *
- *     @type string $producer        Optional producer namespace. Must be paired
+ *     @type int    $actor_id       Required. User ID who triggered the notification.
+ *     @type string $type           Required. Type identifier (e.g. 'reply', 'mention').
+ *     @type string $link           Required. URL to the notification target.
+ *     @type string $title          Required. Human-readable title/subject.
+ *     @type int    $item_id        Optional. Related object ID (post/topic/reply/event).
+ *     @type string $producer        Required producer namespace. Must be paired
  *                                   with idempotency_key.
- *     @type string $idempotency_key Optional producer-owned replay key. Must be
+ *     @type string $idempotency_key Required producer-owned replay key. Must be
  *                                   paired with producer.
  *     @type bool   $producer_owns_email Optional. When true, the producer owns
  *                                       email delivery for this receipt. Requires
@@ -180,14 +159,7 @@ function ec_users_notify_with_receipts( $user_ids, array $data ): array {
 	$actor_id = isset( $data['actor_id'] ) ? (int) $data['actor_id'] : 0;
 	$type     = isset( $data['type'] ) ? sanitize_key( $data['type'] ) : '';
 	$link     = isset( $data['link'] ) ? esc_url_raw( (string) $data['link'] ) : '';
-	$title    = isset( $data['title'] ) ? (string) $data['title'] : '';
-
-	// Back-compat: the legacy payload used 'topic_title' for the title field.
-	if ( '' === $title && ! empty( $data['topic_title'] ) ) {
-		$title = (string) $data['topic_title'];
-	}
-
-	$title = sanitize_text_field( $title );
+	$title    = isset( $data['title'] ) ? sanitize_text_field( (string) $data['title'] ) : '';
 
 	$producer        = isset( $data['producer'] ) ? strtolower( trim( (string) $data['producer'] ) ) : '';
 	$idempotency_key = isset( $data['idempotency_key'] ) ? trim( (string) $data['idempotency_key'] ) : '';
@@ -208,6 +180,8 @@ function ec_users_notify_with_receipts( $user_ids, array $data ): array {
 		$payload_error = 'invalid_idempotency_key';
 	} elseif ( $owns_email && ( ! $has_producer || ! $has_key ) ) {
 		$payload_error = 'email_ownership_requires_idempotency';
+	} elseif ( ! $has_producer ) {
+		$payload_error = 'incomplete_idempotency';
 	}
 
 	if ( null !== $payload_error ) {
@@ -220,10 +194,6 @@ function ec_users_notify_with_receipts( $user_ids, array $data ): array {
 	}
 
 	$item_id = isset( $data['item_id'] ) ? (int) $data['item_id'] : 0;
-	if ( $item_id <= 0 && ! empty( $data['post_id'] ) ) {
-		// Back-compat: legacy callers passed the related object as 'post_id'.
-		$item_id = (int) $data['post_id'];
-	}
 
 	$table        = extrachill_users_notifications_table_name();
 	$created_at   = current_time( 'mysql', true );
@@ -237,40 +207,23 @@ function ec_users_notify_with_receipts( $user_ids, array $data ): array {
 			continue;
 		}
 
-		if ( $has_producer ) {
-			$result = $wpdb->query(
-				$wpdb->prepare(
-					"INSERT IGNORE INTO {$table} (user_id, actor_id, type, title, link, item_id, is_read, created_at, emailed_at, producer_owns_email, producer, idempotency_key, delivery_key) VALUES (%d, %d, %s, %s, %s, NULLIF(%d, 0), 0, %s, NULLIF(%s, ''), %d, %s, %s, %s)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
-					$user_id,
-					$actor_id,
-					$type,
-					$title,
-					$link,
-					$item_id,
-					$created_at,
-					$owns_email ? $created_at : '',
-					(int) $owns_email,
-					$producer,
-					$idempotency_key,
-					$delivery_key
-				)
-			);
-		} else {
-			$result = $wpdb->insert(
-				$table,
-				array(
-					'user_id'    => $user_id,
-					'actor_id'   => $actor_id,
-					'type'       => $type,
-					'title'      => $title,
-					'link'       => $link,
-					'item_id'    => $item_id > 0 ? $item_id : null,
-					'is_read'    => 0,
-					'created_at' => $created_at,
-				),
-				array( '%d', '%d', '%s', '%s', '%s', $item_id > 0 ? '%d' : null, '%d', '%s' )
-			);
-		}
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"INSERT IGNORE INTO {$table} (user_id, actor_id, type, title, link, item_id, is_read, created_at, emailed_at, producer_owns_email, producer, idempotency_key, delivery_key) VALUES (%d, %d, %s, %s, %s, NULLIF(%d, 0), 0, %s, NULLIF(%s, ''), %d, %s, %s, %s)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+				$user_id,
+				$actor_id,
+				$type,
+				$title,
+				$link,
+				$item_id,
+				$created_at,
+				$owns_email ? $created_at : '',
+				(int) $owns_email,
+				$producer,
+				$idempotency_key,
+				$delivery_key
+			)
+		);
 
 		if ( false === $result ) {
 			$receipt['recipients'][ $user_id ] = ec_users_notification_failed_receipt( $user_id, 'insert_failed' );
@@ -281,7 +234,7 @@ function ec_users_notify_with_receipts( $user_ids, array $data ): array {
 		$notification_id = (int) $wpdb->insert_id;
 		$status          = 'inserted';
 
-		if ( $has_producer && 1 !== (int) $result ) {
+		if ( 1 !== (int) $result ) {
 			$existing = $wpdb->get_row(
 				$wpdb->prepare(
 					"SELECT id, producer, idempotency_key, producer_owns_email FROM {$table} WHERE user_id = %d AND delivery_key = %s LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
@@ -717,26 +670,3 @@ function ec_users_clear_notifications( int $user_id, bool $all = false ): int {
 
 	return false === $removed ? 0 : (int) $removed;
 }
-
-// ─── Back-Compat Shim ──────────────────────────────────────────────────────────
-
-/**
- * Forward the legacy extrachill_notify action into the new substrate.
- *
- * Registered network-wide so the existing community producers (forum replies +
- * mentions) keep working AND now write into the table from every site. The
- * community plugin only FIRES do_action( 'extrachill_notify' ) — it does not
- * register a competing handler — so this substrate handler is the sole consumer
- * of the action and there is no double-write.
- *
- * @param int|int[] $user_ids Recipient ID(s).
- * @param mixed     $data     Notification payload (legacy shape supported).
- */
-function ec_users_handle_notify_action( $user_ids, $data ) {
-	if ( ! is_array( $data ) ) {
-		return;
-	}
-
-	ec_users_notify( $user_ids, $data );
-}
-add_action( 'extrachill_notify', 'ec_users_handle_notify_action', 10, 2 );

--- a/tests/unit/ArtistDispatchAccessTest.php
+++ b/tests/unit/ArtistDispatchAccessTest.php
@@ -621,10 +621,22 @@ class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
 		$repaired = ec_users_maybe_notify_artist_dispatch_transition( $recipient, 'approved', 0, $without_marker );
 		$this->assertNotWPError( $repaired );
 		$this->assertNotEmpty( $repaired['deliveries']['notifications']['approved'] );
+		$without_any_marker = $repaired;
+		unset( $without_any_marker['deliveries']['notifications']['approved'] );
+		$this->assertNotFalse( update_user_meta( $recipient, EC_USERS_ARTIST_DISPATCH_STATE_META, $without_any_marker, $repaired ) );
+		$this->assertTrue( ec_users_remove_artist_dispatch_delivery_receipt( $recipient, 'notification', 'approved', $state['request_id'] ) );
+		$reconciled = ec_users_maybe_notify_artist_dispatch_transition( $recipient, 'approved', 0, $without_any_marker );
+		$this->assertNotWPError( $reconciled );
+		$this->assertNotEmpty( $reconciled['deliveries']['notifications']['approved'] );
 		ec_users_release_artist_dispatch_lock( $recipient, $lock );
 		$notifications = ec_users_get_notifications( $recipient );
 		$this->assertSame( 1, $notifications['total'] );
 		$this->assertSame( $bot_id, $notifications['notifications'][0]['actor_id'] );
+		global $wpdb;
+		$table = extrachill_users_notifications_table_name();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT producer, idempotency_key FROM {$table} WHERE user_id = %d", $recipient ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+		$this->assertSame( EC_USERS_ARTIST_DISPATCH_NOTIFICATION_PRODUCER, $row['producer'] );
+		$this->assertSame( sprintf( 'request:%s:event:approved', $state['request_id'] ), $row['idempotency_key'] );
 		remove_filter( 'extrachill_network_bot_user_id', $filter );
 	}
 
@@ -644,6 +656,43 @@ class Test_Artist_Dispatch_Access extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'deliveries', ec_users_get_artist_dispatch_state( $recipient ) );
 		ec_users_release_artist_dispatch_lock( $recipient, $lock );
 		remove_filter( 'extrachill_network_bot_user_id', $no_bot );
+	}
+
+	public function test_failed_notification_receipt_clears_reservation_for_retry(): void {
+		global $wpdb;
+
+		$bot_id    = self::factory()->user->create();
+		$recipient = self::factory()->user->create();
+		$state     = array(
+			'status'     => 'approved',
+			'request_id' => wp_generate_uuid4(),
+		);
+		$this->assertTrue( ec_users_write_artist_dispatch_state( $recipient, $state, array() ) );
+		$bot_filter = static fn() => $bot_id;
+		$table      = extrachill_users_notifications_table_name();
+		$fail_write = static function ( $query ) use ( $table ) {
+			return false !== strpos( $query, "INSERT IGNORE INTO {$table}" )
+				? 'INSERT INTO ec_missing_notification_table (id) VALUES (1)'
+				: $query;
+		};
+		add_filter( 'extrachill_network_bot_user_id', $bot_filter );
+		add_filter( 'query', $fail_write );
+		$previous_suppress = $wpdb->suppress_errors( true );
+		$lock              = ec_users_acquire_artist_dispatch_lock( $recipient, $state['request_id'] );
+		$this->assertNotWPError( $lock );
+		try {
+			$result = ec_users_maybe_notify_artist_dispatch_transition( $recipient, 'approved', 0, $state );
+		} finally {
+			ec_users_release_artist_dispatch_lock( $recipient, $lock );
+			$wpdb->suppress_errors( $previous_suppress );
+			remove_filter( 'query', $fail_write );
+			remove_filter( 'extrachill_network_bot_user_id', $bot_filter );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'artist_dispatch_notification_failed', $result->get_error_code() );
+		$this->assertEmpty( ec_users_get_artist_dispatch_delivery_receipt( $recipient, 'notification', 'approved', $state['request_id'] ) );
+		$this->assertArrayNotHasKey( 'deliveries', ec_users_get_artist_dispatch_state( $recipient ) );
 	}
 
 	public function test_revocation_removes_only_product_grant_and_cleans_grant_created_membership(): void {

--- a/tests/unit/NotificationDeliveryReceiptsTest.php
+++ b/tests/unit/NotificationDeliveryReceiptsTest.php
@@ -94,24 +94,16 @@ class Test_Notification_Delivery_Receipts extends WP_UnitTestCase {
 		$this->assertSame( 0, ec_users_get_unread_count( $recipient ) );
 	}
 
-	public function test_legacy_api_remains_non_idempotent_and_returns_count(): void {
+	public function test_missing_producer_contract_is_rejected(): void {
 		$actor     = self::factory()->user->create();
 		$recipient = self::factory()->user->create();
 		$payload   = $this->payload( $actor );
 		unset( $payload['producer'], $payload['idempotency_key'] );
 
-		$this->assertSame( 1, ec_users_notify( $recipient, $payload ) );
-		$this->assertSame( 1, ec_users_notify( $recipient, $payload ) );
-		$this->assertSame( 2, ec_users_get_unread_count( $recipient ) );
-	}
+		$receipt = ec_users_notify_with_receipts( $recipient, $payload );
 
-	public function test_legacy_count_wrapper_supports_idempotent_payloads(): void {
-		$actor     = self::factory()->user->create();
-		$recipient = self::factory()->user->create();
-		$payload   = $this->payload( $actor );
-
-		$this->assertSame( 1, ec_users_notify( $recipient, $payload ) );
-		$this->assertSame( 0, ec_users_notify( $recipient, $payload ) );
+		$this->assertSame( 'incomplete_idempotency', $receipt['recipients'][ $recipient ]['error'] );
+		$this->assertSame( 0, ec_users_get_unread_count( $recipient ) );
 	}
 
 	public function test_replay_is_network_wide_across_blog_contexts(): void {

--- a/tests/unit/NotificationProducerContractsTest.php
+++ b/tests/unit/NotificationProducerContractsTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Tests for Users-owned notification producer contracts.
+ *
+ * @package ExtraChill\Users
+ */
+
+/**
+ * Verifies stable contracts for every Users-owned notification producer.
+ */
+class Test_Notification_Producer_Contracts extends WP_UnitTestCase {
+
+	/**
+	 * Events site fixture ID.
+	 *
+	 * @var int
+	 */
+	private int $events_blog_id;
+
+	/**
+	 * Event fixture ID.
+	 *
+	 * @var int
+	 */
+	private int $event_id;
+
+	/**
+	 * Recipient fixture ID.
+	 *
+	 * @var int
+	 */
+	private int $user_id;
+
+	/**
+	 * Creates notification, attendance, and event fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		global $wpdb;
+
+		$this->events_blog_id = self::factory()->blog->create();
+		$this->user_id        = self::factory()->user->create();
+
+		extrachill_users_install_notifications_table();
+		extrachill_users_install_concert_tracking_table();
+		$wpdb->query( 'DELETE FROM ' . extrachill_users_notifications_table_name() ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- test table from trusted helper.
+		$wpdb->query( 'DELETE FROM ' . extrachill_users_concert_tracking_table_name() ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- test table from trusted helper.
+
+		switch_to_blog( $this->events_blog_id );
+		try {
+			if ( ! post_type_exists( 'data_machine_events' ) ) {
+				register_post_type( 'data_machine_events', array( 'public' => true ) );
+			}
+			$this->event_id = self::factory()->post->create(
+				array(
+					'post_type'   => 'data_machine_events',
+					'post_status' => 'publish',
+					'post_title'  => 'Producer Contract Show',
+				)
+			);
+
+			\DataMachineEvents\Core\EventDatesTable::create_table();
+			\DataMachineEvents\Core\EventDatesTable::upsert(
+				$this->event_id,
+				wp_date( 'Y-m-d H:i:s', time() + ( 5 * DAY_IN_SECONDS ) ),
+				null,
+				'publish'
+			);
+		} finally {
+			restore_current_blog();
+		}
+
+		$wpdb->insert(
+			extrachill_users_concert_tracking_table_name(),
+			array(
+				'user_id'    => $this->user_id,
+				'event_id'   => $this->event_id,
+				'blog_id'    => $this->events_blog_id,
+				'created_at' => current_time( 'mysql', true ),
+			),
+			array( '%d', '%d', '%d', '%s' )
+		);
+	}
+
+	/**
+	 * A retried reminder converges on its user/event/blog receipt.
+	 */
+	public function test_show_reminder_replay_uses_user_event_blog_contract(): void {
+		ec_users_deliver_show_reminder( $this->user_id, $this->event_id, $this->events_blog_id );
+		ec_users_deliver_show_reminder( $this->user_id, $this->event_id, $this->events_blog_id );
+
+		$row = $this->notification_row( EC_USERS_SHOW_REMINDER_TYPE );
+
+		$this->assertSame( EC_USERS_SHOW_REMINDER_PRODUCER, $row['producer'] );
+		$this->assertSame( sprintf( 'user:%d:event:%d:blog:%d', $this->user_id, $this->event_id, $this->events_blog_id ), $row['idempotency_key'] );
+		$this->assertSame( 1, $this->notification_count( EC_USERS_SHOW_REMINDER_TYPE ) );
+	}
+
+	/**
+	 * A repeated milestone converges on its user/count receipt.
+	 */
+	public function test_milestone_replay_uses_user_count_contract(): void {
+		ec_users_maybe_notify_milestone( $this->user_id, $this->event_id );
+		ec_users_maybe_notify_milestone( $this->user_id, $this->event_id );
+
+		$row = $this->notification_row( 'milestone' );
+
+		$this->assertSame( EC_USERS_CONCERT_MILESTONE_PRODUCER, $row['producer'] );
+		$this->assertSame( sprintf( 'user:%d:count:1', $this->user_id ), $row['idempotency_key'] );
+		$this->assertSame( 1, $this->notification_count( 'milestone' ) );
+	}
+
+	/**
+	 * A registered source uses context, blog, and post identity.
+	 */
+	public function test_publish_source_replay_uses_context_blog_post_contract(): void {
+		$post = self::factory()->post->create_and_get( array( 'post_title' => 'Published Contract' ) );
+		update_post_meta( $post->ID, '_producer_contract_submitter', $this->user_id );
+		$descriptor = array(
+			'meta_key'       => '_producer_contract_submitter',
+			'type'           => 'producer_contract_published',
+			'title_template' => 'Published: %s',
+		);
+
+		ec_users_publish_notify_apply_source( 'producer-contract', $descriptor, $post );
+		delete_post_meta( $post->ID, EC_USERS_PUBLISH_NOTIFIED_META_PREFIX . 'producer-contract' );
+		ec_users_publish_notify_apply_source( 'producer-contract', $descriptor, $post );
+
+		$row = $this->notification_row( 'producer_contract_published' );
+
+		$this->assertSame( EC_USERS_PUBLISH_NOTIFY_PRODUCER, $row['producer'] );
+		$this->assertSame( sprintf( 'context:producer-contract:blog:%d:post:%d', get_current_blog_id(), $post->ID ), $row['idempotency_key'] );
+		$this->assertSame( 1, $this->notification_count( 'producer_contract_published' ) );
+	}
+
+	/**
+	 * Failed publish delivery retains the source's attempt-once guard.
+	 */
+	public function test_publish_source_preserves_attempt_guard_after_failed_receipt(): void {
+		$post = self::factory()->post->create_and_get( array( 'post_title' => 'Failed Contract' ) );
+		update_post_meta( $post->ID, '_failed_contract_submitter', 999999999 );
+
+		ec_users_publish_notify_apply_source(
+			'failed-contract',
+			array(
+				'meta_key'       => '_failed_contract_submitter',
+				'type'           => 'failed_contract_published',
+				'title_template' => 'Published: %s',
+			),
+			$post
+		);
+
+		$this->assertNotEmpty( get_post_meta( $post->ID, EC_USERS_PUBLISH_NOTIFIED_META_PREFIX . 'failed-contract', true ) );
+		$this->assertSame( 0, $this->notification_count( 'failed_contract_published' ) );
+	}
+
+	/**
+	 * Fetch one notification contract row.
+	 *
+	 * @param string $type Notification type.
+	 * @return array<string, string>
+	 */
+	private function notification_row( string $type ): array {
+		global $wpdb;
+
+		$table = extrachill_users_notifications_table_name();
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT producer, idempotency_key FROM {$table} WHERE user_id = %d AND type = %s", $this->user_id, $type ), ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+
+		$this->assertIsArray( $row );
+		return $row;
+	}
+
+	/**
+	 * Count recipient notifications of one type.
+	 *
+	 * @param string $type Notification type.
+	 */
+	private function notification_count( string $type ): int {
+		global $wpdb;
+
+		$table = extrachill_users_notifications_table_name();
+		return (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE user_id = %d AND type = %s", $this->user_id, $type ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from trusted helper.
+	}
+}


### PR DESCRIPTION
## Summary
- migrate every Users-owned producer to explicit producer/idempotency contracts
- remove `ec_users_notify()`, the `extrachill_notify` action bridge, and legacy payload aliases
- require canonical receipt delivery and document every Users-owned replay key

## Breaking rollout constraint
Do not merge/release/deploy this PR until Community, Events, News Wire, and Blog consumer migrations are deployed. Removing the wrapper first would break those producers.

Persisted notification migrations and the old cron cleanup remain because shipped state still depends on them; this removes only obsolete write-time compatibility.

## Verification
- changed PHP syntax passed
- targeted production PHPCS: zero errors (existing database warnings only)
- `git diff --check` passed
- organization-wide migration worktrees have zero exact legacy function/action references
- managed PHPUnit is currently blocked before bootstrap by missing Codebox DB credentials

Closes #309