### PR TITLE
fix: clear publish notification lint blockers

### DIFF
--- a/inc/notifications/publish-notify.php
+++ b/inc/notifications/publish-notify.php
@@ -186,7 +186,7 @@ function ec_users_publish_notify_on_transition( string $new_status, string $old_
 	}
 
 	// Skip auto-drafts / revisions and anything that is not a real post row.
-	if ( 'auto-draft' === $post->post_status && '' === $post->post_title ) {
+	if ( 'auto-draft' === get_post_status( $post ) && '' === $post->post_title ) {
 		return;
 	}
 
@@ -253,7 +253,7 @@ function ec_users_publish_notify_apply_source( string $context, array $descripto
 
 	$post_title = get_the_title( $post );
 	$title      = sprintf( $title_template, $post_title );
-	$link       = (string) get_permalink( $post );
+	$link       = (string) get_permalink( $post->ID );
 	$producer   = EC_USERS_PUBLISH_NOTIFY_PRODUCER;
 	$key        = sprintf( 'context:%s:blog:%d:post:%d', $context, get_current_blog_id(), $post->ID );
 

--- a/tests/unit/NotificationProducerContractsTest.php
+++ b/tests/unit/NotificationProducerContractsTest.php
@@ -112,6 +112,23 @@ class Test_Notification_Producer_Contracts extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Empty auto-drafts never enter the publish-notification producer loop.
+	 */
+	public function test_publish_observer_ignores_empty_auto_drafts(): void {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_status' => 'auto-draft',
+				'post_title'  => '',
+			)
+		);
+
+		ec_users_publish_notify_on_transition( 'publish', 'auto-draft', $post );
+
+		$this->assertSame( 'auto-draft', get_post_status( $post ) );
+		$this->assertSame( 0, $this->notification_count( 'producer_contract_published' ) );
+	}
+
+	/**
 	 * A registered source uses context, blog, and post identity.
 	 */
 	public function test_publish_source_replay_uses_context_blog_post_contract(): void {


### PR DESCRIPTION
## Summary
- use `get_post_status()` for the configured WordPress stub contract
- pass the integer post ID to `get_permalink()`

## Verification
- focused PHPStan: no errors
- PHP syntax: clean
- `git diff --check`

Closes #314