### PR TITLE
fix: provide Homeboy database test environment

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -17,9 +17,49 @@ permissions:
   issues: write
 
 jobs:
-  lint:
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2
-    with:
-      commands: review lint,review test
-      expected-commands: review lint,review test
-    secrets: inherit
+  homeboy:
+    name: Homeboy (${{ matrix.command }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        command: [review lint, review test]
+    services:
+      mysql:
+        image: mysql:8.0@sha256:7dcddc01f13bab2f15cde676d44d01f61fc9f99fe7785e86196dfc07d358ae2b
+        env:
+          MYSQL_ROOT_PASSWORD: ''
+          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+          MYSQL_DATABASE: homeboy_wptests
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        continue-on-error: true
+        with:
+          client-id: ${{ secrets.HOMEBOY_APP_ID }}
+          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
+
+      - name: Run Homeboy ${{ matrix.command }}
+        env:
+          WP_CODEBOX_DB_HOST: 127.0.0.1
+          WP_CODEBOX_DB_PORT: '3306'
+          WP_CODEBOX_DB_USER: root
+          WP_CODEBOX_DB_PASSWORD: ''
+        uses: Extra-Chill/homeboy-action@v2
+        with:
+          commands: ${{ matrix.command }}
+          expected-commands: review lint,review test
+          app-token: ${{ steps.app-token.outputs.token || github.token }}
+          differential-gating: 'true'


### PR DESCRIPTION
## Summary

- replace the reusable Homeboy workflow call with the direct action pattern used by passing WP Codebox MySQL consumers
- provision a pinned MySQL service and map `WP_CODEBOX_DB_HOST`, `WP_CODEBOX_DB_PORT`, `WP_CODEBOX_DB_USER`, and `WP_CODEBOX_DB_PASSWORD` into the Homeboy action environment
- enable direct differential gating so candidate and baseline test children inherit the same database environment

## Root cause

`homeboy.json` correctly declares an external WP Codebox MySQL service and its four required child environment names. The reusable Homeboy workflow does not receive caller workflow environment values, and its generic `workflow_call` secret contract cannot propagate component-specific extension environment variables. The component workflow therefore owns provisioning its declared external service and placing those variables in the direct action environment, matching the passing `extrachill-events` workflow rather than adding WordPress-specific names to generic Homeboy infrastructure.

## Secret propagation

The candidate and differential baseline execute inside the same `Extra-Chill/homeboy-action@v2` step with identical `WP_CODEBOX_DB_*` environment mappings. The workflow does not print token or secret values, and no credential value is written to artifacts or logs.

## Verification

- parsed `.github/workflows/homeboy.yml` with the installed Node YAML parser
- validated `homeboy.json` with `jq empty`
- passed `git diff --check`
- passed `homeboy review lint --changed-since=origin/main` (the workflow-only change has no extension-declared lint route)
- verified the direct action contract runs differential baseline commands within the same inherited action environment

Closes #320