### PR TITLE
refactor: require registered subscription identities

### DIFF
--- a/docs/entity-subscriptions.md
+++ b/docs/entity-subscriptions.md
@@ -1,6 +1,6 @@
 # Entity Subscriptions
 
-Entity subscriptions are private, network-wide update preferences for canonical `festival`, `artist`, `venue`, and `location` taxonomies. They are not followers, newsletter lists, artist-email consent, or bbPress topic subscriptions. The system never returns subscriber counts.
+Entity subscriptions are private, network-wide preferences for purpose-specific identities registered by feature plugins. The generic layer defines no entity identities and never returns subscriber counts.
 
 ## Consumer abilities
 
@@ -12,10 +12,10 @@ Authenticated users manage only their own records through:
 
 `extrachill/resolve-entity-subscription-recipients` is a non-REST ability restricted to network administrators. Runtime producers use the private PHP contract below instead.
 
-Every input includes `entity_type`, `taxonomy`, and `slug`. The default canonical pairs are `festival/festival`, `artist/artist`, `venue/venue`, and `location/location`.
+Every input includes `entity_type`, `taxonomy`, and `slug`. A feature must register its bounded identity through `extrachill_users_entity_subscription_entities`; unregistered identities fail closed.
 
 ## Producer contract
 
-Main, Wire, Events, and Community producers must register their own stable producer identifier through `extrachill_users_entity_subscription_producer_authorized`. They then call `extrachill_users_entity_subscription_recipients( $producer, $entity_type, $taxonomy, $slug )` and pass the returned IDs to `ec_users_notify_with_receipts()` with that producer identifier and a producer-owned stable idempotency key. Producers must treat `inserted` and `existing` as successful delivery and retry only `failed` recipients with the same key.
+Feature-owned producers must register their own stable producer identifier through `extrachill_users_entity_subscription_producer_authorized`. They then call `extrachill_users_entity_subscription_recipients( $producer, $entity_type, $taxonomy, $slug )` and pass the returned IDs to `ec_users_notify_with_receipts()` with that producer identifier and a producer-owned stable idempotency key. Producers must treat `inserted` and `existing` as successful delivery and retry only `failed` recipients with the same key.
 
 Recipient resolution is a private PHP contract, not a REST ability, and only returns unique user IDs. It is denied until the producer authorizes itself through the filter. Producers must not log, render, or count recipients. For normal bell notifications, use the default `notification` delivery; the notification substrate applies the user's digest-email preference when it sends email. Producers that directly deliver email must pass `email`, which excludes users who disabled notification emails.

--- a/inc/entity-subscriptions/service.php
+++ b/inc/entity-subscriptions/service.php
@@ -28,8 +28,8 @@ add_action( 'init', 'extrachill_users_maybe_install_entity_subscriptions_table' 
 /**
  * Normalize and validate an entity identity.
  *
- * The default map defines the network's canonical entity/taxonomy pairs. A
- * feature may extend it without changing this generic persistence layer.
+ * Feature plugins register their bounded entity/taxonomy pairs without
+ * changing this generic persistence layer.
  *
  * @param string $entity_type Entity type.
  * @param string $taxonomy Taxonomy.
@@ -43,12 +43,7 @@ function extrachill_users_normalize_entity_subscription( $entity_type, $taxonomy
 	$slug              = sanitize_title( $slug );
 	$entities          = apply_filters(
 		'extrachill_users_entity_subscription_entities',
-		array(
-			'festival' => 'festival',
-			'artist'   => 'artist',
-			'venue'    => 'venue',
-			'location' => 'location',
-		)
+		array()
 	);
 	$definition        = $entities[ $entity_type ] ?? null;
 	$expected_taxonomy = is_array( $definition ) ? sanitize_key( $definition['taxonomy'] ?? '' ) : sanitize_key( $definition );
@@ -77,12 +72,7 @@ function extrachill_users_entity_subscription_uses_notification_email_preference
 	$entity_type = sanitize_key( $entity_type );
 	$entities    = apply_filters(
 		'extrachill_users_entity_subscription_entities',
-		array(
-			'festival' => 'festival',
-			'artist'   => 'artist',
-			'venue'    => 'venue',
-			'location' => 'location',
-		)
+		array()
 	);
 	$definition  = $entities[ $entity_type ] ?? null;
 

--- a/tests/unit/EntitySubscriptionsTest.php
+++ b/tests/unit/EntitySubscriptionsTest.php
@@ -25,8 +25,9 @@ class Test_Entity_Subscriptions extends WP_UnitTestCase {
 	}
 
 	public function register_scoped_test_identities( array $entities ): array {
-		$entities['venue-announcements'] = array(
-			'taxonomy'                           => 'venue',
+		$entities['topic']               = 'topic';
+		$entities['topic-announcements'] = array(
+			'taxonomy'                           => 'topic',
 			'uses_notification_email_preference' => false,
 		);
 
@@ -36,13 +37,13 @@ class Test_Entity_Subscriptions extends WP_UnitTestCase {
 	public function test_subscribe_normalizes_and_deduplicates(): void {
 		$user_id = self::factory()->user->create();
 
-		$first  = extrachill_users_subscribe_to_entity( $user_id, 'Festival', 'festival', 'Big Fest 2026' );
-		$second = extrachill_users_subscribe_to_entity( $user_id, 'festival', 'festival', 'big-fest-2026' );
+		$first  = extrachill_users_subscribe_to_entity( $user_id, 'Topic', 'topic', 'Release Notes' );
+		$second = extrachill_users_subscribe_to_entity( $user_id, 'topic', 'topic', 'release-notes' );
 
 		$this->assertTrue( $first['subscribed'] );
-		$this->assertSame( 'big-fest-2026', $first['slug'] );
+		$this->assertSame( 'release-notes', $first['slug'] );
 		$this->assertTrue( $second['subscribed'] );
-		$this->assertSame( array( $user_id ), extrachill_users_entity_subscription_recipients( 'test-producer', 'festival', 'festival', 'big-fest-2026' ) );
+		$this->assertSame( array( $user_id ), extrachill_users_entity_subscription_recipients( 'test-producer', 'topic', 'topic', 'release-notes' ) );
 	}
 
 	public function test_abilities_include_private_recipient_resolution(): void {
@@ -59,22 +60,22 @@ class Test_Entity_Subscriptions extends WP_UnitTestCase {
 		wp_set_current_user( $user_id );
 		$result = $subscribe->execute(
 			array(
-				'entity_type' => 'festival',
-				'taxonomy'    => 'festival',
-				'slug'        => 'bonnaroo',
+				'entity_type' => 'topic',
+				'taxonomy'    => 'topic',
+				'slug'        => 'release-notes',
 			)
 		);
 
-		$this->assertSame( 'bonnaroo', $result['slug'] );
+		$this->assertSame( 'release-notes', $result['slug'] );
 		$this->assertTrue( $result['subscribed'] );
 	}
 
 	public function test_list_is_self_only_bounded_and_preserves_purpose_identity(): void {
 		$user_id       = self::factory()->user->create();
 		$other_user_id = self::factory()->user->create();
-		extrachill_users_subscribe_to_entity( $user_id, 'venue', 'venue', 'the-royal-american' );
-		extrachill_users_subscribe_to_entity( $user_id, 'venue-announcements', 'venue', 'the-royal-american' );
-		extrachill_users_subscribe_to_entity( $other_user_id, 'artist', 'artist', 'phish' );
+		extrachill_users_subscribe_to_entity( $user_id, 'topic', 'topic', 'release-notes' );
+		extrachill_users_subscribe_to_entity( $user_id, 'topic-announcements', 'topic', 'release-notes' );
+		extrachill_users_subscribe_to_entity( $other_user_id, 'topic', 'topic', 'roadmap' );
 		wp_set_current_user( $user_id );
 
 		$result = extrachill_users_ability_list_entity_subscriptions(
@@ -87,23 +88,23 @@ class Test_Entity_Subscriptions extends WP_UnitTestCase {
 		$this->assertSame( 2, $result['total'] );
 		$this->assertSame( 1, $result['per_page'] );
 		$this->assertSame( 2, $result['total_pages'] );
-		$this->assertContains( $result['subscriptions'][0]['entity_type'], array( 'venue', 'venue-announcements' ) );
+		$this->assertContains( $result['subscriptions'][0]['entity_type'], array( 'topic', 'topic-announcements' ) );
 	}
 
 	public function test_status_and_unsubscribe_are_self_contained(): void {
 		$user_id = self::factory()->user->create();
-		extrachill_users_subscribe_to_entity( $user_id, 'venue', 'venue', 'the-royal-american' );
+		extrachill_users_subscribe_to_entity( $user_id, 'topic', 'topic', 'release-notes' );
 
-		$this->assertTrue( extrachill_users_entity_subscription_status( $user_id, 'venue', 'venue', 'the-royal-american' )['subscribed'] );
-		$this->assertFalse( extrachill_users_unsubscribe_from_entity( $user_id, 'venue', 'venue', 'the-royal-american' )['subscribed'] );
-		$this->assertFalse( extrachill_users_entity_subscription_status( $user_id, 'venue', 'venue', 'the-royal-american' )['subscribed'] );
+		$this->assertTrue( extrachill_users_entity_subscription_status( $user_id, 'topic', 'topic', 'release-notes' )['subscribed'] );
+		$this->assertFalse( extrachill_users_unsubscribe_from_entity( $user_id, 'topic', 'topic', 'release-notes' )['subscribed'] );
+		$this->assertFalse( extrachill_users_entity_subscription_status( $user_id, 'topic', 'topic', 'release-notes' )['subscribed'] );
 	}
 
 	public function test_unsubscribe_is_idempotent_when_no_row_exists(): void {
 		$user_id = self::factory()->user->create();
 
-		$first  = extrachill_users_unsubscribe_from_entity( $user_id, 'venue', 'venue', 'the-royal-american' );
-		$second = extrachill_users_unsubscribe_from_entity( $user_id, 'venue', 'venue', 'the-royal-american' );
+		$first  = extrachill_users_unsubscribe_from_entity( $user_id, 'topic', 'topic', 'release-notes' );
+		$second = extrachill_users_unsubscribe_from_entity( $user_id, 'topic', 'topic', 'release-notes' );
 
 		$this->assertFalse( $first['subscribed'] );
 		$this->assertFalse( $second['subscribed'] );
@@ -125,7 +126,7 @@ class Test_Entity_Subscriptions extends WP_UnitTestCase {
 		$previous_suppression = $wpdb->suppress_errors( true );
 		add_filter( 'query', $fail );
 		try {
-			$result = extrachill_users_unsubscribe_from_entity( $user_id, 'venue', 'venue', 'the-royal-american' );
+			$result = extrachill_users_unsubscribe_from_entity( $user_id, 'topic', 'topic', 'release-notes' );
 		} finally {
 			remove_filter( 'query', $fail );
 			$wpdb->suppress_errors( $previous_suppression );
@@ -137,7 +138,15 @@ class Test_Entity_Subscriptions extends WP_UnitTestCase {
 
 	public function test_invalid_entity_pair_is_rejected(): void {
 		$user_id = self::factory()->user->create();
-		$result  = extrachill_users_subscribe_to_entity( $user_id, 'festival', 'artist', 'big-fest' );
+		$result  = extrachill_users_subscribe_to_entity( $user_id, 'topic', 'category', 'release-notes' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_entity_subscription', $result->get_error_code() );
+	}
+
+	public function test_unregistered_identity_is_rejected(): void {
+		$user_id = self::factory()->user->create();
+		$result  = extrachill_users_subscribe_to_entity( $user_id, 'unregistered', 'unregistered', 'release-notes' );
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'invalid_entity_subscription', $result->get_error_code() );
@@ -145,9 +154,9 @@ class Test_Entity_Subscriptions extends WP_UnitTestCase {
 
 	public function test_recipient_resolution_requires_producer_authorization(): void {
 		$user_id = self::factory()->user->create();
-		extrachill_users_subscribe_to_entity( $user_id, 'location', 'location', 'charleston-sc' );
+		extrachill_users_subscribe_to_entity( $user_id, 'topic', 'topic', 'release-notes' );
 
-		$denied = extrachill_users_entity_subscription_recipients( 'untrusted', 'location', 'location', 'charleston-sc' );
+		$denied = extrachill_users_entity_subscription_recipients( 'untrusted', 'topic', 'topic', 'release-notes' );
 		$this->assertWPError( $denied );
 		$this->assertSame( 'entity_subscription_producer_forbidden', $denied->get_error_code() );
 	}
@@ -155,11 +164,11 @@ class Test_Entity_Subscriptions extends WP_UnitTestCase {
 	public function test_direct_email_recipient_resolution_respects_digest_preference(): void {
 		$enabled_user  = self::factory()->user->create();
 		$disabled_user = self::factory()->user->create();
-		extrachill_users_subscribe_to_entity( $enabled_user, 'artist', 'artist', 'phish' );
-		extrachill_users_subscribe_to_entity( $disabled_user, 'artist', 'artist', 'phish' );
+		extrachill_users_subscribe_to_entity( $enabled_user, 'topic', 'topic', 'release-notes' );
+		extrachill_users_subscribe_to_entity( $disabled_user, 'topic', 'topic', 'release-notes' );
 		ec_users_set_notification_emails_disabled( $disabled_user, true );
 
-		$this->assertSame( array( $enabled_user, $disabled_user ), extrachill_users_entity_subscription_recipients( 'test-producer', 'artist', 'artist', 'phish' ) );
-		$this->assertSame( array( $enabled_user ), extrachill_users_entity_subscription_recipients( 'test-producer', 'artist', 'artist', 'phish', 'email' ) );
+		$this->assertSame( array( $enabled_user, $disabled_user ), extrachill_users_entity_subscription_recipients( 'test-producer', 'topic', 'topic', 'release-notes' ) );
+		$this->assertSame( array( $enabled_user ), extrachill_users_entity_subscription_recipients( 'test-producer', 'topic', 'topic', 'release-notes', 'email' ) );
 	}
 }


### PR DESCRIPTION
## Summary
- remove built-in artist, festival, venue, and location identities from the generic subscription layer
- require feature plugins to register bounded purpose identities explicitly
- keep storage, Abilities, producer authorization, and feature-owned products such as `local_scene_digest`
- replace product-specific tests and docs with neutral registered fixtures

## Verification
- `vendor/bin/phpcs --standard=WordPress --warning-severity=0 inc/entity-subscriptions/service.php`
- PHP syntax checks for the service and updated unit test
- explicit unit coverage added for rejecting unregistered identities
- `git diff --check`

## Companion changes
- Extra-Chill/extrachill-events#595 retires venue and event entity notifications
- Extra-Chill/extrachill-blog#100 retires artist/festival editorial surfaces and producers

Closes #318